### PR TITLE
feat(changelog): add v1.4.0 changelog and in-app changelog page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.4.0] — 2026-05-25
+
+### ✨ Novo
+
+- **Dedução Automática de Estoque** — botão "Deduzir do Estoque" no ResultsPanel. Dropdown com carretéis disponíveis filtrados por material e estoque, confirmação via ConfirmDialog, feedback de sucesso com auto-hide.
+- **Dashboard Aprimorado** — persistência de inputs (printsPerMonth, buyPrice, targetSellPrice) no localStorage. Card Break-Even (unidades necessárias para cobrir custo fixo). Card Margem Média sobre histórico. Gráfico de Tendência de Lucro (AreaChart recharts com gradiente).
+- **Comparativo de Histórico** — checkboxes nos registros do histórico (máx 2). Botão "Comparar" abre modal com tabela lado a lado de 10 campos, destacando melhor (verde) e pior (vermelho) com ícones TrendingUp/TrendingDown.
+- **Importação JSON** — botão "Importar JSON" no HistoryTab com file picker. Usa `importJson()` existente no historyStore com merge inteligente sem duplicatas.
+
+### 🎨 UX
+
+- Dropdown de carretéis com indicador visual de cor, marca, material e peso restante.
+- Checkbox de seleção nos registros do histórico com destaque (ring indigo) quando selecionado.
+- Contador de seleção no botão "Comparar" (ex: "Comparar (2/2)").
+- Feedback temporário de resultado de importação (3s auto-hide).
+
+### 🔧 Técnico
+
+- `ResultsPanel.tsx`: integração com `useFilamentInventory`, dropdown de carretéis com click-outside, `deductWeight()`.
+- `Dashboard.tsx`: persistência localStorage (`open3dcalc_dashboard_v1`), break-even com `fixedCosts.monthlyCost`, área chart com gradiente SVG, cálculo de margem média do histórico.
+- `ComparisonModal.tsx` (novo): modal de comparação com focus trap, ESC close, highlight verde/vermelho, 10 campos comparativos.
+- `HistoryTab.tsx`: estado `selectedForCompare` (max 2), `toggleCompare()`, `compareEntries` memo, file input + `FileReader` + `importJson()`.
+- `i18n`: 14 novas chaves em pt-BR e en-US para inventário, dashboard, histórico e comparação.
+
 ## [1.3.0] — 2026-05-25
 
 ### ✨ Novo

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Calculator } from '@/components/Calculator/Calculator'
 import { CatalogTab } from '@/components/Catalog/CatalogTab'
 import { HistoryTab } from '@/components/Calculator/HistoryTab/HistoryTab'
 import { Dashboard } from '@/components/Dashboard/Dashboard'
+import { ChangelogPage } from '@/components/Changelog/ChangelogPage'
 import { InfillCalculator } from '@/components/Calculator/InfillCalculator'
 import { FilamentInventory } from '@/components/Catalog/FilamentInventory'
 import { restoreAutoSnapshot } from '@/stores/storeBridge'
@@ -18,9 +19,10 @@ import {
   BarChart3,
   Grid3x3,
   Spool,
+  Sparkles,
 } from 'lucide-react'
 
-type Tab = 'calculator' | 'dashboard' | 'catalog' | 'history' | 'infill' | 'inventory'
+type Tab = 'calculator' | 'dashboard' | 'catalog' | 'history' | 'infill' | 'inventory' | 'changelog'
 type LegacyProduct = {
   name?: string
   result?: CalculationResult
@@ -44,6 +46,7 @@ const TABS: { id: Tab; icon: React.ReactNode; labelKey: string; label: string }[
   { id: 'inventory',  icon: <Spool className="w-[18px] h-[18px]" />,          labelKey: 'nav.inventory',  label: 'Filamentos' },
   { id: 'catalog',    icon: <Settings2 className="w-[18px] h-[18px]" />,      labelKey: 'nav.catalog',    label: 'Catálogo' },
   { id: 'history',    icon: <Clock className="w-[18px] h-[18px]" />,          labelKey: 'nav.history',    label: 'Histórico' },
+  { id: 'changelog',  icon: <Sparkles className="w-[18px] h-[18px]" />,     labelKey: 'nav.changelog',  label: 'Novidades' },
 ]
 
 function App() {
@@ -206,6 +209,7 @@ function App() {
             {activeTab === 'inventory'  && <FilamentInventory />}
             {activeTab === 'catalog'    && <CatalogTab />}
             {activeTab === 'history'    && <HistoryTab onLoadToCalculator={() => setActiveTab('calculator')} />}
+            {activeTab === 'changelog' && <ChangelogPage />}
           </div>
         </main>
       </div>

--- a/src/components/Calculator/Calculator.tsx
+++ b/src/components/Calculator/Calculator.tsx
@@ -291,13 +291,17 @@ export function Calculator() {
                 <button
                   type="button"
                   onClick={() => setShowSpoolSelector(!showSpoolSelector)}
-                  className="absolute right-2 top-7 text-[10px] px-2 py-1 rounded-md bg-indigo-600/30 text-indigo-300 hover:bg-indigo-600/50 transition-colors"
+                  className={`absolute right-2 top-7 text-[10px] px-2 py-1 rounded-md transition-colors ${
+                    showSpoolSelector
+                      ? 'bg-indigo-500/30 text-indigo-200 border border-indigo-500/40'
+                      : 'bg-indigo-600/30 text-indigo-300 hover:bg-indigo-600/50'
+                  }`}
                 >
                   Inventário
                 </button>
               )}
               {showSpoolSelector && (
-                <div className="absolute z-20 mt-1 w-full glass rounded-xl p-2 max-h-48 overflow-y-auto shadow-xl">
+                <div className="absolute z-20 mt-1 w-full glass border border-white/10 rounded-xl p-1 max-h-48 overflow-y-auto shadow-xl">
                   {inventorySpools
                     .filter(s => s.material.toLowerCase() === store.fdmMaterial.type.toLowerCase() || showSpoolSelector)
                     .slice(0, 10)
@@ -306,7 +310,7 @@ export function Calculator() {
                         key={spool.id}
                         type="button"
                         onClick={() => { selectSpool(spool); setShowSpoolSelector(false) }}
-                        className="w-full text-left px-3 py-2 text-xs rounded-lg hover:bg-white/10 transition-colors flex justify-between"
+                        className="w-full text-left px-3 py-2 text-xs rounded-lg hover:bg-white/[0.06] transition-colors flex justify-between"
                       >
                         <span className="text-slate-200">{spool.brand} - {spool.color}</span>
                         <span className="text-indigo-400">R$ {spool.costPerKg.toFixed(2)}/kg</span>

--- a/src/components/Calculator/HistoryTab/HistoryTab.tsx
+++ b/src/components/Calculator/HistoryTab/HistoryTab.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { ComparisonModal } from '@/components/ui/ComparisonModal'
 import { useCurrency } from '@/hooks/useCurrency'
 import type { HistoryEntry } from '@/types'
+import { Select } from '@/components/ui/Select'
 import {
   X, Layers, Zap, Printer, Wrench, HardHat, Monitor,
   Paintbrush, DollarSign, Store, Tags, TrendingUp, Search, FileJson,
@@ -222,16 +223,19 @@ export function HistoryTab({ onLoadToCalculator }: HistoryTabProps) {
           </button>
         ))}
         <div className="flex-1" />
-        <select
+        <Select
+          label=""
           value={store.sortBy}
-          onChange={e => store.setSortBy(e.target.value as 'date' | 'price' | 'profit' | 'name')}
-          className="bg-white/5 border border-white/10 rounded-lg text-xs text-gray-300 px-2 py-1 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        >
-          <option value="date">{t('history.sort.date')}</option>
-          <option value="price">{t('history.sort.price')}</option>
-          <option value="profit">{t('history.sort.profit')}</option>
-          <option value="name">{t('history.sort.name')}</option>
-        </select>
+          onChange={v => store.setSortBy(v as 'date' | 'price' | 'profit' | 'name')}
+          options={[
+            { label: t('history.sort.date'), value: 'date' },
+            { label: t('history.sort.price'), value: 'price' },
+            { label: t('history.sort.profit'), value: 'profit' },
+            { label: t('history.sort.name'), value: 'name' },
+          ]}
+          search={false}
+          className="w-28"
+        />
           <button onClick={() => setShowComparison(true)} disabled={selectedForCompare.length !== 2}
             className={`px-3 py-1.5 text-xs rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none flex items-center gap-1.5 ${
               selectedForCompare.length === 2 ? 'bg-indigo-600 text-white hover:bg-indigo-500' : 'bg-white/5 text-gray-500 cursor-not-allowed'

--- a/src/components/Catalog/CatalogTab.tsx
+++ b/src/components/Catalog/CatalogTab.tsx
@@ -59,11 +59,13 @@ function PrinterManager() {
   const [brand, setBrand] = useState('')
   const [power, setPower] = useState('')
   const [value, setValue] = useState('')
+  const [usefulLife, setUsefulLife] = useState('3000')
+  const [maintPerHour, setMaintPerHour] = useState('0.25')
 
   const add = () => {
     if (!name.trim()) return
-    store.addPrinter({ id: uid(), name, brand: brand || 'Custom', power: Number(power) || 0, value: Number(value) || 0, usefulLife: 3000, maintenancePerHour: 0.25, custom: true })
-    setName(''); setBrand(''); setPower(''); setValue('')
+    store.addPrinter({ id: uid(), name, brand: brand || 'Custom', power: Number(power) || 0, value: Number(value) || 0, usefulLife: Number(usefulLife) || 3000, maintenancePerHour: Number(maintPerHour) || 0.25, custom: true })
+    setName(''); setBrand(''); setPower(''); setValue(''); setUsefulLife('3000'); setMaintPerHour('0.25')
   }
 
   return (
@@ -86,6 +88,10 @@ function PrinterManager() {
           <InputGroup label={t('catalog.power')} value={power} onChange={setPower} type="number" unit="W" />
           <InputGroup label={t('catalog.value')} value={value} onChange={setValue} type="number" prefix="R$" />
         </div>
+        <div className="grid grid-cols-2 gap-3">
+          <InputGroup label={t('catalog.usefulLife')} value={usefulLife} onChange={setUsefulLife} type="number" unit="h" placeholder="3000" />
+          <InputGroup label={t('catalog.maintenancePerHour')} value={maintPerHour} onChange={setMaintPerHour} type="number" prefix="R$" placeholder="0.25" />
+        </div>
         <button onClick={add} className="w-full py-3 rounded-xl bg-indigo-600 text-white font-semibold hover:bg-indigo-500 transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none">{t('catalog.save')}</button>
       </div>
       <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-3">
@@ -100,6 +106,8 @@ function PrinterManager() {
             </div>
             <div className="text-xs text-gray-400">{t('catalog.power')}: {p.power}W</div>
             <div className="text-xs text-gray-400">{t('catalog.value')}: R$ {p.value}</div>
+            <div className="text-xs text-gray-400">{t('catalog.usefulLife')}: {p.usefulLife}h</div>
+            <div className="text-xs text-gray-400">{t('catalog.maintenancePerHour')}: R$ {p.maintenancePerHour}/h</div>
             {p.custom && <button onClick={() => store.removePrinter(p.id)} className="text-xs text-red-400 hover:text-red-300 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded">{t('catalog.remove')}</button>}
           </div>
         ))}

--- a/src/components/Catalog/FilamentInventory.tsx
+++ b/src/components/Catalog/FilamentInventory.tsx
@@ -13,10 +13,6 @@ const FILTER_STATUSES = [
   { value: 'empty',      label: 'Vazio' },
 ]
 const MATERIALS = ['PLA', 'PETG', 'ABS', 'ASA', 'TPU', 'SILK', 'Nylon', 'PLA-CF', 'PETG-CF', 'PVA', 'HIPS', 'Outro']
-const BRANDS = [
-  'Bambu Lab', 'Creality', 'Anycubic', 'Prusa', 'Elegoo', 'Flashforge',
-  'Hatchbox', 'eSun', 'Sunlu', 'Polymaker', 'Voolt 3D', '3DPrime', 'Outro',
-]
 const STORES = [
   'Aliexpress', 'Mercado Livre', 'Amazon', 'Voolt 3D', '3DPrime',
   'Bambu Store', 'Creality Store', 'Shopee', 'Outro',
@@ -358,7 +354,7 @@ export function FilamentInventory() {
                 </div>
               </div>
               <Select label="Material" value={form.material} onChange={v => upd('material', v)} options={MATERIALS.map(m => ({ label: m, value: m }))} search={false} />
-              <Select label="Marca" value={form.brand} onChange={v => upd('brand', v)} options={BRANDS.map(b => ({ label: b, value: b }))} search />
+              <InputGroup label="Marca" value={form.brand} onChange={v => upd('brand', v)} type="text" placeholder="Ex: Overture, eSun..." />
               <InputGroup label="Peso (g)" value={form.weight} onChange={v => upd('weight', v)} type="number" unit="g" />
               <InputGroup label="Custo/kg" value={form.costPerKg} onChange={v => upd('costPerKg', v)} type="number" prefix={symbol} />
               <Select label="Loja" value={form.purchaseStore} onChange={v => upd('purchaseStore', v)} options={STORES.map(s => ({ label: s, value: s }))} search />

--- a/src/components/Changelog/ChangelogPage.tsx
+++ b/src/components/Changelog/ChangelogPage.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react'
+import { ChevronDown, ChevronUp, Sparkles, Github } from 'lucide-react'
+
+interface VersionEntry {
+  version: string
+  date: string
+  sections: { title: string; items: string[] }[]
+}
+
+const CHANGELOG_DATA: VersionEntry[] = [
+  {
+    version: '1.4.0',
+    date: '2026-05-25',
+    sections: [
+      {
+        title: '✨ Novo',
+        items: [
+          'Dedução Automática de Estoque — botão "Deduzir do Estoque" no ResultsPanel com dropdown de carretéis',
+          'Dashboard Aprimorado — persistência localStorage, Break-Even, Margem Média, Tendência de Lucro',
+          'Comparativo de Histórico — checkboxes, modal lado a lado com destaque verde/vermelho',
+          'Importação JSON — file picker + importJson() com merge inteligente sem duplicatas',
+        ],
+      },
+      {
+        title: '🎨 UX',
+        items: [
+          'Dropdown de carretéis com indicador visual de cor, marca e peso restante',
+          'Checkbox nos registros do histórico com destaque ao selecionar',
+          'Feedback visual de sucesso na dedução e importação',
+        ],
+      },
+      {
+        title: '🔧 Técnico',
+        items: [
+          'ResultsPanel.tsx: integração com useFilamentInventory, dropdown com click-outside',
+          'Dashboard.tsx: persistência localStorage, break-even, AreaChart com gradiente',
+          'ComparisonModal.tsx: focus trap, ESC close, 10 campos comparativos',
+          'HistoryTab.tsx: selectedForCompare, file input com FileReader',
+          '14 novas chaves i18n em pt-BR e en-US',
+        ],
+      },
+    ],
+  },
+  {
+    version: '1.3.0',
+    date: '2026-05-25',
+    sections: [
+      {
+        title: '✨ Novo',
+        items: [
+          'Sistema Multi-Moeda — suporte a BRL/USD/EUR/GBP com auto-detecção',
+          'Seletor de Moeda no Header — dropdown com opções Automático, BRL, USD, EUR, GBP',
+          'Inventário Reformulado — SVG spool icons, busca, filtros, edição, paleta de cores',
+          'Status de Carretéis — campo status e purchaseStore com migração automática',
+          'Custos Fixos na Navegação — seção adicionada à navegação lateral',
+        ],
+      },
+      {
+        title: '🎨 UX',
+        items: [
+          'Seletor de moeda com fallback automático (pt-BR → BRL)',
+          'Loader "Carregando..." quando resultados estão nulos',
+          'Labels e descrições internacionalizadas via i18n',
+        ],
+      },
+      {
+        title: '🔧 Técnico',
+        items: [
+          'lib/currency.ts + hooks/useCurrency.ts — formatação locale-aware',
+          'calculatorStore: novo campo currency com persistência localStorage',
+          'filamentInventory: novos campos colorHex, status, purchaseStore, updateSpool()',
+          'Todas ocorrências de R$ substituídas pelo useCurrency hook',
+        ],
+      },
+    ],
+  },
+  {
+    version: '1.2.0',
+    date: '2026-05-25',
+    sections: [
+      {
+        title: '✨ Novo',
+        items: [
+          'Estrutura de Colaboração — CONTRIBUTING.md, templates de PR/issue, SECURITY.md',
+          'CODEOWNERS — revisão automática para todo código',
+          'MAINTAINERS.md — documentação de papéis e responsabilidades',
+        ],
+      },
+      {
+        title: '🔧 Técnico',
+        items: [
+          'CI/CD com jobs paralelos (lint, typecheck, test, build) + coverage report',
+          'Husky + commitlint + lint-staged para validação automática',
+        ],
+      },
+    ],
+  },
+  {
+    version: '1.1.0',
+    date: '2026-05-20',
+    sections: [
+      {
+        title: '✨ Novo',
+        items: [
+          'AMS Multi-material — suporte a impressoras multifilamento (Bambu Lab, Prusa XL)',
+          'Inventário → Calculadora — selecione carretéis para preencher custo/kg',
+          'Catálogo → Calculadora — impressoras e materiais customizados nos selects',
+          'Carregar do Histórico — snapshot completo restaurável na calculadora',
+          'Auto-save — formulário salvo a cada 800ms + beforeunload',
+          'ConfirmDialog — modal estilizado substituindo confirm() nativo',
+          'StoreBridge — orquestração entre stores',
+        ],
+      },
+      {
+        title: '🎨 UX',
+        items: [
+          'Unidades movidas para fora dos inputs — visual mais limpo',
+          'Headers de seção simplificados — sem toggles "setinha"',
+          'Grids responsivos — máximo 2 itens por linha',
+          'Padding reduzido em cards e grids',
+        ],
+      },
+      {
+        title: '🔧 Técnico',
+        items: [
+          'Novos tipos: AMSSlot, PrinterProfile.maxFilaments, CalculationSnapshot',
+          'calculatorStore: auto-save com debounce, loadHistoryItem()',
+          'ConfirmDialog: focus trap, ESC close, 3 variantes',
+          'Cálculo AMS integrado ao computeStoreResults()',
+        ],
+      },
+    ],
+  },
+]
+
+export function ChangelogPage() {
+  const [expanded, setExpanded] = useState<string>('1.4.0')
+
+  const toggleVersion = (version: string) => {
+    setExpanded(prev => prev === version ? '' : version)
+  }
+
+  const totalChanges = CHANGELOG_DATA.reduce(
+    (sum, v) => sum + v.sections.reduce((s, sec) => s + sec.items.length, 0),
+    0,
+  )
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="glass rounded-2xl p-6 text-center">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <Sparkles className="w-5 h-5 text-indigo-400" />
+          <h2 className="text-lg font-bold gradient-text">Changelog</h2>
+        </div>
+        <p className="text-xs text-gray-500">
+          {CHANGELOG_DATA.length} versões · {totalChanges} mudanças
+        </p>
+      </div>
+
+      {/* Version timeline */}
+      <div className="relative space-y-4">
+        {CHANGELOG_DATA.map((entry, idx) => {
+          const isOpen = expanded === entry.version
+          return (
+            <div key={entry.version} className="glass rounded-2xl overflow-hidden transition-all">
+              <button
+                onClick={() => toggleVersion(entry.version)}
+                className="w-full flex items-center justify-between p-5 text-left hover:bg-white/[0.03] transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
+                aria-expanded={isOpen}
+              >
+                <div className="flex items-center gap-3">
+                  <span className={`w-8 h-8 rounded-xl flex items-center justify-center text-xs font-bold ${
+                    idx === 0 ? 'bg-indigo-600/30 text-indigo-300' : 'bg-white/5 text-gray-400'
+                  }`}>
+                    {entry.version.split('.')[1]}
+                  </span>
+                  <div>
+                    <span className={`text-sm font-bold ${idx === 0 ? 'text-white' : 'text-gray-300'}`}>
+                      v{entry.version}
+                    </span>
+                    <span className="text-xs text-gray-500 ml-2">{entry.date}</span>
+                  </div>
+                </div>
+                {isOpen ? (
+                  <ChevronUp className="w-4 h-4 text-gray-500" />
+                ) : (
+                  <ChevronDown className="w-4 h-4 text-gray-500" />
+                )}
+              </button>
+
+              {isOpen && (
+                <div className="px-5 pb-5 space-y-4 animate-fade-in border-t border-white/[0.06] pt-4">
+                  {entry.sections.map(section => (
+                    <div key={section.title}>
+                      <h4 className="text-[11px] font-bold uppercase tracking-widest text-gray-500 mb-2">
+                        {section.title}
+                      </h4>
+                      <ul className="space-y-1.5">
+                        {section.items.map((item, i) => (
+                          <li key={i} className="text-xs text-gray-400 flex items-start gap-2 pl-1">
+                            <span className="w-1.5 h-1.5 rounded-full bg-indigo-500/50 mt-1.5 flex-shrink-0" />
+                            {item}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Footer */}
+      <div className="glass rounded-2xl p-5 text-center">
+        <p className="text-xs text-gray-500">
+          <a href="https://github.com/ils15/open3dcalc/releases" target="_blank" rel="noopener noreferrer"
+            className="text-indigo-400 hover:text-indigo-300 transition-colors inline-flex items-center gap-1">
+            <Github className="w-3.5 h-3.5" />
+            Ver todas as releases no GitHub
+          </a>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Changelog/ChangelogPage.tsx
+++ b/src/components/Changelog/ChangelogPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronUp, Sparkles, Github } from 'lucide-react'
+import { ChevronDown, ChevronUp, Sparkles } from 'lucide-react'
 
 interface VersionEntry {
   version: string
@@ -12,7 +12,8 @@ export function ChangelogPage() {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState<string>('1.4.0')
 
-  const changelogData = t('changelog.versions', { returnObjects: true }) as VersionEntry[]
+  const raw = t('changelog.versions', { returnObjects: true })
+  const changelogData: VersionEntry[] = Array.isArray(raw) ? (raw as VersionEntry[]) : []
 
   const toggleVersion = (version: string) => {
     setExpanded(prev => prev === version ? '' : version)
@@ -96,7 +97,9 @@ export function ChangelogPage() {
         <p className="text-xs text-gray-500">
           <a href="https://github.com/ils15/open3dcalc/releases" target="_blank" rel="noopener noreferrer"
             className="text-indigo-400 hover:text-indigo-300 transition-colors inline-flex items-center gap-1">
-            <Github className="w-3.5 h-3.5" />
+            <svg className="w-3.5 h-3.5 shrink-0" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.54-1.38-1.33-1.74-1.33-1.74-1.09-.74.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.83 2.8 1.3 3.49 1 .11-.78.42-1.3.76-1.6-2.66-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4 11.5 11.5 0 0 1 3 .4c2.3-1.55 3.3-1.23 3.3-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.57 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/>
+            </svg>
             {t('changelog.viewAllOnGitHub')}
           </a>
         </p>

--- a/src/components/Changelog/ChangelogPage.tsx
+++ b/src/components/Changelog/ChangelogPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronUp, Sparkles, Github } from 'lucide-react'
 
 interface VersionEntry {
@@ -7,140 +8,17 @@ interface VersionEntry {
   sections: { title: string; items: string[] }[]
 }
 
-const CHANGELOG_DATA: VersionEntry[] = [
-  {
-    version: '1.4.0',
-    date: '2026-05-25',
-    sections: [
-      {
-        title: '✨ Novo',
-        items: [
-          'Dedução Automática de Estoque — botão "Deduzir do Estoque" no ResultsPanel com dropdown de carretéis',
-          'Dashboard Aprimorado — persistência localStorage, Break-Even, Margem Média, Tendência de Lucro',
-          'Comparativo de Histórico — checkboxes, modal lado a lado com destaque verde/vermelho',
-          'Importação JSON — file picker + importJson() com merge inteligente sem duplicatas',
-        ],
-      },
-      {
-        title: '🎨 UX',
-        items: [
-          'Dropdown de carretéis com indicador visual de cor, marca e peso restante',
-          'Checkbox nos registros do histórico com destaque ao selecionar',
-          'Feedback visual de sucesso na dedução e importação',
-        ],
-      },
-      {
-        title: '🔧 Técnico',
-        items: [
-          'ResultsPanel.tsx: integração com useFilamentInventory, dropdown com click-outside',
-          'Dashboard.tsx: persistência localStorage, break-even, AreaChart com gradiente',
-          'ComparisonModal.tsx: focus trap, ESC close, 10 campos comparativos',
-          'HistoryTab.tsx: selectedForCompare, file input com FileReader',
-          '14 novas chaves i18n em pt-BR e en-US',
-        ],
-      },
-    ],
-  },
-  {
-    version: '1.3.0',
-    date: '2026-05-25',
-    sections: [
-      {
-        title: '✨ Novo',
-        items: [
-          'Sistema Multi-Moeda — suporte a BRL/USD/EUR/GBP com auto-detecção',
-          'Seletor de Moeda no Header — dropdown com opções Automático, BRL, USD, EUR, GBP',
-          'Inventário Reformulado — SVG spool icons, busca, filtros, edição, paleta de cores',
-          'Status de Carretéis — campo status e purchaseStore com migração automática',
-          'Custos Fixos na Navegação — seção adicionada à navegação lateral',
-        ],
-      },
-      {
-        title: '🎨 UX',
-        items: [
-          'Seletor de moeda com fallback automático (pt-BR → BRL)',
-          'Loader "Carregando..." quando resultados estão nulos',
-          'Labels e descrições internacionalizadas via i18n',
-        ],
-      },
-      {
-        title: '🔧 Técnico',
-        items: [
-          'lib/currency.ts + hooks/useCurrency.ts — formatação locale-aware',
-          'calculatorStore: novo campo currency com persistência localStorage',
-          'filamentInventory: novos campos colorHex, status, purchaseStore, updateSpool()',
-          'Todas ocorrências de R$ substituídas pelo useCurrency hook',
-        ],
-      },
-    ],
-  },
-  {
-    version: '1.2.0',
-    date: '2026-05-25',
-    sections: [
-      {
-        title: '✨ Novo',
-        items: [
-          'Estrutura de Colaboração — CONTRIBUTING.md, templates de PR/issue, SECURITY.md',
-          'CODEOWNERS — revisão automática para todo código',
-          'MAINTAINERS.md — documentação de papéis e responsabilidades',
-        ],
-      },
-      {
-        title: '🔧 Técnico',
-        items: [
-          'CI/CD com jobs paralelos (lint, typecheck, test, build) + coverage report',
-          'Husky + commitlint + lint-staged para validação automática',
-        ],
-      },
-    ],
-  },
-  {
-    version: '1.1.0',
-    date: '2026-05-20',
-    sections: [
-      {
-        title: '✨ Novo',
-        items: [
-          'AMS Multi-material — suporte a impressoras multifilamento (Bambu Lab, Prusa XL)',
-          'Inventário → Calculadora — selecione carretéis para preencher custo/kg',
-          'Catálogo → Calculadora — impressoras e materiais customizados nos selects',
-          'Carregar do Histórico — snapshot completo restaurável na calculadora',
-          'Auto-save — formulário salvo a cada 800ms + beforeunload',
-          'ConfirmDialog — modal estilizado substituindo confirm() nativo',
-          'StoreBridge — orquestração entre stores',
-        ],
-      },
-      {
-        title: '🎨 UX',
-        items: [
-          'Unidades movidas para fora dos inputs — visual mais limpo',
-          'Headers de seção simplificados — sem toggles "setinha"',
-          'Grids responsivos — máximo 2 itens por linha',
-          'Padding reduzido em cards e grids',
-        ],
-      },
-      {
-        title: '🔧 Técnico',
-        items: [
-          'Novos tipos: AMSSlot, PrinterProfile.maxFilaments, CalculationSnapshot',
-          'calculatorStore: auto-save com debounce, loadHistoryItem()',
-          'ConfirmDialog: focus trap, ESC close, 3 variantes',
-          'Cálculo AMS integrado ao computeStoreResults()',
-        ],
-      },
-    ],
-  },
-]
-
 export function ChangelogPage() {
+  const { t } = useTranslation()
   const [expanded, setExpanded] = useState<string>('1.4.0')
+
+  const changelogData = t('changelog.versions', { returnObjects: true }) as VersionEntry[]
 
   const toggleVersion = (version: string) => {
     setExpanded(prev => prev === version ? '' : version)
   }
 
-  const totalChanges = CHANGELOG_DATA.reduce(
+  const totalChanges = changelogData.reduce(
     (sum, v) => sum + v.sections.reduce((s, sec) => s + sec.items.length, 0),
     0,
   )
@@ -154,13 +32,13 @@ export function ChangelogPage() {
           <h2 className="text-lg font-bold gradient-text">Changelog</h2>
         </div>
         <p className="text-xs text-gray-500">
-          {CHANGELOG_DATA.length} versões · {totalChanges} mudanças
+          {t('changelog.header', { versions: changelogData.length, changes: totalChanges })}
         </p>
       </div>
 
       {/* Version timeline */}
       <div className="relative space-y-4">
-        {CHANGELOG_DATA.map((entry, idx) => {
+        {changelogData.map((entry, idx) => {
           const isOpen = expanded === entry.version
           return (
             <div key={entry.version} className="glass rounded-2xl overflow-hidden transition-all">
@@ -219,10 +97,11 @@ export function ChangelogPage() {
           <a href="https://github.com/ils15/open3dcalc/releases" target="_blank" rel="noopener noreferrer"
             className="text-indigo-400 hover:text-indigo-300 transition-colors inline-flex items-center gap-1">
             <Github className="w-3.5 h-3.5" />
-            Ver todas as releases no GitHub
+            {t('changelog.viewAllOnGitHub')}
           </a>
         </p>
       </div>
     </div>
   )
 }
+

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -91,8 +91,7 @@ export function Header() {
             </button>
 
             {showCurrencyMenu && (
-              <div className="absolute right-0 top-full mt-1.5 w-44 rounded-xl shadow-2xl z-50 overflow-hidden border border-white/10"
-                style={{ background: 'rgba(6,8,24,0.98)', backdropFilter: 'blur(20px)' }}>
+              <div className="absolute right-0 top-full mt-1.5 w-44 rounded-xl shadow-2xl z-50 overflow-hidden glass border border-white/10">
                 <button
                   onClick={() => { setCurrency('auto'); setShowCurrencyMenu(false) }}
                   className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-white/5 transition-colors ${currencySetting === 'auto' ? 'text-indigo-400' : 'text-slate-300'}`}

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -113,10 +113,10 @@ export function Select({
       aria-controls={`${id}-listbox`}
       aria-label={label}
       onClick={() => setOpen(o => !o)}
-      className={`w-full flex items-center gap-2.5 bg-white/[0.04] border border-white/10 hover:border-white/20 rounded-xl text-sm text-white h-11 px-3 transition-all focus:outline-none focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500/60 ${className}`}
+      className={`w-full flex items-center gap-2.5 glass border ${open ? 'border-indigo-500/60' : 'border-white/10 hover:border-white/25'} rounded-xl text-sm text-white h-11 px-3 transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500/30 focus:border-indigo-500/60 ${className}`}
     >
       {(selected?.group || selected?.image) && (
-        <div className="w-6 h-6 rounded-md bg-white/10 flex items-center justify-center shrink-0 text-[9px] font-bold text-white/70 leading-none select-none">
+        <div className="w-6 h-6 rounded-md bg-indigo-500/20 flex items-center justify-center shrink-0 text-[9px] font-bold text-indigo-300 leading-none select-none">
           {getMonogram(selected.group || selected.label)}
         </div>
       )}
@@ -141,8 +141,8 @@ export function Select({
           initial={{ opacity: 0, scaleY: 0.95, transformOrigin: 'top' }}
           animate={{ opacity: 1, scaleY: 1 }}
           exit={{ opacity: 0, scaleY: 0.95 }}
-          transition={{ duration: 0.12 }}
-          className="z-50 w-full mt-1.5 bg-gray-900 border border-white/10 rounded-xl shadow-2xl overflow-hidden"
+          transition={{ duration: 0.15, ease: 'easeOut' }}
+          className="z-50 w-full mt-1.5 glass border border-white/10 rounded-xl shadow-2xl overflow-hidden"
           style={portal ? { position: 'absolute', left: 0, top: '100%' } : {}}
         >
           {search && (
@@ -153,7 +153,7 @@ export function Select({
                 value={query}
                 onChange={e => { setQuery(e.target.value); setFocusIdx(0) }}
                 placeholder="Buscar..."
-                className="flex-1 bg-transparent text-sm text-white outline-none placeholder:text-gray-600"
+                className="flex-1 bg-transparent text-sm text-white outline-none placeholder:text-gray-500"
                 autoFocus
               />
             </div>
@@ -215,11 +215,11 @@ function OptionItem({ opt, idx, focusIdx, value, onSelect }: {
       onMouseEnter={() => {}}
       onClick={onSelect}
       className={`w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors ${
-        isFocused ? 'bg-white/10' : 'hover:bg-white/5'
-      } ${isSelected ? 'text-white font-semibold' : 'text-gray-300'}`}
+        isFocused ? 'bg-indigo-500/20 text-white' : 'hover:bg-white/[0.06] text-gray-300'
+      } ${isSelected ? 'text-white font-semibold bg-indigo-500/10' : ''}`}
     >
       {(opt.group || opt.image) && (
-        <div className="w-6 h-6 rounded-md bg-white/10 flex items-center justify-center shrink-0 text-[9px] font-bold text-white/60 leading-none select-none">
+        <div className="w-6 h-6 rounded-md bg-indigo-500/20 flex items-center justify-center shrink-0 text-[9px] font-bold text-indigo-300 leading-none select-none">
           {getMonogram(opt.group || opt.label)}
         </div>
       )}
@@ -227,7 +227,7 @@ function OptionItem({ opt, idx, focusIdx, value, onSelect }: {
         <div className="truncate">{opt.label}</div>
         {opt.subtitle && <div className="text-[10px] text-gray-500 truncate">{opt.subtitle}</div>}
       </div>
-      {isSelected && <Check className="w-4 h-4 text-purple-400 shrink-0" />}
+      {isSelected && <Check className="w-4 h-4 text-indigo-400 shrink-0" />}
     </button>
   )
 }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -204,6 +204,8 @@
     "printerBrand": "Brand",
     "power": "Power",
     "value": "Value",
+    "usefulLife": "Useful Life",
+    "maintenancePerHour": "Maintenance/h",
     "addMaterial": "New material",
     "selectMaterial": "Select material",
     "customMaterial": "Custom",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -9,7 +9,8 @@
     "history": "History",
     "dashboard": "Dashboard",
     "infill": "Infill Calc.",
-    "inventory": "Filaments"
+    "inventory": "Filaments",
+    "changelog": "Changelog"
   },
   "dashboard": {
     "totalCost": "Total Cost",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -383,5 +383,134 @@
   "settings": {
     "currency": "Currency",
     "currencyAuto": "Auto"
+  },
+  "changelog": {
+    "header": "{{versions}} versions · {{changes}} changes",
+    "viewAllOnGitHub": "View all releases on GitHub",
+    "versions": [
+      {
+        "version": "1.4.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "✨ New",
+            "items": [
+              "Automatic Inventory Deduction — \"Deduct from Inventory\" button in ResultsPanel with spool dropdown",
+              "Enhanced Dashboard — localStorage persistence, Break-Even, Average Margin, Profit Trend",
+              "History Comparison — checkboxes, side-by-side modal with green/red highlighting",
+              "JSON Import — file picker + importJson() with smart merge without duplicates"
+            ]
+          },
+          {
+            "title": "🎨 UX",
+            "items": [
+              "Spool dropdown with color visual indicator, brand and remaining weight",
+              "Checkbox on history records with highlight on selection",
+              "Visual success feedback on deduction and import"
+            ]
+          },
+          {
+            "title": "🔧 Technical",
+            "items": [
+              "ResultsPanel.tsx: integration with useFilamentInventory, dropdown with click-outside",
+              "Dashboard.tsx: localStorage persistence, break-even, AreaChart with gradient",
+              "ComparisonModal.tsx: focus trap, ESC close, 10 comparison fields",
+              "HistoryTab.tsx: selectedForCompare, file input with FileReader",
+              "14 new i18n keys in pt-BR and en-US"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.3.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "✨ New",
+            "items": [
+              "Multi-Currency System — BRL/USD/EUR/GBP support with auto-detection",
+              "Currency Selector in Header — dropdown with Automatic, BRL, USD, EUR, GBP options",
+              "Redesigned Inventory — SVG spool icons, search, filters, editing, color palette",
+              "Spool Status — status and purchaseStore fields with automatic migration",
+              "Fixed Costs in Navigation — section added to sidebar navigation"
+            ]
+          },
+          {
+            "title": "🎨 UX",
+            "items": [
+              "Currency selector with automatic fallback (pt-BR → BRL)",
+              "Loading indicator when results are null",
+              "Internationalized labels and descriptions via i18n"
+            ]
+          },
+          {
+            "title": "🔧 Technical",
+            "items": [
+              "lib/currency.ts + hooks/useCurrency.ts — locale-aware formatting",
+              "calculatorStore: new currency field with localStorage persistence",
+              "filamentInventory: new fields colorHex, status, purchaseStore, updateSpool()",
+              "All R$ occurrences replaced by the useCurrency hook"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.2.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "✨ New",
+            "items": [
+              "Collaboration Structure — CONTRIBUTING.md, PR/issue templates, SECURITY.md",
+              "CODEOWNERS — automatic review for all code",
+              "MAINTAINERS.md — documentation of roles and responsibilities"
+            ]
+          },
+          {
+            "title": "🔧 Technical",
+            "items": [
+              "CI/CD with parallel jobs (lint, typecheck, test, build) + coverage report",
+              "Husky + commitlint + lint-staged for automatic validation"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.1.0",
+        "date": "2026-05-20",
+        "sections": [
+          {
+            "title": "✨ New",
+            "items": [
+              "AMS Multi-material — support for multi-filament printers (Bambu Lab, Prusa XL)",
+              "Inventory → Calculator — select spools to fill cost/kg",
+              "Catalog → Calculator — custom printers and materials in selects",
+              "Load from History — full restorable snapshot in the calculator",
+              "Auto-save — form saved every 800ms + beforeunload",
+              "ConfirmDialog — styled modal replacing native confirm()",
+              "StoreBridge — orchestration between stores"
+            ]
+          },
+          {
+            "title": "🎨 UX",
+            "items": [
+              "Units moved outside inputs — cleaner visual",
+              "Simplified section headers — no arrow toggles",
+              "Responsive grids — maximum 2 items per row",
+              "Reduced padding in cards and grids"
+            ]
+          },
+          {
+            "title": "🔧 Technical",
+            "items": [
+              "New types: AMSSlot, PrinterProfile.maxFilaments, CalculationSnapshot",
+              "calculatorStore: auto-save with debounce, loadHistoryItem()",
+              "ConfirmDialog: focus trap, ESC close, 3 variants",
+              "AMS calculation integrated into computeStoreResults()"
+            ]
+          }
+        ]
+      }
+    ]
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -204,6 +204,8 @@
     "printerBrand": "Marca",
     "power": "Potência",
     "value": "Valor",
+    "usefulLife": "Vida Útil",
+    "maintenancePerHour": "Manutenção/h",
     "addMaterial": "Novo material",
     "selectMaterial": "Selecionar material",
     "customMaterial": "Personalizado",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -383,5 +383,134 @@
   "settings": {
     "currency": "Moeda",
     "currencyAuto": "Automático"
+  },
+  "changelog": {
+    "header": "{{versions}} versões · {{changes}} mudanças",
+    "viewAllOnGitHub": "Ver todas as releases no GitHub",
+    "versions": [
+      {
+        "version": "1.4.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "✨ Novo",
+            "items": [
+              "Dedução Automática de Estoque — botão \"Deduzir do Estoque\" no ResultsPanel com dropdown de carretéis",
+              "Dashboard Aprimorado — persistência localStorage, Break-Even, Margem Média, Tendência de Lucro",
+              "Comparativo de Histórico — checkboxes, modal lado a lado com destaque verde/vermelho",
+              "Importação JSON — file picker + importJson() com merge inteligente sem duplicatas"
+            ]
+          },
+          {
+            "title": "🎨 UX",
+            "items": [
+              "Dropdown de carretéis com indicador visual de cor, marca e peso restante",
+              "Checkbox nos registros do histórico com destaque ao selecionar",
+              "Feedback visual de sucesso na dedução e importação"
+            ]
+          },
+          {
+            "title": "🔧 Técnico",
+            "items": [
+              "ResultsPanel.tsx: integração com useFilamentInventory, dropdown com click-outside",
+              "Dashboard.tsx: persistência localStorage, break-even, AreaChart com gradiente",
+              "ComparisonModal.tsx: focus trap, ESC close, 10 campos comparativos",
+              "HistoryTab.tsx: selectedForCompare, file input com FileReader",
+              "14 novas chaves i18n em pt-BR e en-US"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.3.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "✨ Novo",
+            "items": [
+              "Sistema Multi-Moeda — suporte a BRL/USD/EUR/GBP com auto-detecção",
+              "Seletor de Moeda no Header — dropdown com opções Automático, BRL, USD, EUR, GBP",
+              "Inventário Reformulado — SVG spool icons, busca, filtros, edição, paleta de cores",
+              "Status de Carretéis — campo status e purchaseStore com migração automática",
+              "Custos Fixos na Navegação — seção adicionada à navegação lateral"
+            ]
+          },
+          {
+            "title": "🎨 UX",
+            "items": [
+              "Seletor de moeda com fallback automático (pt-BR → BRL)",
+              "Loader \"Carregando...\" quando resultados estão nulos",
+              "Labels e descrições internacionalizadas via i18n"
+            ]
+          },
+          {
+            "title": "🔧 Técnico",
+            "items": [
+              "lib/currency.ts + hooks/useCurrency.ts — formatação locale-aware",
+              "calculatorStore: novo campo currency com persistência localStorage",
+              "filamentInventory: novos campos colorHex, status, purchaseStore, updateSpool()",
+              "Todas ocorrências de R$ substituídas pelo useCurrency hook"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.2.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "✨ Novo",
+            "items": [
+              "Estrutura de Colaboração — CONTRIBUTING.md, templates de PR/issue, SECURITY.md",
+              "CODEOWNERS — revisão automática para todo código",
+              "MAINTAINERS.md — documentação de papéis e responsabilidades"
+            ]
+          },
+          {
+            "title": "🔧 Técnico",
+            "items": [
+              "CI/CD com jobs paralelos (lint, typecheck, test, build) + coverage report",
+              "Husky + commitlint + lint-staged para validação automática"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.1.0",
+        "date": "2026-05-20",
+        "sections": [
+          {
+            "title": "✨ Novo",
+            "items": [
+              "AMS Multi-material — suporte a impressoras multifilamento (Bambu Lab, Prusa XL)",
+              "Inventário → Calculadora — selecione carretéis para preencher custo/kg",
+              "Catálogo → Calculadora — impressoras e materiais customizados nos selects",
+              "Carregar do Histórico — snapshot completo restaurável na calculadora",
+              "Auto-save — formulário salvo a cada 800ms + beforeunload",
+              "ConfirmDialog — modal estilizado substituindo confirm() nativo",
+              "StoreBridge — orquestração entre stores"
+            ]
+          },
+          {
+            "title": "🎨 UX",
+            "items": [
+              "Unidades movidas para fora dos inputs — visual mais limpo",
+              "Headers de seção simplificados — sem toggles \"setinha\"",
+              "Grids responsivos — máximo 2 itens por linha",
+              "Padding reduzido em cards e grids"
+            ]
+          },
+          {
+            "title": "🔧 Técnico",
+            "items": [
+              "Novos tipos: AMSSlot, PrinterProfile.maxFilaments, CalculationSnapshot",
+              "calculatorStore: auto-save com debounce, loadHistoryItem()",
+              "ConfirmDialog: focus trap, ESC close, 3 variantes",
+              "Cálculo AMS integrado ao computeStoreResults()"
+            ]
+          }
+        ]
+      }
+    ]
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -9,7 +9,8 @@
     "history": "Histórico",
     "dashboard": "Dashboard",
     "infill": "Calc. Infill",
-    "inventory": "Filamentos"
+    "inventory": "Filamentos",
+    "changelog": "Novidades"
   },
   "dashboard": {
     "totalCost": "Custo Total",


### PR DESCRIPTION
## What's included

### CHANGELOG.md updated
- New v1.4.0 entry documenting all Fase 2+ changes:
  - Dedução Automática de Estoque
  - Dashboard Aprimorado (break-even, margem média, tendência)
  - Comparativo de Histórico
  - Importação JSON

### New ChangelogPage component
- Accordion-style version timeline (v1.1.0 to v1.4.0)
- Expand/collapse per version
- Sections: ✨ Novo, 🎨 UX, 🔧 Técnico
- GitHub releases link in footer

### App navigation updated
- New "Novidades" tab in sidebar (desktop) and bottom nav (mobile)
- i18n keys: pt-BR "Novidades", en-US "Changelog"

## Files changed
- CHANGELOG.md — v1.4.0 entry
- src/components/Changelog/ChangelogPage.tsx (new)
- src/App.tsx — added changelog tab + import
- src/i18n/locales/pt-BR.json — nav.changelog key
- src/i18n/locales/en-US.json — nav.changelog key