### PR TITLE
feat(fase-2): inventory deduction, dashboard enhancements, comparison modal, history compare/import

### DIFF
--- a/src/components/Calculator/HistoryTab/HistoryTab.tsx
+++ b/src/components/Calculator/HistoryTab/HistoryTab.tsx
@@ -125,6 +125,7 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
   const [selectedEntry, setSelectedEntry] = useState<HistoryEntry | null>(null)
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const [selectedForCompare, setSelectedForCompare] = useState<string[]>([])
+  const [showComparison, setShowComparison] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [importResult, setImportResult] = useState<string | null>(null)
 
@@ -160,7 +161,11 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
     reader.onload = (ev) => {
       try {
         const result = store.importJson(ev.target?.result as string)
-        setImportResult(t('history.importSuccess', { imported: result.imported, skipped: result.skipped }))
+        if (result.imported === 0 && result.skipped === 0) {
+          setImportResult(t('history.importError'))
+        } else {
+          setImportResult(t('history.importSuccess', { imported: result.imported, skipped: result.skipped }))
+        }
       } catch {
         setImportResult(t('history.importError'))
       }
@@ -171,8 +176,8 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
 
   useEffect(() => {
     if (!importResult) return
-    const t = setTimeout(() => setImportResult(null), 3000)
-    return () => clearTimeout(t)
+    const timer = setTimeout(() => setImportResult(null), 3000)
+    return () => clearTimeout(timer)
   }, [importResult])
 
   const compareEntries = useMemo(() => {
@@ -227,7 +232,7 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
           <option value="profit">{t('history.sort.profit')}</option>
           <option value="name">{t('history.sort.name')}</option>
         </select>
-          <button onClick={() => {}} disabled={selectedForCompare.length !== 2}
+          <button onClick={() => setShowComparison(true)} disabled={selectedForCompare.length !== 2}
             className={`px-3 py-1.5 text-xs rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none flex items-center gap-1.5 ${
               selectedForCompare.length === 2 ? 'bg-indigo-600 text-white hover:bg-indigo-500' : 'bg-white/5 text-gray-500 cursor-not-allowed'
             }`}
@@ -310,8 +315,8 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
       )}
 
       <DetailModal entry={selectedEntry} onClose={() => setSelectedEntry(null)} />
-      {compareEntries.length === 2 && (
-        <ComparisonModal entryA={compareEntries[0]} entryB={compareEntries[1]} onClose={() => setSelectedForCompare([])} />
+      {compareEntries.length === 2 && showComparison && (
+        <ComparisonModal entryA={compareEntries[0]} entryB={compareEntries[1]} onClose={() => { setShowComparison(false); setSelectedForCompare([]) }} />
       )}
       <ConfirmDialog
         open={confirmDeleteId !== null}

--- a/src/components/Calculator/HistoryTab/HistoryTab.tsx
+++ b/src/components/Calculator/HistoryTab/HistoryTab.tsx
@@ -1,14 +1,15 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistoryStore } from '@/stores/historyStore'
 import { useCalculatorStore } from '@/stores/calculatorStore'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import { ComparisonModal } from '@/components/ui/ComparisonModal'
 import { useCurrency } from '@/hooks/useCurrency'
 import type { HistoryEntry } from '@/types'
 import {
   X, Layers, Zap, Printer, Wrench, HardHat, Monitor,
   Paintbrush, DollarSign, Store, Tags, TrendingUp, Search, FileJson,
-  RotateCcw,
+  Upload, CheckSquare, RotateCcw,
 } from 'lucide-react'
 
 interface DetailModalProps {
@@ -123,6 +124,9 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
   const [search, setSearch] = useState('')
   const [selectedEntry, setSelectedEntry] = useState<HistoryEntry | null>(null)
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+  const [selectedForCompare, setSelectedForCompare] = useState<string[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [importResult, setImportResult] = useState<string | null>(null)
 
   // Sync local search state with store
   useEffect(() => {
@@ -148,6 +152,41 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
     a.click()
     URL.revokeObjectURL(url)
   }, [store])
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      try {
+        const result = store.importJson(ev.target?.result as string)
+        setImportResult(t('history.importSuccess', { imported: result.imported, skipped: result.skipped }))
+      } catch {
+        setImportResult(t('history.importError'))
+      }
+    }
+    reader.readAsText(file)
+    e.target.value = ''
+  }
+
+  useEffect(() => {
+    if (!importResult) return
+    const t = setTimeout(() => setImportResult(null), 3000)
+    return () => clearTimeout(t)
+  }, [importResult])
+
+  const compareEntries = useMemo(() => {
+    if (selectedForCompare.length !== 2) return []
+    return selectedForCompare.map(id => store.getEntry(id)).filter(Boolean) as HistoryEntry[]
+  }, [selectedForCompare, store])
+
+  const toggleCompare = (id: string) => {
+    setSelectedForCompare(prev => {
+      if (prev.includes(id)) return prev.filter(i => i !== id)
+      if (prev.length >= 2) return prev
+      return [...prev, id]
+    })
+  }
 
   // Filter type tabs
   const filterTabs = [
@@ -188,6 +227,13 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
           <option value="profit">{t('history.sort.profit')}</option>
           <option value="name">{t('history.sort.name')}</option>
         </select>
+          <button onClick={() => {}} disabled={selectedForCompare.length !== 2}
+            className={`px-3 py-1.5 text-xs rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none flex items-center gap-1.5 ${
+              selectedForCompare.length === 2 ? 'bg-indigo-600 text-white hover:bg-indigo-500' : 'bg-white/5 text-gray-500 cursor-not-allowed'
+            }`}
+          >
+            <CheckSquare className="w-3.5 h-3.5" /> {t('history.compare')} ({selectedForCompare.length}/2)
+          </button>
       </div>
 
       <div className="relative mb-4">
@@ -206,7 +252,9 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
       ) : (
         <div className="space-y-2 max-h-80 overflow-y-auto">
           {filtered.map(entry => (
-            <div key={entry.id} className="glass rounded-xl p-3 flex items-center justify-between hover:bg-white/5 transition-colors">
+            <div key={entry.id} className={`glass rounded-xl p-3 flex items-center gap-3 hover:bg-white/5 transition-colors ${selectedForCompare.includes(entry.id) ? 'ring-2 ring-indigo-500/50' : ''}`}>
+              <input type="checkbox" checked={selectedForCompare.includes(entry.id)} onChange={() => toggleCompare(entry.id)}
+                className="accent-indigo-500 w-4 h-4 flex-shrink-0 cursor-pointer" />
               <div>
                 <p className="text-sm font-semibold">{entry.name}</p>
                 <p className="text-xs text-gray-500">
@@ -244,15 +292,27 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
         </div>
       )}
 
-      <button
-        onClick={handleExport}
-        className="w-full mt-4 py-2.5 rounded-xl text-sm glass text-gray-400 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none flex items-center justify-center gap-2"
-      >
-        <FileJson className="w-4 h-4" />
-        {t('history.exportJson')}
-      </button>
+      <div className="flex gap-2 mt-4">
+        <button onClick={handleExport}
+          className="flex-1 py-2.5 rounded-xl text-sm glass text-gray-400 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none flex items-center justify-center gap-2"
+        >
+          <FileJson className="w-4 h-4" /> {t('history.exportJson')}
+        </button>
+        <button onClick={() => fileInputRef.current?.click()}
+          className="flex-1 py-2.5 rounded-xl text-sm glass text-gray-400 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none flex items-center justify-center gap-2"
+        >
+          <Upload className="w-4 h-4" /> {t('history.importJson')}
+        </button>
+      </div>
+      <input ref={fileInputRef} type="file" accept=".json" className="hidden" onChange={handleFileSelect} />
+      {importResult && (
+        <div className="mt-2 text-xs text-center text-emerald-400 animate-fade-in">{importResult}</div>
+      )}
 
       <DetailModal entry={selectedEntry} onClose={() => setSelectedEntry(null)} />
+      {compareEntries.length === 2 && (
+        <ComparisonModal entryA={compareEntries[0]} entryB={compareEntries[1]} onClose={() => setSelectedForCompare([])} />
+      )}
       <ConfirmDialog
         open={confirmDeleteId !== null}
         title="Remover produto"

--- a/src/components/Calculator/ResultsPanel.tsx
+++ b/src/components/Calculator/ResultsPanel.tsx
@@ -47,7 +47,7 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
   const unitWeight = results?.unitWeight ?? 0
 
   const availableSpools = useMemo(() =>
-    spools.filter(s => s.status === 'in_stock' && s.material === currentMaterial && s.weightGrams >= unitWeight),
+    spools.filter(s => s.status === 'in_stock' && s.material.toLowerCase() === currentMaterial.toLowerCase() && s.weightGrams >= unitWeight),
     [spools, currentMaterial, unitWeight],
   )
 
@@ -69,8 +69,8 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
   // Auto-hide success message
   useEffect(() => {
     if (!deductSuccess) return
-    const t = setTimeout(() => setDeductSuccess(false), 3000)
-    return () => clearTimeout(t)
+    const timer = setTimeout(() => setDeductSuccess(false), 3000)
+    return () => clearTimeout(timer)
   }, [deductSuccess])
 
   const handleDeductClick = (spool: FilamentSpool) => {
@@ -253,8 +253,8 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
         </button>
       </div>
 
-      {/* Deduct from Inventory */}
-      <div className="relative">
+      {/* Deduct from Inventory — FDM only */}
+      {isFDM && <div className="relative">
         <button
           ref={inventoryBtnRef}
           onClick={() => setShowInventoryDropdown(prev => !prev)}
@@ -313,7 +313,7 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
             )}
           </div>
         )}
-      </div>
+      </div>}
     </>
   )
 

--- a/src/components/Calculator/ResultsPanel.tsx
+++ b/src/components/Calculator/ResultsPanel.tsx
@@ -1,12 +1,14 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCalculatorStore } from '@/stores/calculatorStore'
 import { useHistoryStore } from '@/stores/historyStore'
+import { useFilamentInventory } from '@/stores/filamentInventory'
+import type { FilamentSpool } from '@/stores/filamentInventory'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { useCurrency } from '@/hooks/useCurrency'
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts'
 import {
-  FolderOpen, Save, FileText, BarChart2, CheckCircle2, ScrollText,
+  FolderOpen, Save, FileText, BarChart2, CheckCircle2, ScrollText, Database,
 } from 'lucide-react'
 import { exportQuoteJson, downloadQuoteJson } from '@/lib/quoteApi'
 
@@ -28,6 +30,62 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
 
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saved'>('idle')
   const [showClearConfirm, setShowClearConfirm] = useState(false)
+
+  // Inventory deduction state
+  const [showInventoryDropdown, setShowInventoryDropdown] = useState(false)
+  const [selectedSpool, setSelectedSpool] = useState<FilamentSpool | null>(null)
+  const [showDeductConfirm, setShowDeductConfirm] = useState(false)
+  const [deductSuccess, setDeductSuccess] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const inventoryBtnRef = useRef<HTMLButtonElement>(null)
+
+  const spools = useFilamentInventory(s => s.spools)
+  const deductWeightFromSpool = useFilamentInventory(s => s.deductWeight)
+  const fdmType = useCalculatorStore(s => s.fdmMaterial.type)
+  const resinType = useCalculatorStore(s => s.resinMaterial.type)
+  const currentMaterial = activeTab === 'fdm' ? fdmType : resinType
+  const unitWeight = results?.unitWeight ?? 0
+
+  const availableSpools = useMemo(() =>
+    spools.filter(s => s.status === 'in_stock' && s.material === currentMaterial && s.weightGrams >= unitWeight),
+    [spools, currentMaterial, unitWeight],
+  )
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    if (!showInventoryDropdown) return
+    const handleClick = (e: MouseEvent) => {
+      if (
+        dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
+        inventoryBtnRef.current && !inventoryBtnRef.current.contains(e.target as Node)
+      ) {
+        setShowInventoryDropdown(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [showInventoryDropdown])
+
+  // Auto-hide success message
+  useEffect(() => {
+    if (!deductSuccess) return
+    const t = setTimeout(() => setDeductSuccess(false), 3000)
+    return () => clearTimeout(t)
+  }, [deductSuccess])
+
+  const handleDeductClick = (spool: FilamentSpool) => {
+    setSelectedSpool(spool)
+    setShowInventoryDropdown(false)
+    setShowDeductConfirm(true)
+  }
+
+  const handleConfirmDeduct = () => {
+    if (!selectedSpool) return
+    deductWeightFromSpool(selectedSpool.id, unitWeight)
+    setShowDeductConfirm(false)
+    setSelectedSpool(null)
+    setDeductSuccess(true)
+  }
 
   const isFDM = activeTab === 'fdm'
   const { format: fmtCurrency } = useCurrency()
@@ -194,6 +252,68 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
           <ScrollText className="w-3.5 h-3.5" /> {t('results.exportQuote')}
         </button>
       </div>
+
+      {/* Deduct from Inventory */}
+      <div className="relative">
+        <button
+          ref={inventoryBtnRef}
+          onClick={() => setShowInventoryDropdown(prev => !prev)}
+          className="w-full py-3 rounded-xl text-[11px] sm:text-xs font-bold bg-emerald-800/40 text-emerald-300 hover:bg-emerald-700/50 transition-all focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none flex items-center justify-center gap-1.5 relative"
+          aria-label={t('results.deductFromInventory')}
+          aria-expanded={showInventoryDropdown}
+        >
+          <Database className="w-3.5 h-3.5" />
+          {deductSuccess ? (
+            <><CheckCircle2 className="w-3.5 h-3.5 text-emerald-300" /> {t('results.deductSuccess')}</>
+          ) : (
+            t('results.deductFromInventory')
+          )}
+        </button>
+
+        {showInventoryDropdown && (
+          <div
+            ref={dropdownRef}
+            className="absolute z-50 mt-2 w-full glass rounded-2xl p-3 border border-white/10 shadow-2xl animate-fade-in"
+            role="listbox"
+            aria-label={t('results.deductSelect')}
+          >
+            <div className="text-[10px] font-bold uppercase tracking-widest text-gray-500 mb-2">
+              {t('results.deductSelect')}
+            </div>
+            {availableSpools.length === 0 ? (
+              <p className="text-xs text-gray-500 text-center py-4">{t('common.noData')}</p>
+            ) : (
+              <div className="space-y-1 max-h-56 overflow-y-auto pr-1">
+                {availableSpools.map(spool => (
+                  <button
+                    key={spool.id}
+                    onClick={() => handleDeductClick(spool)}
+                    className="w-full text-left p-2.5 rounded-xl bg-white/5 hover:bg-white/10 transition-colors flex items-center gap-3 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none"
+                    role="option"
+                    aria-selected={selectedSpool?.id === spool.id}
+                  >
+                    <span
+                      className="w-3 h-3 rounded-full flex-shrink-0 ring-1 ring-white/20"
+                      style={{ backgroundColor: spool.colorHex }}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-xs text-white font-medium truncate">
+                        {spool.brand} — {spool.material}
+                      </div>
+                      <div className="text-[10px] text-gray-500">
+                        {spool.color} &middot; {t('results.deductAvailable', { weight: spool.weightGrams.toFixed(0) })}
+                      </div>
+                    </div>
+                    <div className="text-[10px] font-mono text-emerald-400/70 whitespace-nowrap">
+                      -{unitWeight.toFixed(1)}g
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </>
   )
 
@@ -209,6 +329,18 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
         cancelLabel="Cancelar"
         onConfirm={() => { clearHistory(); setShowClearConfirm(false) }}
         onCancel={() => setShowClearConfirm(false)}
+      />
+      <ConfirmDialog
+        open={showDeductConfirm}
+        title={t('results.deductFromInventory')}
+        message={selectedSpool
+          ? t('results.deductConfirm', { weight: unitWeight.toFixed(1), spool: `${selectedSpool.brand} - ${selectedSpool.material}` })
+          : ''}
+        variant="info"
+        confirmLabel={t('common.confirm')}
+        cancelLabel={t('common.cancel')}
+        onConfirm={handleConfirmDeduct}
+        onCancel={() => { setShowDeductConfirm(false); setSelectedSpool(null) }}
       />
     </>
   )

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -29,7 +29,7 @@ function saveDashboardSettings(data: Record<string, unknown>) {
 }
 
 export function Dashboard() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const store = useCalculatorStore()
   const results = store.results
   const fixedCosts = store.fixedCosts
@@ -89,11 +89,12 @@ export function Dashboard() {
     const sorted = [...historyEntries]
       .sort((a, b) => a.timestamp - b.timestamp)
       .slice(-10)
+    const locale = i18n.resolvedLanguage || i18n.language
     return sorted.map(e => ({
-      date: new Date(e.timestamp).toLocaleDateString(),
+      date: new Date(e.timestamp).toLocaleDateString(locale),
       profit: Math.round(e.profit * 100) / 100,
     }))
-  }, [historyEntries])
+  }, [historyEntries, i18n.resolvedLanguage, i18n.language])
 
   const printVsBuy = results && buyPrice ? {
     printCost: results.totalCost,
@@ -312,7 +313,7 @@ export function Dashboard() {
                   tick={{ fontSize: 10, fill: '#64748b' }}
                   axisLine={false}
                   tickLine={false}
-                  tickFormatter={v => formatMoney(v).replace(/[^0-9.,]/g, '')}
+                  tickFormatter={v => new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language, { notation: 'compact', maximumFractionDigits: 1 }).format(v)}
                   width={50}
                 />
                 <Tooltip

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,20 +1,52 @@
-import { useState } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCalculatorStore } from '@/stores/calculatorStore'
+import { useHistoryStore } from '@/stores/historyStore'
 import { InputGroup } from '@/components/ui/InputGroup'
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, AreaChart, Area, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { useCurrency } from '@/hooks/useCurrency'
 
+const DASHBOARD_KEY = 'open3dcalc_dashboard_v1'
+
 const COLORS = ['#6366f1', '#ec4899', '#10b981', '#f59e0b', '#3b82f6', '#ef4444', '#14b8a6']
+
+function loadDashboardSettings() {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(DASHBOARD_KEY)
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+
+function saveDashboardSettings(data: Record<string, unknown>) {
+  try {
+    localStorage.setItem(DASHBOARD_KEY, JSON.stringify(data))
+  } catch {
+    // Silently fail if localStorage is unavailable
+  }
+}
 
 export function Dashboard() {
   const { t } = useTranslation()
   const store = useCalculatorStore()
   const results = store.results
+  const fixedCosts = store.fixedCosts
   const { format: formatMoney, symbol: currencySymbol } = useCurrency()
-  const [printsPerMonth, setPrintsPerMonth] = useState(30)
-  const [buyPrice, setBuyPrice] = useState('')
-  const [targetSellPrice, setTargetSellPrice] = useState('')
+  const historyEntries = useHistoryStore(s => s.entries)
+
+  // Load saved values on mount
+  const saved = useMemo(() => loadDashboardSettings(), [])
+
+  const [printsPerMonth, setPrintsPerMonth] = useState(() => (saved.printsPerMonth as number) ?? 30)
+  const [buyPrice, setBuyPrice] = useState(() => (saved.buyPrice as string) ?? '')
+  const [targetSellPrice, setTargetSellPrice] = useState(() => (saved.targetSellPrice as string) ?? '')
+
+  // Persist to localStorage on change
+  useEffect(() => {
+    saveDashboardSettings({ printsPerMonth, buyPrice, targetSellPrice })
+  }, [printsPerMonth, buyPrice, targetSellPrice])
 
   const handleInput = (value: string, setter: (v: number) => void) => {
     setter(value === '' ? 0 : parseFloat(value) || 0)
@@ -26,6 +58,42 @@ export function Dashboard() {
     profit: results.profit * printsPerMonth,
     annualProfit: results.profit * printsPerMonth * 12,
   } : null
+
+  // Break-even calculation
+  const breakEven = results && fixedCosts.enabled && fixedCosts.monthlyCost > 0 ? {
+    variableCostPerUnit: results.totalCost,
+    sellPrice: results.sellPrice,
+    marginPerUnit: results.sellPrice - results.totalCost,
+    monthlyFixedCost: fixedCosts.monthlyCost,
+  } : null
+
+  const breakEvenUnits = breakEven && breakEven.marginPerUnit > 0
+    ? Math.ceil(breakEven.monthlyFixedCost / breakEven.marginPerUnit)
+    : null
+
+  const breakEvenRevenue = breakEvenUnits !== null && breakEven
+    ? breakEvenUnits * breakEven.sellPrice
+    : null
+
+  // Average margin from history
+  const avgMargin = useMemo(() => {
+    const margins = historyEntries
+      .filter(e => e.sellPrice > 0)
+      .map(e => (e.profit / e.sellPrice) * 100)
+    if (margins.length === 0) return null
+    return margins.reduce((a, b) => a + b, 0) / margins.length
+  }, [historyEntries])
+
+  // Profit trend data
+  const trendData = useMemo(() => {
+    const sorted = [...historyEntries]
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .slice(-10)
+    return sorted.map(e => ({
+      date: new Date(e.timestamp).toLocaleDateString(),
+      profit: Math.round(e.profit * 100) / 100,
+    }))
+  }, [historyEntries])
 
   const printVsBuy = results && buyPrice ? {
     printCost: results.totalCost,
@@ -162,6 +230,116 @@ export function Dashboard() {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* Break-Even Card */}
+      <div className="glass rounded-2xl p-5">
+        <h3 className="text-sm font-bold text-white mb-4">{t('dashboard.breakEven')}</h3>
+        {breakEven ? (
+          breakEvenUnits !== null ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="glass rounded-xl p-4 text-center">
+                <p className="text-[10px] text-gray-500">{t('dashboard.breakEvenUnits')}</p>
+                <p className="text-lg font-extrabold text-cyan-400">{breakEvenUnits} {t('common.units')}</p>
+                <p className="text-[10px] text-gray-500 mt-1">
+                  {formatMoney(breakEven.monthlyFixedCost)} / {formatMoney(breakEven.marginPerUnit)}
+                </p>
+              </div>
+              <div className="glass rounded-xl p-4 text-center">
+                <p className="text-[10px] text-gray-500">{t('dashboard.breakEvenRevenue')}</p>
+                <p className="text-lg font-extrabold text-emerald-400">
+                  {breakEvenRevenue !== null ? formatMoney(breakEvenRevenue) : '---'}
+                </p>
+                <p className="text-[10px] text-gray-500 mt-1">
+                  {breakEvenUnits} x {formatMoney(breakEven.sellPrice)}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="glass rounded-xl p-4 text-center">
+              <p className="text-xs text-red-400">{t('dashboard.cantBreakEven')}</p>
+              <p className="text-[10px] text-gray-500 mt-1">
+                {t('breakdown.material')}: {formatMoney(breakEven.variableCostPerUnit)} / {t('dashboard.salePrice')}: {formatMoney(breakEven.sellPrice)}
+              </p>
+            </div>
+          )
+        ) : (
+          <p className="text-xs text-gray-500 text-center py-2">
+            {t('calc.fixedCost.title')} {t('common.noData')}
+          </p>
+        )}
+      </div>
+
+      {/* Average Margin Card */}
+      <div className="glass rounded-2xl p-5">
+        <h3 className="text-sm font-bold text-white mb-4">{t('dashboard.avgMargin')}</h3>
+        {avgMargin !== null ? (
+          <div className="text-center">
+            <p className={`text-3xl font-black ${avgMargin >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+              {avgMargin >= 0 ? '+' : ''}{avgMargin.toFixed(1)}%
+            </p>
+            <p className="text-[10px] text-gray-500 mt-1">
+              {t('calc.history')}: {historyEntries.length} {t('common.entries')}
+            </p>
+          </div>
+        ) : (
+          <p className="text-xs text-gray-500 text-center py-2">{t('dashboard.noHistory')}</p>
+        )}
+      </div>
+
+      {/* Profit Trend Chart */}
+      <div className="glass rounded-2xl p-5">
+        <h3 className="text-sm font-bold text-white mb-4">{t('dashboard.trend')}</h3>
+        {trendData.length > 1 ? (
+          <div className="w-full h-56">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={trendData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="profitGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#818cf8" stopOpacity={0.4} />
+                    <stop offset="95%" stopColor="#818cf8" stopOpacity={0.05} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 10, fill: '#64748b' }}
+                  axisLine={false}
+                  tickLine={false}
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  tick={{ fontSize: 10, fill: '#64748b' }}
+                  axisLine={false}
+                  tickLine={false}
+                  tickFormatter={v => formatMoney(v).replace(/[^0-9.,]/g, '')}
+                  width={50}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: '#1e293b',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: '8px',
+                    fontSize: '12px',
+                  }}
+                  formatter={(value: number) => formatMoney(value)}
+                  labelStyle={{ color: '#94a3b8' }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="profit"
+                  stroke="#818cf8"
+                  strokeWidth={2}
+                  fill="url(#profitGradient)"
+                  dot={{ fill: '#818cf8', r: 3, strokeWidth: 0 }}
+                  activeDot={{ r: 5, fill: '#a5b4fc', strokeWidth: 0 }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <p className="text-xs text-gray-500 text-center py-8">{t('dashboard.noHistory')}</p>
+        )}
       </div>
 
       {/* Target Margin Mode */}

--- a/src/components/ui/ComparisonModal.tsx
+++ b/src/components/ui/ComparisonModal.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { X, TrendingUp, TrendingDown, Minus } from 'lucide-react'
+import { useCurrency } from '@/hooks/useCurrency'
+import type { HistoryEntry } from '@/types'
+
+interface ComparisonModalProps {
+  entryA: HistoryEntry
+  entryB: HistoryEntry
+  onClose: () => void
+}
+
+interface CompareField {
+  key: keyof CalculationResultProxy
+  labelKey: string
+  higherIsBetter: boolean
+}
+
+// Helper type to access fields from either result or entry directly
+type CalculationResultProxy = {
+  totalCost: number
+  sellPrice: number
+  profit: number
+  materialCost: number
+  energyCost: number
+  machineCost: number
+  laborCost: number
+  postProcessingCost: number
+  marketplaceFee: number
+  taxAmount: number
+}
+
+const comparisonFields: CompareField[] = [
+  // Costs — lower is better
+  { key: 'totalCost', labelKey: 'calc.totalCost', higherIsBetter: false },
+  { key: 'materialCost', labelKey: 'breakdown.material', higherIsBetter: false },
+  { key: 'energyCost', labelKey: 'breakdown.energy', higherIsBetter: false },
+  { key: 'machineCost', labelKey: 'breakdown.depreciation', higherIsBetter: false },
+  { key: 'laborCost', labelKey: 'breakdown.labor', higherIsBetter: false },
+  { key: 'postProcessingCost', labelKey: 'breakdown.finishing', higherIsBetter: false },
+  // Fees — lower is better
+  { key: 'marketplaceFee', labelKey: 'breakdown.marketplaceFee', higherIsBetter: false },
+  { key: 'taxAmount', labelKey: 'breakdown.tax', higherIsBetter: false },
+  // Revenue — higher is better
+  { key: 'sellPrice', labelKey: 'dashboard.salePrice', higherIsBetter: true },
+  { key: 'profit', labelKey: 'dashboard.profit', higherIsBetter: true },
+]
+
+function getEntryValue(entry: HistoryEntry, key: keyof CalculationResultProxy): number {
+  // These fields exist both on entry and result — prefer result for consistency
+  const result = entry.result
+  return result[key] as number
+}
+
+function getComparisonClass(valueA: number, valueB: number, higherIsBetter: boolean): {
+  aClass: string
+  bClass: string
+  aIcon: React.ReactNode | null
+  bIcon: React.ReactNode | null
+} {
+  const diff = valueA - valueB
+  if (Math.abs(diff) < 0.001) {
+    return { aClass: '', bClass: '', aIcon: null, bIcon: null }
+  }
+
+  // diff > 0 means A > B
+  const aIsBetter = higherIsBetter ? diff > 0 : diff < 0
+
+  return {
+    aClass: aIsBetter ? 'text-emerald-400' : 'text-red-400',
+    bClass: aIsBetter ? 'text-red-400' : 'text-emerald-400',
+    aIcon: aIsBetter
+      ? <TrendingUp className="w-3.5 h-3.5 inline-block ml-1" />
+      : <TrendingDown className="w-3.5 h-3.5 inline-block ml-1" />,
+    bIcon: aIsBetter
+      ? <TrendingDown className="w-3.5 h-3.5 inline-block ml-1" />
+      : <TrendingUp className="w-3.5 h-3.5 inline-block ml-1" />,
+  }
+}
+
+export function ComparisonModal({ entryA, entryB, onClose }: ComparisonModalProps) {
+  const { t } = useTranslation()
+  const { format: formatMoney } = useCurrency()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  // Focus trap + ESC close
+  useEffect(() => {
+    closeButtonRef.current?.focus()
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+
+      // Focus trap
+      if (e.key !== 'Tab') return
+      const dialog = dialogRef.current
+      if (!dialog) return
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('history.compareTitle')}
+    >
+      <div
+        ref={dialogRef}
+        className="glass rounded-2xl p-6 w-[95%] max-w-2xl max-h-[85vh] overflow-y-auto animate-fade-in"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex justify-between items-center mb-5">
+          <h2 className="text-lg font-bold gradient-text">{t('history.compareTitle')}</h2>
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            className="text-gray-400 hover:text-white flex items-center justify-center p-1.5 rounded-lg focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none transition-colors hover:bg-white/5"
+            aria-label={t('common.close')}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Entry names row */}
+        <div className="grid grid-cols-[1fr_1fr_1fr] gap-3 mb-4 text-sm">
+          <div className="text-gray-500 font-medium">{t('history.compareField')}</div>
+          <div className="text-indigo-300 font-semibold text-center truncate px-1" title={entryA.name}>
+            {entryA.name}
+          </div>
+          <div className="text-amber-300 font-semibold text-center truncate px-1" title={entryB.name}>
+            {entryB.name}
+          </div>
+        </div>
+
+        {/* Comparison rows */}
+        <div className="space-y-1">
+          {comparisonFields.map(field => {
+            const valueA = getEntryValue(entryA, field.key)
+            const valueB = getEntryValue(entryB, field.key)
+            const { aClass, bClass, aIcon, bIcon } = getComparisonClass(valueA, valueB, field.higherIsBetter)
+            const isEqual = Math.abs(valueA - valueB) < 0.001
+
+            return (
+              <div
+                key={field.key}
+                className="grid grid-cols-[1fr_1fr_1fr] gap-3 py-2.5 px-2 rounded-xl border-b border-white/5 last:border-b-0 hover:bg-white/[0.03] transition-colors text-sm"
+              >
+                <div className="text-gray-400 flex items-center">
+                  {t(field.labelKey)}
+                </div>
+                <div className={`text-center font-medium flex items-center justify-center gap-1 ${aClass || 'text-gray-200'}`}>
+                  {formatMoney(valueA)}
+                  {aIcon}
+                </div>
+                <div className={`text-center font-medium flex items-center justify-center gap-1 ${bClass || 'text-gray-200'}`}>
+                  {formatMoney(valueB)}
+                  {bIcon}
+                </div>
+                {isEqual && (
+                  <div className="col-span-3 flex justify-center mt-0.5">
+                    <Minus className="w-3.5 h-3.5 text-gray-500" />
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Legend */}
+        <div className="mt-5 flex items-center justify-center gap-6 text-xs text-gray-500 border-t border-white/10 pt-4">
+          <span className="flex items-center gap-1.5">
+            <TrendingUp className="w-3.5 h-3.5 text-emerald-400" />
+            {t('history.compareBetter') || 'Melhor'}
+          </span>
+          <span className="flex items-center gap-1.5">
+            <TrendingDown className="w-3.5 h-3.5 text-red-400" />
+            {t('history.compareWorse') || 'Pior'}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/ComparisonModal.tsx
+++ b/src/components/ui/ComparisonModal.tsx
@@ -196,11 +196,11 @@ export function ComparisonModal({ entryA, entryB, onClose }: ComparisonModalProp
         <div className="mt-5 flex items-center justify-center gap-6 text-xs text-gray-500 border-t border-white/10 pt-4">
           <span className="flex items-center gap-1.5">
             <TrendingUp className="w-3.5 h-3.5 text-emerald-400" />
-            {t('history.compareBetter') || 'Melhor'}
+            {t('history.compareBetter')}
           </span>
           <span className="flex items-center gap-1.5">
             <TrendingDown className="w-3.5 h-3.5 text-red-400" />
-            {t('history.compareWorse') || 'Pior'}
+            {t('history.compareWorse')}
           </span>
         </div>
       </div>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -307,6 +307,8 @@
     "compareField": "Field",
     "valueA": "Record A",
     "valueB": "Record B",
+    "compareBetter": "Better",
+    "compareWorse": "Worse",
     "noResults": "No results found"
   },
   "breakdown": {
@@ -356,10 +358,10 @@
     "exportQuote": "Export Quote",
     "exportQuoteSuccess": "Quote exported successfully",
     "deductFromInventory": "Deduct from Inventory",
-    "deductConfirm": "Deduct {weight}g from spool {spool}?",
+    "deductConfirm": "Deduct {{weight}}g from spool {{spool}}?",
     "deductSuccess": "Weight deducted successfully!",
     "deductSelect": "Select spool to deduct from",
-    "deductAvailable": "{weight}g available"
+    "deductAvailable": "{{weight}}g available"
   },
   "tooltip": {
     "costPerKg": "Average price per kg of filament. PLA ~R$90, PETG ~R$110, ABS ~R$100.",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -15,7 +15,14 @@
     "totalCost": "Total Cost",
     "salePrice": "Sale Price",
     "profit": "Net Profit",
-    "roi": "ROI"
+    "roi": "ROI",
+    "breakEven": "Break-Even Point",
+    "breakEvenUnits": "Units needed",
+    "breakEvenRevenue": "Revenue at break-even",
+    "avgMargin": "Average Margin",
+    "trend": "Profit Trend",
+    "noHistory": "No history data",
+    "cantBreakEven": "Price doesn't cover costs"
   },
   "calc": {
     "fdm": "FDM Printing",
@@ -291,6 +298,15 @@
     "delete": "Delete",
     "deleteConfirm": "Delete this product?",
     "exportJson": "Export Data (JSON)",
+    "importJson": "Import JSON",
+    "importSuccess": "{{imported}} imported, {{skipped}} skipped",
+    "importError": "Error importing file",
+    "compare": "Compare",
+    "compareTitle": "Comparison",
+    "compareSelect": "Select 2 records to compare",
+    "compareField": "Field",
+    "valueA": "Record A",
+    "valueB": "Record B",
     "noResults": "No results found"
   },
   "breakdown": {
@@ -332,11 +348,18 @@
     "hours": "h",
     "minutes": "min",
     "watt": "W",
-    "noData": "No data available"
+    "noData": "No data available",
+    "units": "units",
+    "entries": "entries"
   },
   "results": {
     "exportQuote": "Export Quote",
-    "exportQuoteSuccess": "Quote exported successfully"
+    "exportQuoteSuccess": "Quote exported successfully",
+    "deductFromInventory": "Deduct from Inventory",
+    "deductConfirm": "Deduct {weight}g from spool {spool}?",
+    "deductSuccess": "Weight deducted successfully!",
+    "deductSelect": "Select spool to deduct from",
+    "deductAvailable": "{weight}g available"
   },
   "tooltip": {
     "costPerKg": "Average price per kg of filament. PLA ~R$90, PETG ~R$110, ABS ~R$100.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -307,6 +307,8 @@
     "compareField": "Campo",
     "valueA": "Registro A",
     "valueB": "Registro B",
+    "compareBetter": "Melhor",
+    "compareWorse": "Pior",
     "noResults": "Nenhum resultado encontrado"
   },
   "breakdown": {
@@ -356,10 +358,10 @@
     "exportQuote": "Exportar Cotação",
     "exportQuoteSuccess": "Cotação exportada com sucesso",
     "deductFromInventory": "Deduzir do Estoque",
-    "deductConfirm": "Deduzir {weight}g do carretel {spool}?",
+    "deductConfirm": "Deduzir {{weight}}g do carretel {{spool}}?",
     "deductSuccess": "Peso deduzido com sucesso!",
     "deductSelect": "Selecionar carretel para deduzir",
-    "deductAvailable": "{weight}g disponíveis"
+    "deductAvailable": "{{weight}}g disponíveis"
   },
   "tooltip": {
     "costPerKg": "Preço médio do kg do filamento. PLA ~R$90, PETG ~R$110, ABS ~R$100.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -15,7 +15,14 @@
     "totalCost": "Custo Total",
     "salePrice": "Preço de Venda",
     "profit": "Lucro Líquido",
-    "roi": "ROI"
+    "roi": "ROI",
+    "breakEven": "Ponto de Equilíbrio",
+    "breakEvenUnits": "Unidades necessárias",
+    "breakEvenRevenue": "Receita no equilíbrio",
+    "avgMargin": "Margem Média",
+    "trend": "Tendência de Lucro",
+    "noHistory": "Sem dados de histórico",
+    "cantBreakEven": "Preço não cobre custos"
   },
   "calc": {
     "fdm": "Impressão FDM",
@@ -291,6 +298,15 @@
     "delete": "Excluir",
     "deleteConfirm": "Excluir este produto?",
     "exportJson": "Exportar Dados (JSON)",
+    "importJson": "Importar JSON",
+    "importSuccess": "{{imported}} importados, {{skipped}} ignorados",
+    "importError": "Erro ao importar arquivo",
+    "compare": "Comparar",
+    "compareTitle": "Comparativo",
+    "compareSelect": "Selecione 2 registros para comparar",
+    "compareField": "Campo",
+    "valueA": "Registro A",
+    "valueB": "Registro B",
     "noResults": "Nenhum resultado encontrado"
   },
   "breakdown": {
@@ -332,11 +348,18 @@
     "hours": "h",
     "minutes": "min",
     "watt": "W",
-    "noData": "Nenhum dado disponível"
+    "noData": "Nenhum dado disponível",
+    "units": "unidades",
+    "entries": "entradas"
   },
   "results": {
     "exportQuote": "Exportar Cotação",
-    "exportQuoteSuccess": "Cotação exportada com sucesso"
+    "exportQuoteSuccess": "Cotação exportada com sucesso",
+    "deductFromInventory": "Deduzir do Estoque",
+    "deductConfirm": "Deduzir {weight}g do carretel {spool}?",
+    "deductSuccess": "Peso deduzido com sucesso!",
+    "deductSelect": "Selecionar carretel para deduzir",
+    "deductAvailable": "{weight}g disponíveis"
   },
   "tooltip": {
     "costPerKg": "Preço médio do kg do filamento. PLA ~R$90, PETG ~R$110, ABS ~R$100.",


### PR DESCRIPTION
## What's included

### T-003: Dedução de Estoque
- Botão "Deduzir do Estoque" no ResultsPanel
- Dropdown de seleção de carretel (filtrado por material e estoque)
- Confirmação via ConfirmDialog
- Feedback visual de sucesso

### T-007: Dashboard Aprimorado
- Persistência de inputs no localStorage (printsPerMonth, buyPrice, targetSellPrice)
- Card Break-Even (unidades necessárias para cobrir custo fixo)
- Card Margem Média sobre histórico
- Gráfico de Tendência de Lucro (AreaChart com gradiente)

### T-006: Comparativo de Histórico
- Checkboxes nos registros do histórico (máx 2)
- Botão "Comparar" que abre ComparisonModal
- Tabela lado a lado com 10 campos
- Destaque verde/vermelho para melhor/pior valor

### T-010: Importação JSON
- Botão "Importar JSON" com file picker
- Usa importJson() existente no historyStore
- Merge inteligente sem duplicatas

### Arquivos modificados
- src/components/Calculator/ResultsPanel.tsx
- src/components/Dashboard/Dashboard.tsx
- src/components/ui/ComparisonModal.tsx (novo)
- src/components/Calculator/HistoryTab/HistoryTab.tsx
- src/i18n/locales/en-US.json
- src/i18n/locales/pt-BR.json