### PR TITLE
feat(calculator): 3-Level Calculator System (Basic/Intermediate/Advanced)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,27 +21,27 @@
 
 ### ⚠️ Problemas identificados
 
-| Área             | Problema                                                                   | Impacto |
-| ---------------- | -------------------------------------------------------------------------- | ------- |
-| **Histórico**    | Não é possível carregar um item do histórico de volta na calculadora       | Alto    |
-| **Histórico**    | Sem ordenação (por data, preço, nome)                                      | Médio   |
-| **Histórico**    | Sem comparativo lado a lado entre dois registros                           | Médio   |
-| **Histórico**    | Sem importação de JSON (só exporta)                                        | Baixo   |
-| **Dashboard**    | `printsPerMonth`, `buyPrice`, `targetSellPrice` resetam ao fechar          | Médio   |
-| **Dashboard**    | Sem gráfico de tendência de lucro ao longo dos cálculos salvos             | Médio   |
-| **Dashboard**    | Sem análise de break-even (quantidade mínima para cobrir custo fixo)       | Médio   |
-| **Catálogo**     | Impressoras e materiais customizados não aparecem no select da calculadora | Alto    |
-| **Catálogo**     | Sem edição inline de itens existentes (só adicionar/remover)               | Médio   |
-| **Inventário**   | Nenhuma integração com a calculadora (carretel não preenche custo/kg)      | Alto    |
-| **Inventário**   | Dedução de peso só tem botões fixos (-10g/-50g/-100g), sem campo livre     | Baixo   |
-| **Inventário**   | Sem filtro por material ou marca                                           | Baixo   |
-| **Inventário**   | Sem edição de um carretel existente                                        | Médio   |
-| **UX Geral**     | Auto-save inexistente — usuário precisa clicar "Salvar Configurações"      | Alto    |
-| **UX Geral**     | `confirm()` nativo para deletar/limpar (feio, sem acessibilidade)          | Médio   |
-| **UX Geral**     | Quick Mode ativo, mas sem tooltip ou explicação do que muda                | Baixo   |
-| **UX Geral**     | Sem estado de onboarding para novos usuários (tela em branco sem context)  | Médio   |
-| **ResultsPanel** | Dois sistemas de histórico separados (sidebar vs HistoryTab) — duplicação  | Alto    |
-| **Mobile**       | Navegação inferior funcional, mas sem acesso rápido a PDF/CSV no mobile    | Baixo   |
+| Área             | Problema                                                                   | Impacto  |
+| ---------------- | -------------------------------------------------------------------------- | -------- |
+| **Histórico**    | Não é possível carregar um item do histórico de volta na calculadora       | Alto     |
+| **Histórico**    | Sem ordenação (por data, preço, nome)                                      | Médio    |
+| **Histórico**    | Sem comparativo lado a lado entre dois registros                           | Médio    |
+| **Histórico**    | Sem importação de JSON (só exporta)                                        | Baixo    |
+| **Dashboard**    | `printsPerMonth`, `buyPrice`, `targetSellPrice` resetam ao fechar          | Médio    |
+| **Dashboard**    | Sem gráfico de tendência de lucro ao longo dos cálculos salvos             | Médio    |
+| **Dashboard**    | Sem análise de break-even (quantidade mínima para cobrir custo fixo)       | Médio    |
+| **Catálogo**     | Impressoras e materiais customizados não aparecem no select da calculadora | Alto     |
+| **Catálogo**     | Sem edição inline de itens existentes (só adicionar/remover)               | Médio    |
+| **Inventário**   | Nenhuma integração com a calculadora (carretel não preenche custo/kg)      | Alto     |
+| **Inventário**   | Dedução de peso só tem botões fixos (-10g/-50g/-100g), sem campo livre     | Baixo    |
+| **Inventário**   | Sem filtro por material ou marca                                           | Baixo    |
+| **Inventário**   | Sem edição de um carretel existente                                        | Médio    |
+| **UX Geral**     | Auto-save inexistente — usuário precisa clicar "Salvar Configurações"      | Alto     |
+| **UX Geral**     | `confirm()` nativo para deletar/limpar (feio, sem acessibilidade)          | Médio    |
+| **UX Geral**     | Quick Mode substituído por 3 níveis (Básico/Intermediário/Avançado)        | ✅ Feito |
+| **UX Geral**     | Sem estado de onboarding para novos usuários (tela em branco sem contexto) | Médio    |
+| **ResultsPanel** | Dois sistemas de histórico separados (sidebar vs HistoryTab) — duplicação  | Alto     |
+| **Mobile**       | Navegação inferior funcional, mas sem acesso rápido a PDF/CSV no mobile    | Baixo    |
 
 ---
 
@@ -160,6 +160,16 @@
 - `Escape` → fechar qualquer modal aberto
 - Indicador de atalho visível em tooltips dos botões principais
 
+#### 3.6 Calculadora de 3 Níveis
+
+- Toggle de 3 botões: Básico / Intermediário / Avançado
+- **Básico:** 4 seções essenciais (Material, Parâmetros, Vendas, Resultados)
+- **Intermediário:** 5 seções (+ Falhas) com campos intermediários
+- **Avançado:** Todas as 10 seções com campos completos
+- Engrenagem (⚙️) no header de cada seção para customizar campos individuais
+- Persistência do nível e campos ocultos no localStorage
+- Migração automática do modo rápido antigo (quickMode → calcLevel)
+
 ---
 
 ### Fase 4 — Qualidade & Infraestrutura
@@ -239,21 +249,22 @@
 - **AMS Multi-material** — suporte a impressoras multifilamento com até 4 slots
 - **Responsividade** — grids 2 itens/linha, padding reduzido, unidades fora dos inputs
 - **UX** — modo rápido reposicionado, headers sem toggle, seções colapsáveis
+- **3-Level Calculator** — sistema Básico/Intermediário/Avançado com toggle de 3 botões, campos customizáveis por seção via engrenagem (⚙️), persistência localStorage
 
-### 📋 Pendente (Fase 2 + Fases 3 e 4)
+### 📋 Pendente (Fases 3 e 4)
 
-- **T-003: Dedução Automática de Estoque** — botão "Deduzir do Estoque" no ResultsPanel
-- **T-006: Comparativo de Registros** — modal lado a lado com diferenças destacadas
-- **T-007: Dashboard Persistente** — break-even chart, gráfico de tendência, margem média
-- **T-010: Import JSON** — botão de import no HistoryTab
-- **Fase 3: Usabilidade** — onboarding, tooltips, edição inline catálogo, atalhos teclado
+- **3.1 Onboarding** — modal de boas-vindas para novos usuários
+- **3.2 Tooltips** — ícone `ⓘ` em campos não-óbvios com explicações
+- **3.3 Inventário edição livre** — edição inline, dedução livre, filtros
+- **3.4 Catálogo edição inline** — lápis em cada card, input substitui texto
+- **3.5 Atalhos de teclado** — Ctrl+S salvar, Ctrl+H histórico, Esc fechar
 - **Fase 4: Qualidade** — testes unitários/integração, error boundaries, PWA, performance
 
-| Item                                | Status                               |
-| ----------------------------------- | ------------------------------------ |
-| Fase 1 — Fundação & Quick Wins      | ✅ Concluída                         |
-| Fase 2 — Histórico & Dashboard      | 🟡 Parcial (2.3, 2.4, 2.5 pendentes) |
-| Fase 3 — Usabilidade & Experiência  | 📋 Planejado                         |
-| Fase 4 — Qualidade & Infraestrutura | 📋 Planejado                         |
+| Item                                | Status                          |
+| ----------------------------------- | ------------------------------- |
+| Fase 1 — Fundação & Quick Wins      | ✅ Concluída                    |
+| Fase 2 — Histórico & Dashboard      | ✅ Concluída                    |
+| Fase 3 — Usabilidade & Experiência  | 🟡 Parcial (3-Level Calc feito) |
+| Fase 4 — Qualidade & Infraestrutura | 📋 Planejado                    |
 
-> Atualizado em: 25 de Maio de 2026
+> Atualizado em: 28 de Maio de 2026

--- a/src/components/Calculator/Calculator.tsx
+++ b/src/components/Calculator/Calculator.tsx
@@ -8,12 +8,13 @@ import {
 	type LucideIcon,
 	Printer,
 	Receipt,
+	Settings,
 	ShieldCheck,
 	SlidersHorizontal,
 	Upload,
 	Wrench,
 } from "lucide-react";
-import { lazy, Suspense, useCallback, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { BufferGeometry } from "three";
 import { InputGroup } from "@/components/ui/InputGroup";
@@ -23,6 +24,7 @@ import { ToggleSwitch } from "@/components/ui/ToggleCard";
 import { useCurrency } from "@/hooks/useCurrency";
 import { estimatePrintTimeFromDimensions } from "@/lib/printTimeEstimator";
 import { useCalculatorStore } from "@/stores/calculatorStore";
+import type { CalcLevel } from "@/stores/calculatorStore";
 import { useCatalogStore } from "@/stores/catalogStore";
 import { useFilamentInventory } from "@/stores/filamentInventory";
 import { selectSpool } from "@/stores/storeBridge";
@@ -115,8 +117,28 @@ const SECTION_ENABLES: Record<string, string[]> = {
 	results: [],
 };
 
-/** Section IDs visible in Basic (quick) mode */
-const BASIC_SECTION_IDS = new Set(["material", "print", "sales", "results"]);
+/** Section IDs visible in each level */
+const LEVEL_SECTIONS: Record<CalcLevel, string[]> = {
+	basic: ['material', 'print', 'sales', 'results'],
+	intermediate: ['material', 'print', 'failure', 'sales', 'results'],
+	advanced: ['material', 'print', 'failure', 'hardware', 'machine', 'fixedCost', 'labor', 'ops', 'sales', 'results'],
+}
+
+/** Fields visible at intermediate level per section (beyond basic fields) */
+const INTERMEDIATE_FIELDS: Record<string, string[]> = {
+	material: ['purgeWeight', 'spoolEfficiency', 'density', 'wasteMargin'],
+	print: ['selectedPrinter'],
+	failure: [],  // all failure fields visible at intermediate
+	sales: ['infillPercent', 'extrasCost', 'shippingCost', 'marketplace', 'taxPercent', 'markupPresets'],
+}
+
+/** Which fields are "basic" (always visible) per section */
+const BASIC_FIELDS: Record<string, string[]> = {
+	material: ['type', 'costPerKg', 'weightUsed', 'costPerLiter', 'volumeUsedMl'],
+	print: ['printTimeHours', 'printerPowerWatts', 'energyCostPerKwh'],
+	failure: ['failureMode', 'failureValue', 'riskMultiplier'],
+	sales: ['quantity', 'packagingCost', 'profitMarginPercent'],
+}
 
 export function Calculator() {
 	const { t } = useTranslation();
@@ -147,12 +169,40 @@ export function Calculator() {
 	};
 
 	const isFDM = store.activeTab === "fdm";
-	const isBasicMode = store.quickMode;
-	const isAdvanced = !isBasicMode;
-	const visibleSections = isBasicMode
-		? SECTIONS.filter((s) => BASIC_SECTION_IDS.has(s.id))
-		: SECTIONS;
+	const visibleSections = SECTIONS.filter((s) => LEVEL_SECTIONS[store.calcLevel].includes(s.id));
 	const { format: fmtCurrency, symbol: currencySymbol } = useCurrency();
+
+	const isFieldVisible = useCallback(
+		(sectionId: string, fieldId: string) => {
+			const level = store.calcLevel
+			const sectionFields = INTERMEDIATE_FIELDS[sectionId] ?? []
+			const basicFields = BASIC_FIELDS[sectionId] ?? []
+
+			// Basic level: only basic fields
+			if (level === 'basic') return basicFields.includes(fieldId)
+			// Intermediate level: basic + intermediate fields
+			if (level === 'intermediate') return basicFields.includes(fieldId) || sectionFields.includes(fieldId)
+			// Advanced: everything (unless hidden via customizer)
+			return !store.hiddenFields.includes(`${sectionId}.${fieldId}`)
+		},
+		[store.calcLevel, store.hiddenFields]
+	)
+
+	const [openCustomizer, setOpenCustomizer] = useState<string | null>(null)
+	const customizerRef = useRef<HTMLDivElement>(null)
+
+	// Click outside to close customizer
+	useEffect(() => {
+		const handleClickOutside = (e: MouseEvent) => {
+			if (customizerRef.current && !customizerRef.current.contains(e.target as Node)) {
+				setOpenCustomizer(null)
+			}
+		}
+		if (openCustomizer) {
+			document.addEventListener('mousedown', handleClickOutside)
+			return () => document.removeEventListener('mousedown', handleClickOutside)
+		}
+	}, [openCustomizer])
 
 	const handleFileDrop = useCallback(
 		async (file: File) => {
@@ -321,7 +371,9 @@ export function Calculator() {
 		Icon: LucideIcon,
 		title: string,
 		subtitle?: string,
+		sectionId?: string,
 	) {
+		const isCustomizable = sectionId && INTERMEDIATE_FIELDS[sectionId]?.length > 0 && store.calcLevel !== 'basic'
 		return (
 			<div className="flex items-center gap-2 mb-2 pb-1.5 border-b border-white/[0.06]">
 				<Icon className="w-3.5 h-3.5 text-indigo-400 shrink-0" />
@@ -331,6 +383,39 @@ export function Calculator() {
 						<p className="text-[10px] text-slate-500 truncate">{subtitle}</p>
 					)}
 				</div>
+				{isCustomizable && sectionId && (
+					<div className="relative" ref={openCustomizer === sectionId ? customizerRef : undefined}>
+						<button
+							type="button"
+							onClick={() => setOpenCustomizer(openCustomizer === sectionId ? null : sectionId)}
+							className="p-1 rounded-md hover:bg-white/[0.06] text-slate-500 hover:text-slate-300 transition-colors"
+							title={t('calc.customizeFields')}
+						>
+							<Settings className="w-3.5 h-3.5" />
+						</button>
+						{openCustomizer === sectionId && (
+							<div className="absolute right-0 top-8 z-50 w-56 glass border border-white/10 rounded-xl p-2 shadow-xl">
+								<p className="text-[10px] font-semibold text-slate-400 px-2 py-1 uppercase tracking-wide">
+									{t('calc.customizeFields')}
+								</p>
+								{(INTERMEDIATE_FIELDS[sectionId] ?? []).map((fieldId) => (
+									<label
+										key={fieldId}
+										className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-white/[0.04] cursor-pointer text-xs text-slate-300"
+									>
+										<input
+											type="checkbox"
+											checked={!store.hiddenFields.includes(`${sectionId}.${fieldId}`)}
+											onChange={() => store.toggleField(`${sectionId}.${fieldId}`)}
+											className="rounded border-white/20 bg-white/5 text-indigo-500 focus:ring-indigo-500"
+										/>
+										{fieldId}
+									</label>
+								))}
+							</div>
+						)}
+					</div>
+				)}
 			</div>
 		);
 	}
@@ -338,18 +423,19 @@ export function Calculator() {
 	function renderMaterialSection() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
-				{renderSectionHeader(
-					isFDM ? Layers : FlaskConical,
-					t("calc.material"),
-					t(
-						isFDM
-							? "calc.sectionDesc.fdmMaterial"
-							: "calc.sectionDesc.resinMaterial",
-					),
-				)}
+			{renderSectionHeader(
+				isFDM ? Layers : FlaskConical,
+				t("calc.material"),
+				t(
+					isFDM
+						? "calc.sectionDesc.fdmMaterial"
+						: "calc.sectionDesc.resinMaterial",
+				),
+				"material",
+			)}
 				{isFDM ? (
 					<>
-						{isAdvanced && (store.selectedPrinter.maxFilaments ?? 1) > 1 && (
+						{isFieldVisible("material", "purgeWeight") && (store.selectedPrinter.maxFilaments ?? 1) > 1 && (
 							<div className="flex items-center justify-end gap-2 mb-3">
 								<span className="text-[10px] font-semibold text-sky-400 uppercase tracking-wide">
 									AMS Multi-material
@@ -572,52 +658,54 @@ export function Calculator() {
 									type="number"
 									unit="g"
 								/>
-								{isAdvanced && (
-									<>
-										<InputGroup
-											label={t("calc.purge")}
-											value={store.fdmMaterial.purgeWeight}
-											onChange={(v) =>
-												handleInput(v, (val) =>
-													store.setFdmMaterial({
-														...store.fdmMaterial,
-														purgeWeight: val,
-													}),
-												)
-											}
-											type="number"
-											unit="g"
-										/>
-										<InputGroup
-											label={t("calc.spoolEfficiency")}
-											value={store.fdmMaterial.spoolEfficiency}
-											onChange={(v) =>
-												handleInput(v, (val) =>
-													store.setFdmMaterial({
-														...store.fdmMaterial,
-														spoolEfficiency: val,
-													}),
-												)
-											}
-											type="number"
-											unit="%"
-										/>
-										<InputGroup
-											label={t("calc.density")}
-											value={store.fdmMaterial.density}
-											onChange={(v) =>
-												handleInput(v, (val) =>
-													store.setFdmMaterial({
-														...store.fdmMaterial,
-														density: val,
-													}),
-												)
-											}
-											type="number"
-											unit="g/cm³"
-										/>
-									</>
-								)}
+							{isFieldVisible("material", "purgeWeight") && (
+								<InputGroup
+									label={t("calc.purge")}
+									value={store.fdmMaterial.purgeWeight}
+									onChange={(v) =>
+										handleInput(v, (val) =>
+											store.setFdmMaterial({
+												...store.fdmMaterial,
+												purgeWeight: val,
+											}),
+										)
+									}
+									type="number"
+									unit="g"
+								/>
+							)}
+							{isFieldVisible("material", "spoolEfficiency") && (
+								<InputGroup
+									label={t("calc.spoolEfficiency")}
+									value={store.fdmMaterial.spoolEfficiency}
+									onChange={(v) =>
+										handleInput(v, (val) =>
+											store.setFdmMaterial({
+												...store.fdmMaterial,
+												spoolEfficiency: val,
+											}),
+										)
+									}
+									type="number"
+									unit="%"
+								/>
+							)}
+							{isFieldVisible("material", "density") && (
+								<InputGroup
+									label={t("calc.density")}
+									value={store.fdmMaterial.density}
+									onChange={(v) =>
+										handleInput(v, (val) =>
+											store.setFdmMaterial({
+												...store.fdmMaterial,
+												density: val,
+											}),
+										)
+									}
+									type="number"
+									unit="g/cm³"
+								/>
+							)}
 							</div>
 						)}
 						<div className="sm:col-span-2 mt-3">
@@ -739,22 +827,22 @@ export function Calculator() {
 							type="number"
 							unit="ml"
 						/>
-						{isAdvanced && (
-							<InputGroup
-								label={t("calc.wasteMargin")}
-								value={store.resinMaterial.wasteMarginPercent}
-								onChange={(v) =>
-									handleInput(v, (val) =>
-										store.setResinMaterial({
-											...store.resinMaterial,
-											wasteMarginPercent: val,
-										}),
-									)
-								}
-								type="number"
-								unit="%"
-							/>
-						)}
+					{isFieldVisible("material", "wasteMargin") && (
+						<InputGroup
+							label={t("calc.wasteMargin")}
+							value={store.resinMaterial.wasteMarginPercent}
+							onChange={(v) =>
+								handleInput(v, (val) =>
+									store.setResinMaterial({
+										...store.resinMaterial,
+										wasteMarginPercent: val,
+									}),
+								)
+							}
+							type="number"
+							unit="%"
+						/>
+					)}
 					</div>
 				)}
 			</div>
@@ -764,11 +852,12 @@ export function Calculator() {
 	function renderPrintSection() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
-				{renderSectionHeader(
-					SlidersHorizontal,
-					t("calc.printParams"),
-					t("calc.sectionDesc.print"),
-				)}
+			{renderSectionHeader(
+				SlidersHorizontal,
+				t("calc.printParams"),
+				t("calc.sectionDesc.print"),
+				"print",
+			)}
 				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
 					<InputGroup
 						label={t("calc.printTime")}
@@ -840,7 +929,7 @@ export function Calculator() {
 						unit="R$/kWh"
 						step="0.01"
 					/>
-					{isFDM && isAdvanced && (
+					{isFDM && isFieldVisible("print", "selectedPrinter") && (
 						<div className="sm:col-span-2">
 							<Select
 								label={t("calc.printer")}
@@ -887,11 +976,12 @@ export function Calculator() {
 
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
-				{renderSectionHeader(
-					AlertTriangle,
-					t("calc.failure.title"),
-					t("calc.failure.description"),
-				)}
+			{renderSectionHeader(
+				AlertTriangle,
+				t("calc.failure.title"),
+				t("calc.failure.description"),
+				"failure",
+			)}
 				<div className="space-y-4">
 					<div className="flex items-center justify-between glass rounded-xl px-4 py-3">
 						<span className="text-xs font-semibold text-gray-400">
@@ -956,15 +1046,16 @@ export function Calculator() {
 	function renderHardwareSection() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5 space-y-6">
-				{renderSectionHeader(
-					Wrench,
-					t("calc.fdmHardware"),
-					t(
-						isFDM
-							? "calc.sectionDesc.fdmHardware"
-							: "calc.sectionDesc.resinHardware",
-					),
-				)}
+			{renderSectionHeader(
+				Wrench,
+				t("calc.fdmHardware"),
+				t(
+					isFDM
+						? "calc.sectionDesc.fdmHardware"
+						: "calc.sectionDesc.resinHardware",
+				),
+				"hardware",
+			)}
 				{isFDM && (
 					<>
 						<div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
@@ -1250,11 +1341,12 @@ export function Calculator() {
 	function renderMachineSection() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
-				{renderSectionHeader(
-					Printer,
-					t("calc.machine"),
-					t("calc.sectionDesc.machine"),
-				)}
+			{renderSectionHeader(
+				Printer,
+				t("calc.machine"),
+				t("calc.sectionDesc.machine"),
+				"machine",
+			)}
 				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
 					<InputGroup
 						label={t("calc.machineCost")}
@@ -1385,11 +1477,12 @@ export function Calculator() {
 	function renderFixedCostsSection() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
-				{renderSectionHeader(
-					Receipt,
-					t("calc.fixedCost.title"),
-					t("calc.fixedCost.description"),
-				)}
+			{renderSectionHeader(
+				Receipt,
+				t("calc.fixedCost.title"),
+				t("calc.fixedCost.description"),
+				"fixedCost",
+			)}
 				<div className="flex items-center justify-between mb-3">
 					<span className="text-xs text-gray-400">
 						{t("calc.fixedCost.title")}
@@ -1434,11 +1527,12 @@ export function Calculator() {
 	function renderLaborSection() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
-				{renderSectionHeader(
-					HardHat,
-					t("calc.labor"),
-					t("calc.sectionDesc.labor"),
-				)}
+			{renderSectionHeader(
+				HardHat,
+				t("calc.labor"),
+				t("calc.sectionDesc.labor"),
+				"labor",
+			)}
 				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
 					<InputGroup
 						label={t("calc.setupTime")}
@@ -1512,11 +1606,12 @@ export function Calculator() {
 	function renderOpsSection() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
-				{renderSectionHeader(
-					ShieldCheck,
-					t("calc.opsSoftware"),
-					t("calc.sectionDesc.ops"),
-				)}
+			{renderSectionHeader(
+				ShieldCheck,
+				t("calc.opsSoftware"),
+				t("calc.sectionDesc.ops"),
+				"ops",
+			)}
 				<div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
 					<div>
 						<div className="flex items-center justify-between border-b border-white/10 pb-2 mb-3">
@@ -1634,10 +1729,11 @@ export function Calculator() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
 				{renderSectionHeader(
-					DollarSign,
-					t("calc.sales"),
-					t("calc.sectionDesc.sales"),
-				)}
+				DollarSign,
+				t("calc.sales"),
+				t("calc.sectionDesc.sales"),
+				 "sales",
+					)}
 				<div className="space-y-4">
 					<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
 						<InputGroup
@@ -1649,9 +1745,9 @@ export function Calculator() {
 							type="number"
 							unit="un"
 						/>
-						{isAdvanced && (
-							<InputGroup
-								label={t("calc.infillPercent")}
+						{isFieldVisible("sales", "infillPercent") && (
+						<InputGroup
+						label={t("calc.infillPercent")}
 								value={store.infillPercent}
 								onChange={(v) =>
 									handleInput(v, (val) => store.setInfillPercent(val))
@@ -1661,9 +1757,9 @@ export function Calculator() {
 							/>
 						)}
 					</div>
-					{isAdvanced && (
-						<InputGroup
-							label={t("calc.extras")}
+					{isFieldVisible("sales", "extrasCost") && (
+					<InputGroup
+					label={t("calc.extras")}
 							value={
 								isFDM
 									? store.fdmExtras.extrasCost
@@ -1704,9 +1800,9 @@ export function Calculator() {
 							type="number"
 							prefix={currencySymbol}
 						/>
-						{isAdvanced && (
-							<InputGroup
-								label={t("calc.shipping")}
+						{isFieldVisible("sales", "shippingCost") && (
+						<InputGroup
+						label={t("calc.shipping")}
 								value={
 									isFDM
 										? store.fdmSales.shippingCost
@@ -1730,11 +1826,11 @@ export function Calculator() {
 							/>
 						)}
 					</div>
-					{isAdvanced && (
-						<>
-							<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-								<Select
-									label={t("calc.marketplace")}
+					{isFieldVisible("sales", "marketplace") && (
+					<>
+					<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					<Select
+					label={t("calc.marketplace")}
 									value={store.selectedMarketplace.id}
 									onChange={handleMarketplaceChange}
 									options={catalogMarketplaces.map((m) => ({
@@ -1899,22 +1995,18 @@ export function Calculator() {
 						</button>
 					</div>
 
-					{/* Basic / Advanced toggle */}
+					{/* Level toggle */}
 					<div className="segmented-control">
-						<button
-							type="button"
-							onClick={() => store.setQuickMode(true)}
-							className={`segmented-btn focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${isBasicMode ? "active-basic" : ""}`}
-						>
-							{t("calc.basic")}
-						</button>
-						<button
-							type="button"
-							onClick={() => store.setQuickMode(false)}
-							className={`segmented-btn focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${isAdvanced ? "active-advanced" : ""}`}
-						>
-							{t("calc.advanced")}
-						</button>
+						{(['basic', 'intermediate', 'advanced'] as const).map((level) => (
+							<button
+								key={level}
+								type="button"
+								onClick={() => store.setCalcLevel(level)}
+								className={`segmented-btn focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${store.calcLevel === level ? `active-${level}` : ''}`}
+							>
+								{level === 'basic' ? t('calc.basic') : level === 'intermediate' ? t('calc.intermediate') : t('calc.advanced')}
+							</button>
+						))}
 					</div>
 
 					{/* Product Name */}

--- a/src/components/Calculator/Calculator.tsx
+++ b/src/components/Calculator/Calculator.tsx
@@ -140,6 +140,12 @@ const BASIC_FIELDS: Record<string, string[]> = {
 	sales: ['quantity', 'packagingCost', 'profitMarginPercent'],
 }
 
+const LEVEL_LABELS: Record<CalcLevel, 'calc.basic' | 'calc.intermediate' | 'calc.advanced'> = {
+	basic: 'calc.basic',
+	intermediate: 'calc.intermediate',
+	advanced: 'calc.advanced',
+}
+
 export function Calculator() {
 	const { t } = useTranslation();
 	const store = useCalculatorStore();
@@ -1732,11 +1738,11 @@ export function Calculator() {
 		return (
 			<div className="glass rounded-2xl p-4 sm:p-5">
 				{renderSectionHeader(
-				DollarSign,
-				t("calc.sales"),
-				t("calc.sectionDesc.sales"),
-				 "sales",
-					)}
+					DollarSign,
+					t("calc.sales"),
+					t("calc.sectionDesc.sales"),
+					"sales",
+				)}
 				<div className="space-y-4">
 					<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
 						<InputGroup
@@ -1749,8 +1755,8 @@ export function Calculator() {
 							unit="un"
 						/>
 						{isFieldVisible("sales", "infillPercent") && (
-						<InputGroup
-						label={t("calc.infillPercent")}
+							<InputGroup
+								label={t("calc.infillPercent")}
 								value={store.infillPercent}
 								onChange={(v) =>
 									handleInput(v, (val) => store.setInfillPercent(val))
@@ -1761,8 +1767,8 @@ export function Calculator() {
 						)}
 					</div>
 					{isFieldVisible("sales", "extrasCost") && (
-					<InputGroup
-					label={t("calc.extras")}
+						<InputGroup
+							label={t("calc.extras")}
 							value={
 								isFDM
 									? store.fdmExtras.extrasCost
@@ -1804,8 +1810,8 @@ export function Calculator() {
 							prefix={currencySymbol}
 						/>
 						{isFieldVisible("sales", "shippingCost") && (
-						<InputGroup
-						label={t("calc.shipping")}
+							<InputGroup
+								label={t("calc.shipping")}
 								value={
 									isFDM
 										? store.fdmSales.shippingCost
@@ -1830,10 +1836,10 @@ export function Calculator() {
 						)}
 					</div>
 					{isFieldVisible("sales", "marketplace") && (
-					<>
-					<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-					<Select
-					label={t("calc.marketplace")}
+						<>
+							<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+								<Select
+									label={t("calc.marketplace")}
 									value={store.selectedMarketplace.id}
 									onChange={handleMarketplaceChange}
 									options={catalogMarketplaces.map((m) => ({
@@ -2007,7 +2013,7 @@ export function Calculator() {
 								onClick={() => store.setCalcLevel(level)}
 								className={`segmented-btn focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${store.calcLevel === level ? `active-${level}` : ''}`}
 							>
-								{level === 'basic' ? t('calc.basic') : level === 'intermediate' ? t('calc.intermediate') : t('calc.advanced')}
+								{t(LEVEL_LABELS[level])}
 							</button>
 						))}
 					</div>

--- a/src/components/Calculator/Calculator.tsx
+++ b/src/components/Calculator/Calculator.tsx
@@ -180,8 +180,11 @@ export function Calculator() {
 
 			// Basic level: only basic fields
 			if (level === 'basic') return basicFields.includes(fieldId)
-			// Intermediate level: basic + intermediate fields
-			if (level === 'intermediate') return basicFields.includes(fieldId) || sectionFields.includes(fieldId)
+			// Intermediate level: basic + intermediate fields, unless hidden via customizer
+			if (level === 'intermediate') {
+				return (basicFields.includes(fieldId) || sectionFields.includes(fieldId))
+					&& !store.hiddenFields.includes(`${sectionId}.${fieldId}`)
+			}
 			// Advanced: everything (unless hidden via customizer)
 			return !store.hiddenFields.includes(`${sectionId}.${fieldId}`)
 		},

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -123,6 +123,8 @@
     "quickMode": "Quick Mode",
     "basic": "Basic",
     "advanced": "Advanced",
+    "intermediate": "Intermediate",
+    "customizeFields": "Customize fields",
     "productName": "Product Name",
     "productNamePlaceholder": "E.g.: Decorative Vase",
     "costPerGram": "Cost per Gram",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -123,6 +123,8 @@
     "quickMode": "Modo Rápido",
     "basic": "Básico",
     "advanced": "Avançado",
+    "intermediate": "Intermediário",
+    "customizeFields": "Personalizar campos",
     "productName": "Nome do Produto",
     "productNamePlaceholder": "Ex: Vaso Decorativo",
     "costPerGram": "Custo por Grama",

--- a/src/index.css
+++ b/src/index.css
@@ -327,6 +327,16 @@ select {
   color: #6ee7b7;
   box-shadow: 0 2px 8px rgba(16, 185, 129, 0.2);
 }
+.segmented-btn.active-intermediate {
+  background: linear-gradient(
+    135deg,
+    rgba(234, 179, 8, 0.2),
+    rgba(202, 138, 4, 0.15)
+  );
+  border-color: rgba(234, 179, 8, 0.35);
+  color: #fde68a;
+  box-shadow: 0 2px 8px rgba(234, 179, 8, 0.2);
+}
 .segmented-btn.active-advanced {
   background: linear-gradient(
     135deg,

--- a/src/stores/calculatorStore.ts
+++ b/src/stores/calculatorStore.ts
@@ -40,7 +40,7 @@ function debouncedAutoSave(getState: () => CalculatorState) {
       productName: s.productName, quantity: s.quantity,
       infillPercent: s.infillPercent, targetMarginMode: s.targetMarginMode,
       enabledSections: s.enabledSections,
-      quickMode: s.quickMode, calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
+      calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
     }
     localStorage.setItem('open3dcalc_settings_v2', JSON.stringify(data))
   }, 800)
@@ -304,7 +304,7 @@ function computeStoreResults(s: ComputeStoreInput): CalculationResult {
 function migrateQuickMode(quickMode: boolean | undefined): CalcLevel {
   if (quickMode === true) return 'basic'
   if (quickMode === false) return 'advanced'
-  return 'intermediate'
+  return 'basic'
 }
 
 export const useCalculatorStore = create<CalculatorState>((set, get) => {
@@ -350,7 +350,6 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
     fdmAmsSlots: DEFAULT_AMS_SLOTS.map(s => ({ ...s })),
 
     productName: '',
-    quickMode: loadStr('quickMode', true),
     calcLevel: loadStr<CalcLevel>('calcLevel', migrateQuickMode(loadStr<boolean | undefined>('quickMode', undefined))),
     hiddenFields: loadStr<string[]>('hiddenFields', []),
     quantity: loadStr('quantity', 1),
@@ -546,7 +545,7 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
         fixedCosts: s.fixedCosts,
         quantity: s.quantity, infillPercent: s.infillPercent,
         currency: s.currency,
-        quickMode: s.quickMode, calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
+        calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
       }
       localStorage.setItem('open3dcalc_settings_v2', JSON.stringify(data))
     },

--- a/src/stores/calculatorStore.ts
+++ b/src/stores/calculatorStore.ts
@@ -40,7 +40,7 @@ function debouncedAutoSave(getState: () => CalculatorState) {
       productName: s.productName, quantity: s.quantity,
       infillPercent: s.infillPercent, targetMarginMode: s.targetMarginMode,
       enabledSections: s.enabledSections,
-      quickMode: s.quickMode,
+      quickMode: s.quickMode, calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
     }
     localStorage.setItem('open3dcalc_settings_v2', JSON.stringify(data))
   }, 800)
@@ -81,6 +81,8 @@ const DEFAULT_AMS_SLOTS: AMSSlot[] = Array.from({ length: 4 }, (_, i) => ({
   spoolEfficiency: 98,
   color: ['#cccccc', '#f87171', '#60a5fa', '#34d399'][i],
 }))
+
+export type CalcLevel = 'basic' | 'intermediate' | 'advanced'
 
 interface CalculatorState {
   activeTab: 'fdm' | 'resin'
@@ -143,8 +145,10 @@ interface CalculatorState {
 
   productName: string
   setProductName: (name: string) => void
-  quickMode: boolean
-  setQuickMode: (v: boolean) => void
+  calcLevel: CalcLevel
+  setCalcLevel: (v: CalcLevel) => void
+  hiddenFields: string[]
+  toggleField: (fieldId: string) => void
   quantity: number
   setQuantity: (v: number) => void
   infillPercent: number
@@ -297,6 +301,12 @@ function computeStoreResults(s: ComputeStoreInput): CalculationResult {
   }
 }
 
+function migrateQuickMode(quickMode: boolean | undefined): CalcLevel {
+  if (quickMode === true) return 'basic'
+  if (quickMode === false) return 'advanced'
+  return 'intermediate'
+}
+
 export const useCalculatorStore = create<CalculatorState>((set, get) => {
   const setWithCompute = (update: Partial<CalculatorState> | ((state: CalculatorState) => Partial<CalculatorState>)) => {
     set((state) => {
@@ -341,6 +351,8 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
 
     productName: '',
     quickMode: loadStr('quickMode', true),
+    calcLevel: loadStr<CalcLevel>('calcLevel', migrateQuickMode(loadStr<boolean | undefined>('quickMode', undefined))),
+    hiddenFields: loadStr<string[]>('hiddenFields', []),
     quantity: loadStr('quantity', 1),
     infillPercent: loadStr('infillPercent', 20),
     targetMarginMode: false,
@@ -403,7 +415,13 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
     setCurrency: (currency) => set({ currency }),
 
     setProductName: (productName) => setWithCompute({ productName }),
-    setQuickMode: (quickMode) => setWithCompute({ quickMode }),
+    setCalcLevel: (calcLevel) => setWithCompute({ calcLevel }),
+    toggleField: (fieldId) => setWithCompute((state) => {
+      const hidden = state.hiddenFields.includes(fieldId)
+        ? state.hiddenFields.filter((id) => id !== fieldId)
+        : [...state.hiddenFields, fieldId]
+      return { hiddenFields: hidden }
+    }),
     setQuantity: (quantity) => setWithCompute({ quantity }),
     setInfillPercent: (infillPercent) => setWithCompute({ infillPercent }),
     setTargetMarginMode: (targetMarginMode) => setWithCompute({ targetMarginMode }),
@@ -528,7 +546,7 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
         fixedCosts: s.fixedCosts,
         quantity: s.quantity, infillPercent: s.infillPercent,
         currency: s.currency,
-        quickMode: s.quickMode,
+        quickMode: s.quickMode, calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
       }
       localStorage.setItem('open3dcalc_settings_v2', JSON.stringify(data))
     },


### PR DESCRIPTION
## Summary

Replaces the simple Basic/Advanced toggle with a 3-level calculator system:

- **Básico:** 4 seções essenciais (Material, Parâmetros, Vendas, Resultados)
- **Intermediário:** 5 seções (+ Falhas) com campos intermediários  
- **Avançado:** Todas as 10 seções com campos completos

## Changes

### Store (`calculatorStore.ts`)
- `quickMode: boolean` → `calcLevel: 'basic' | 'intermediate' | 'advanced'`
- Added `hiddenFields: string[]` for per-section field customization
- Added `toggleField(fieldId)` action
- Added `migrateQuickMode()` for backward compatibility
- Updated `debouncedAutoSave` and `saveSettings`

### UI (`Calculator.tsx`)
- 3-button segmented toggle (Básico / Intermediário / Avançado)
- `LEVEL_SECTIONS` mapping for section visibility per level
- `INTERMEDIATE_FIELDS` and `BASIC_FIELDS` for per-field visibility
- `isFieldVisible()` callback with hiddenFields support
- Gear icon (⚙️) in section headers with customizer popover
- Click-outside detection for popover dismissal

### CSS (`index.css`)
- Added `active-intermediate` class (yellow/gold gradient)

### i18n
- Added `intermediate` and `customizeFields` keys in pt-BR and en-US

### Roadmap
- Updated `ROADMAP.md`: Phase 2 marked ✅, new feature 3.6 documented

## QA Results
- ✅ TypeScript compiles (zero errors)
- ✅ Vite build passes
- ✅ Visual QA: Basic/Intermediate/Advanced toggle works correctly
- ✅ Gear customizer popover opens/closes properly
- ✅ Field toggles persist in localStorage
- ✅ Migration from old quickMode data works