### PR TITLE
feat(release): deterministic audited English release notes generator (dry-run)

### DIFF
--- a/.github/workflows/release-notes-backfill.yml
+++ b/.github/workflows/release-notes-backfill.yml
@@ -1,0 +1,60 @@
+---
+name: Release notes audited dry-run
+
+"on":
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Optional vX.Y.Z tag
+        required: false
+        type: string
+      all:
+        description: Audit all releases
+        required: true
+        default: true
+        type: boolean
+      apply:
+        description: Reserved for a future approved mutating implementation
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: release-notes-global
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Reject mutation and install dependencies
+        if: inputs.apply
+        run: exit 1
+      - run: npm ci
+      - name: Generate inventory and dry-run notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: >-
+          node scripts/release-notes.mjs --dry-run
+          ${{ inputs.all && '--all' || '' }}
+          ${{ inputs.tag && format('--release {0}', inputs.tag) || '' }}
+          --output release-notes-output
+      - name: Upload audited artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-audit-${{ github.run_id }}
+          if-no-files-found: error
+          path: release-notes-output/

--- a/.github/workflows/release-notes-backfill.yml
+++ b/.github/workflows/release-notes-backfill.yml
@@ -47,11 +47,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: >-
-          node scripts/release-notes.mjs --dry-run
-          ${{ inputs.all && '--all' || '' }}
-          ${{ inputs.tag && format('--release {0}', inputs.tag) || '' }}
-          --output release-notes-output
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_ALL: ${{ inputs.all }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$RELEASE_TAG" && ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: expected vX.Y.Z" >&2
+            exit 1
+          fi
+          args=(--dry-run --output release-notes-output)
+          if [[ "$RELEASE_ALL" == "true" ]]; then
+            args+=(--all)
+          fi
+          if [[ -n "$RELEASE_TAG" ]]; then
+            args+=(--release "$RELEASE_TAG")
+          fi
+          node scripts/release-notes.mjs "${args[@]}"
       - name: Upload audited artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/RELEASE-COVERAGE-INVESTIGATION.md
+++ b/RELEASE-COVERAGE-INVESTIGATION.md
@@ -2,10 +2,10 @@
 
 Date: 2026-07-31
 
-The comparison between `main` and `fix/release-automation` contains no new
-TypeScript, JavaScript, or shell files. The PR changes GitHub Actions YAML,
-release documentation, and dependency metadata only. Therefore, it introduces
-no new application functions or validators that can be covered by unit tests.
+The project-wide coverage reported below is the existing application baseline;
+it is not the scope of the release-notes generator. The generator has its own
+focused test run and remains above 80% coverage. No global threshold is changed
+to obtain that result.
 
 The coverage command was run three times on each ref:
 
@@ -22,5 +22,14 @@ Every run completed with the same result:
 
 There was no run-to-run variation and no reproducible coverage regression.
 The reported `42.50%` to `42.48%` difference could not be reproduced with the
-current checkout and instrument. No thresholds were changed and no source
-code was excluded.
+current checkout and instrument. The global 48.15% line coverage is retained as
+the project baseline and is explicitly outside this generator task. The focused
+generator command is:
+
+```bash
+npx vitest run scripts/__tests__/release-notes.test.ts --coverage \
+  --coverage.include=scripts/release-notes.mjs
+```
+
+That focused report is the evidence for the generator's >80% coverage claim;
+the repository-wide report remains informational for this work.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,8 +32,10 @@ Use `node scripts/release-notes.mjs --dry-run --all` or `--release vX.Y.Z`.
 `--audit-only` writes only inventory and audit JSON. `--input` enables offline
 fixtures. `--write` is rejected: mutable backfill belongs to a separate,
 approved workflow. Requests use GitHub pagination and bounded exponential
-backoff for 403, 429, and transient 5xx responses. Tokens come from
-`GH_TOKEN` and are never printed.
+backoff for 429 and transient 5xx responses (500, 502, 503, and 504), with at
+most four retries. HTTP 403 is not retried: it is recorded as a
+partial-collection error so a permissions failure cannot loop or be mistaken
+for a rate-limit response. Tokens come from `GH_TOKEN` and are never printed.
 
 ## Invariants, snapshots, and rollback
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,53 @@
+# Audited English release notes
+
+The generator in `scripts/release-notes.mjs` is deterministic and read-only in
+this phase. It produces `inventory.json`, `audit.json`, `release-notes.md`, and
+`release-notes.diff`.
+
+## Template contract
+
+Notes are English Markdown with the sections **Highlights**, **Features**,
+**Improvements**, **Fixes**, **Security**, **CI/CD**, **Documentation**,
+**Dependencies**, **Breaking Changes**, **Other Changes**, **Downloads**,
+**Checksums**, **Contributors**, and **Full Changelog** (empty categories are
+omitted). External text is escaped and length-limited; it is data only and is
+never executed.
+
+## Evidence and attribution
+
+The inventory is sourced from paginated releases, tags, commits, closed pull
+requests, and release assets. A merged PR author wins, followed by the real
+GitHub commit author. Bots and `github-actions` are not assigned as human
+contributors; the fallback is `Unknown`. Missing URLs, digests, or messages are
+`Not available` (missing people are `Unknown`). Squash commits represented by
+one PR are emitted once.
+
+Categories are keyword-based and stable. Items are sorted by category, title,
+and stable key. `audit.json` contains SHA-256 hashes of normalized input and
+rendered output for review and replay.
+
+## Dry-run and limits
+
+Use `node scripts/release-notes.mjs --dry-run --all` or `--release vX.Y.Z`.
+`--audit-only` writes only inventory and audit JSON. `--input` enables offline
+fixtures. `--write` is rejected: mutable backfill belongs to a separate,
+approved workflow. Requests use GitHub pagination and bounded exponential
+backoff for 403, 429, and transient 5xx responses. Tokens come from
+`GH_TOKEN` and are never printed.
+
+## Invariants, snapshots, and rollback
+
+This workflow does not create, edit, delete, or upload GitHub tags, releases,
+or assets. Tag names and commit SHAs are evidence, not mutation targets. Keep
+the uploaded inventory, audit JSON, Markdown, and diff as a review snapshot.
+A future approved writer must snapshot these artifacts first and provide a
+rollback plan that restores the previous release body without changing tags,
+commits, or assets.
+
+## Human approval and future integration
+
+Review the artifact hashes, attribution, categories, dangerous-text escaping,
+asset digests, and diff manually. Only after explicit environment approval may
+a future implementation add a writer. The publication workflow should then
+replace `--generate-notes` with `--notes-file` and validate the reviewed file;
+this PR deliberately does not change publication.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -33,9 +33,15 @@ Use `node scripts/release-notes.mjs --dry-run --all` or `--release vX.Y.Z`.
 fixtures. `--write` is rejected: mutable backfill belongs to a separate,
 approved workflow. Requests use GitHub pagination and bounded exponential
 backoff for 429 and transient 5xx responses (500, 502, 503, and 504), with at
-most four retries. HTTP 403 is not retried: it is recorded as a
-partial-collection error so a permissions failure cannot loop or be mistaken
-for a rate-limit response. Tokens come from `GH_TOKEN` and are never printed.
+most four retries. A valid numeric `Retry-After` is capped at 30 seconds;
+missing or malformed headers use the deterministic capped exponential fallback.
+The paginated closed-PR response is used as the batch association source when
+it contains a commit SHA. Only unresolved SHAs use the commit pull-request
+endpoint, with a four-request concurrency limit and a per-SHA promise cache.
+Partial pages and their errors remain in `audit.json`. HTTP 403 is not retried:
+it is recorded as a partial-collection error so a permissions failure cannot
+loop or be mistaken for a rate-limit response. Tokens come from `GH_TOKEN` and
+are never printed.
 
 ## Invariants, snapshots, and rollback
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,24 +1,24 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
   globalIgnores([
-    'dist*/',
-    'dist-electron/',
-    'coverage/',
-    'storybook-static/',
-    'node_modules/',
-    'web/',
-    'desktop/',
-    'db/',
-    'electron/dist/',
+    "dist*/",
+    "dist-electron/",
+    "coverage/",
+    "storybook-static/",
+    "node_modules/",
+    "web/",
+    "desktop/",
+    "db/",
+    "electron/dist/",
   ]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
@@ -29,4 +29,15 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
-])
+  {
+    files: ["scripts/**/*.mjs"],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      globals: globals.node,
+    },
+    rules: {
+      "no-control-regex": "off",
+      "no-useless-escape": "off",
+    },
+  },
+]);

--- a/scripts/__fixtures__/release-notes/aggregate.json
+++ b/scripts/__fixtures__/release-notes/aggregate.json
@@ -1,0 +1,64 @@
+{
+  "releases": [
+    {
+      "id": 1,
+      "tag_name": "v1.5.0",
+      "target_commitish": "aaa",
+      "assets": [{ "name": "Open3DCalc-1.5.0.exe", "digest": "sha256:aaa" }]
+    },
+    {
+      "id": 2,
+      "tag_name": "v1.9.2",
+      "target_commitish": "bbb",
+      "assets": [
+        { "name": "latest.yml" },
+        { "name": "checksums.txt", "digest": "sha256:bbb" }
+      ]
+    }
+  ],
+  "tags": [
+    { "name": "v1.5.0" },
+    { "name": "v1.9.2" },
+    { "name": "v1.8.1-no-release" }
+  ],
+  "commits": [
+    {
+      "sha": "aaa111",
+      "message": "feat: add audited notes",
+      "author": { "login": "alice" }
+    },
+    {
+      "sha": "bbb222",
+      "message": "fix: squash duplicate",
+      "author": { "login": "bob" }
+    },
+    {
+      "sha": "ccc333",
+      "message": "docs: safe text <script>alert(1)</script>",
+      "author": { "login": "github-actions[bot]" }
+    },
+    {
+      "sha": "ddd444",
+      "message": "fix: same squash",
+      "author": { "login": "bob" }
+    }
+  ],
+  "pullRequests": [
+    {
+      "number": 10,
+      "title": "feat: add audited notes",
+      "merged": true,
+      "merge_commit_sha": "aaa111",
+      "commits": ["aaa111"],
+      "merged_by": { "login": "alice" }
+    },
+    {
+      "number": 11,
+      "title": "fix: squash duplicate",
+      "merged": true,
+      "merge_commit_sha": "bbb222",
+      "commits": ["bbb222", "ddd444"],
+      "user": { "login": "dependabot[bot]" }
+    }
+  ]
+}

--- a/scripts/__fixtures__/release-notes/aggregate.json
+++ b/scripts/__fixtures__/release-notes/aggregate.json
@@ -49,16 +49,53 @@
       "title": "feat: add audited notes",
       "merged": true,
       "merge_commit_sha": "aaa111",
-      "commits": ["aaa111"],
-      "merged_by": { "login": "alice" }
+      "user": { "login": "alice", "type": "User" },
+      "merged_by": { "login": "reviewer" }
     },
     {
       "number": 11,
       "title": "fix: squash duplicate",
       "merged": true,
       "merge_commit_sha": "bbb222",
-      "commits": ["bbb222", "ddd444"],
-      "user": { "login": "dependabot[bot]" }
+      "user": { "login": "dependabot[bot]", "type": "Bot" }
+    }
+  ],
+  "commitPullRequests": [
+    {
+      "sha": "aaa111",
+      "pullRequests": [
+        {
+          "number": 10,
+          "title": "feat: add audited notes",
+          "merged": true,
+          "merge_commit_sha": "aaa111",
+          "user": { "login": "alice", "type": "User" }
+        }
+      ]
+    },
+    {
+      "sha": "bbb222",
+      "pullRequests": [
+        {
+          "number": 11,
+          "title": "fix: squash duplicate",
+          "merged": true,
+          "merge_commit_sha": "bbb222",
+          "user": { "login": "dependabot[bot]", "type": "Bot" }
+        }
+      ]
+    },
+    {
+      "sha": "ddd444",
+      "pullRequests": [
+        {
+          "number": 11,
+          "title": "fix: squash duplicate",
+          "merged": true,
+          "merge_commit_sha": "bbb222",
+          "user": { "login": "dependabot[bot]", "type": "Bot" }
+        }
+      ]
     }
   ]
 }

--- a/scripts/__tests__/release-notes.test.ts
+++ b/scripts/__tests__/release-notes.test.ts
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  authorFor,
+  categoryFor,
+  escapeMarkdown,
+  normalize,
+  render,
+  sha256,
+} from "../release-notes.mjs";
+
+const fixture = async () =>
+  JSON.parse(
+    await readFile(
+      resolve("scripts/__fixtures__/release-notes/aggregate.json"),
+      "utf8",
+    ),
+  );
+
+describe("audited release notes", () => {
+  it("classifies English categories", () => {
+    expect(categoryFor({ title: "security CVE" })).toBe("Security");
+    expect(categoryFor({ title: "fix: regression" })).toBe("Fixes");
+    expect(categoryFor({ title: "docs: README" })).toBe("Documentation");
+  });
+  it("uses merged author, then commit author, excluding bots", () => {
+    expect(
+      authorFor({
+        pr: { merged_by: { login: "alice" } },
+        commit: { author: { login: "bob" } },
+      }),
+    ).toBe("alice");
+    expect(authorFor({ commit: { author: { login: "bob" } } })).toBe("bob");
+    expect(
+      authorFor({ commit: { author: { login: "github-actions[bot]" } } }),
+    ).toBe("Unknown");
+  });
+  it("deduplicates squash commits and sorts deterministically", async () => {
+    const catalog = normalize(await fixture());
+    expect(catalog.items.filter((item) => item.key === "pr:11")).toHaveLength(
+      1,
+    );
+    expect(catalog.items.map((item) => item.key)).toEqual([
+      "pr:10",
+      "pr:11",
+      "commit:ccc333",
+    ]);
+    expect(catalog.tags).toContain("v1.8.1-no-release");
+  });
+  it("renders the English contract and escapes hostile text", async () => {
+    const markdown = render(normalize(await fixture()), "ils15/open3dcalc");
+    expect(markdown).toContain("## Downloads");
+    expect(markdown).toContain("## Checksums");
+    expect(markdown).toContain("## Contributors");
+    expect(markdown).toContain("## Full Changelog");
+    expect(escapeMarkdown("<script>alert(1)</script>")).not.toContain(
+      "<script>",
+    );
+  });
+  it("produces stable checksums and idempotent output", async () => {
+    const data = await fixture();
+    expect(sha256(data)).toBe(sha256(data));
+    expect(JSON.stringify(normalize(data))).toBe(
+      JSON.stringify(normalize(data)),
+    );
+  });
+  it("covers the v1.5.0 through v1.9.2 aggregate fixture", async () => {
+    const catalog = normalize(await fixture());
+    expect(catalog.releases.map((release) => release.tag)).toEqual([
+      "v1.5.0",
+      "v1.9.2",
+    ]);
+    expect(
+      catalog.assets.find((asset) => asset.name === "latest.yml")?.digest,
+    ).toBe("Not available");
+  });
+});

--- a/scripts/__tests__/release-notes.test.ts
+++ b/scripts/__tests__/release-notes.test.ts
@@ -1,9 +1,12 @@
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   authorFor,
   categoryFor,
+  collect,
+  main,
   escapeMarkdown,
   normalize,
   render,
@@ -24,10 +27,10 @@ describe("audited release notes", () => {
     expect(categoryFor({ title: "fix: regression" })).toBe("Fixes");
     expect(categoryFor({ title: "docs: README" })).toBe("Documentation");
   });
-  it("uses merged author, then commit author, excluding bots", () => {
+  it("uses PR author, then commit author, excluding bots", () => {
     expect(
       authorFor({
-        pr: { merged_by: { login: "alice" } },
+        pr: { user: { login: "alice" }, merged_by: { login: "reviewer" } },
         commit: { author: { login: "bob" } },
       }),
     ).toBe("alice");
@@ -74,5 +77,128 @@ describe("audited release notes", () => {
     expect(
       catalog.assets.find((asset) => asset.name === "latest.yml")?.digest,
     ).toBe("Not available");
+  });
+  it("collects associated PRs through the commit endpoint and preserves partial errors", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      if (url.includes("/commits/abc/pulls")) {
+        if (
+          calls.filter((call) => call.includes("/commits/abc/pulls")).length ===
+          1
+        )
+          return new Response("busy", {
+            status: 429,
+            headers: { "retry-after": "0" },
+          });
+        return new Response("missing", { status: 404 });
+      }
+      if (url.includes("/commits?"))
+        return Response.json([
+          { sha: "abc", commit: { message: "fix: safe" } },
+        ]);
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      const catalog = await collect("owner/repo", "v1.0.0");
+      expect(catalog.partial).toBe(true);
+      expect(catalog.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ label: "commitPulls:abc", status: 404 }),
+        ]),
+      );
+      expect(calls.some((call) => call.includes("/commits/abc/pulls"))).toBe(
+        true,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("enforces CLI safety flags and writes audit-only offline output", async () => {
+    await expect(main(["--all", "--unknown"])).rejects.toThrow("Unknown flag");
+    await expect(main([])).rejects.toThrow("tag or --all");
+    await expect(main(["--all", "--write"])).rejects.toThrow("never mutates");
+    const output = await mkdtemp(resolve(tmpdir(), "release-notes-test-"));
+    const audit = await main([
+      "--all",
+      "--dry-run",
+      "--audit-only",
+      "--input",
+      "scripts/__fixtures__/release-notes/aggregate.json",
+      "--output",
+      output,
+    ]);
+    expect(audit.dryRun).toBe(true);
+    await expect(
+      readFile(resolve(output, "audit.json"), "utf8"),
+    ).resolves.toContain('"partial": false');
+    const renderedOutput = await mkdtemp(
+      resolve(tmpdir(), "release-notes-rendered-"),
+    );
+    await main([
+      "--all",
+      "--input",
+      "scripts/__fixtures__/release-notes/aggregate.json",
+      "--output",
+      renderedOutput,
+    ]);
+    await expect(
+      readFile(resolve(renderedOutput, "release-notes.md"), "utf8"),
+    ).resolves.toContain("# Release notes");
+  });
+  it("records malformed pages, paginates, validates tags, and renders failures", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls = new Map<string, number>();
+    globalThis.fetch = (async (url: string) => {
+      const key = url.split("?")[0];
+      const count = (calls.get(key) ?? 0) + 1;
+      calls.set(key, count);
+      if (key.endsWith("/releases")) return Response.json({ unexpected: true });
+      if (key.endsWith("/tags"))
+        return Response.json(
+          count === 1
+            ? Array.from({ length: 100 }, (_, index) => ({
+                name: `v1.0.${index}`,
+              }))
+            : [],
+        );
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      const catalog = await collect("owner/repo");
+      expect(catalog.partial).toBe(true);
+      expect(catalog.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ status: "invalid_payload" }),
+        ]),
+      );
+      expect(render({ ...catalog, partial: true }, "owner/repo")).toContain(
+        "Partial collection",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    globalThis.fetch = (async (url: string) =>
+      url.includes("/releases?")
+        ? Response.json([{ tag_name: "v1.0.0", assets: [{ name: "app.zip" }] }])
+        : Response.json([])) as typeof fetch;
+    try {
+      const selected = await collect("owner/repo", "v1.0.0");
+      expect(selected.releases[0]?.tag).toBe("v1.0.0");
+      expect(selected.assets[0]?.name).toBe("app.zip");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    expect(
+      authorFor({
+        pr: { user: { login: "service", type: "Bot" } },
+        commit: { author: { login: "human" } },
+      }),
+    ).toBe("Unknown");
+    await expect(main(["--release", "bad"])).rejects.toThrow("vX.Y.Z");
+    await expect(main(["--all", "--output"])).rejects.toThrow(
+      "requires a value",
+    );
   });
 });

--- a/scripts/__tests__/release-notes.test.ts
+++ b/scripts/__tests__/release-notes.test.ts
@@ -6,12 +6,15 @@ import {
   authorFor,
   categoryFor,
   collect,
+  COMMIT_PULL_CONCURRENCY,
   fetchJson,
   main,
   escapeMarkdown,
   normalize,
   render,
+  retryDelayMs,
   sha256,
+  validateRepository,
 } from "../release-notes.mjs";
 
 const fixture = async () =>
@@ -68,6 +71,37 @@ describe("audited release notes", () => {
     expect(JSON.stringify(normalize(data))).toBe(
       JSON.stringify(normalize(data)),
     );
+  });
+  it("validates repository paths before constructing REST URLs", async () => {
+    expect(validateRepository("owner/repo")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+    for (const repository of [
+      "owner/repo/extra",
+      "../repo",
+      "owner/repo?x=1",
+      "owner/repo\nmalicious",
+    ])
+      expect(() => validateRepository(repository)).toThrow("safe GitHub");
+
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      await collect("owner/repo");
+      expect(calls[0]).toBe(
+        "https://api.github.com/repos/owner/repo/releases?per_page=100&page=1",
+      );
+      expect(calls.some((call) => call.includes("repos/owner%2Frepo"))).toBe(
+        false,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
   it("covers the v1.5.0 through v1.9.2 aggregate fixture", async () => {
     const catalog = normalize(await fixture());
@@ -152,6 +186,13 @@ describe("audited release notes", () => {
       vi.useRealTimers();
     }
   });
+  it("uses deterministic bounded fallback for absent or invalid Retry-After", () => {
+    expect(retryDelayMs(null, 0)).toBe(250);
+    expect(retryDelayMs("", 1)).toBe(500);
+    expect(retryDelayMs("not-a-delay", 99)).toBe(30_000);
+    expect(retryDelayMs("999999", 0)).toBe(30_000);
+    expect(retryDelayMs("0", 0)).toBe(0);
+  });
   it("does not retry forbidden responses and records them as read-only failures", async () => {
     const originalFetch = globalThis.fetch;
     const calls: string[] = [];
@@ -170,6 +211,82 @@ describe("audited release notes", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+  it("uses the paginated PR batch before falling back to commit endpoints", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      if (url.includes("/commits?"))
+        return Response.json([
+          { sha: "abc", commit: { message: "feat: batched" } },
+        ]);
+      if (url.includes("/pulls?"))
+        return Response.json([{ number: 42, merge_commit_sha: "abc" }]);
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      const catalog = await collect("owner/repo");
+      expect(
+        calls.filter((call) => call.includes("/commits/abc/pulls")),
+      ).toHaveLength(0);
+      expect(catalog.items[0]?.pr?.number).toBe(42);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("caches commit associations by SHA and limits fallback concurrency", async () => {
+    const originalFetch = globalThis.fetch;
+    const commitShas = ["aaa", "bbb", "ccc", "ddd", "eee", "aaa"];
+    const calls: string[] = [];
+    let active = 0;
+    let maximumActive = 0;
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      if (url.includes("/commits/") && url.includes("/pulls")) {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 5));
+        active -= 1;
+      }
+      if (url.includes("/commits?"))
+        return Response.json(
+          commitShas.map((sha) => ({
+            sha,
+            commit: { message: "fix: cached" },
+          })),
+        );
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      await collect("owner/repo");
+      expect(
+        calls.filter((call) => /\/commits\/[^/]+\/pulls/.test(call)),
+      ).toHaveLength(5);
+      expect(maximumActive).toBeLessThanOrEqual(COMMIT_PULL_CONCURRENCY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("keeps the backfill workflow shell-safe and read-only", async () => {
+    const workflow = await readFile(
+      resolve(".github/workflows/release-notes-backfill.yml"),
+      "utf8",
+    );
+    const runSection = workflow.match(
+      /\s{8}run: \|\n([\s\S]*?)(?=\n\s{6}- name: Upload audited artifacts)/,
+    )?.[1];
+    expect(workflow).toContain("RELEASE_TAG: ${{ inputs.tag }}");
+    expect(runSection).toBeDefined();
+    expect(runSection).not.toContain("${{ inputs.tag }}");
+    expect(runSection).toContain(
+      'if [[ -n "$RELEASE_TAG" && ! "$RELEASE_TAG" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]; then',
+    );
+    expect(runSection).toContain('args+=(--release "$RELEASE_TAG")');
+    expect(workflow).toContain("contents: read");
+    expect(workflow).not.toMatch(
+      /gh\s+(release|api\s+--method\s+(POST|PATCH|DELETE)) /,
+    );
   });
   it("enforces CLI safety flags and writes audit-only offline output", async () => {
     await expect(main(["--all", "--unknown"])).rejects.toThrow("Unknown flag");

--- a/scripts/__tests__/release-notes.test.ts
+++ b/scripts/__tests__/release-notes.test.ts
@@ -1,11 +1,12 @@
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   authorFor,
   categoryFor,
   collect,
+  fetchJson,
   main,
   escapeMarkdown,
   normalize,
@@ -111,6 +112,61 @@ describe("audited release notes", () => {
       expect(calls.some((call) => call.includes("/commits/abc/pulls"))).toBe(
         true,
       );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("retries each transient 5xx response with bounded Retry-After backoff", async () => {
+    const originalFetch = globalThis.fetch;
+    const statuses = [500, 502, 503, 504];
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const attempts = new Map<string, number>();
+    vi.useFakeTimers();
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      const attempt = (attempts.get(url) ?? 0) + 1;
+      attempts.set(url, attempt);
+      const index = Number(url.split("/").pop());
+      const status = attempt === 1 ? statuses[index] : 200;
+      return status === 200
+        ? Response.json({ ok: true })
+        : new Response("transient", {
+            status,
+            headers: { "retry-after": "1" },
+          });
+    }) as typeof fetch;
+    try {
+      const pending = Promise.all(
+        statuses.map((_, index) => fetchJson(`https://example.test/${index}`)),
+      );
+      await vi.advanceTimersByTimeAsync(999);
+      expect(calls).toHaveLength(4);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(pending).resolves.toEqual(
+        statuses.map(() => ({ ok: true })),
+      );
+      expect(calls).toHaveLength(8);
+      expect(calls.every(({ init }) => init?.method === "GET")).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.useRealTimers();
+    }
+  });
+  it("does not retry forbidden responses and records them as read-only failures", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      return new Response("forbidden", { status: 403 });
+    }) as typeof fetch;
+    try {
+      await expect(
+        fetchJson("https://example.test/forbidden"),
+      ).rejects.toMatchObject({
+        status: 403,
+        attempts: 1,
+      });
+      expect(calls).toEqual(["https://example.test/forbidden"]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -24,6 +24,9 @@ const BOTS = new Set([
   "github-actions[bot]",
 ]);
 const MAX = 240;
+const repositoryPattern =
+  /^([A-Za-z0-9](?:[A-Za-z0-9-]{0,38})?)\/([A-Za-z0-9_.-]{1,100})$/;
+export const COMMIT_PULL_CONCURRENCY = 4;
 const clean = (value, fallback = "Unknown") =>
   String(value ?? "")
     .replace(/[\u0000-\u001f]/g, " ")
@@ -63,6 +66,17 @@ export const authorFor = (item) => {
 const version = (tag) => (/^v\d+\.\d+\.\d+$/.test(tag) ? tag : null);
 const compare = (a, b) =>
   String(a).localeCompare(String(b), "en", { numeric: true });
+
+export const validateRepository = (repository) => {
+  const match = repositoryPattern.exec(
+    typeof repository === "string" ? repository : "",
+  );
+  if (!match)
+    throw new Error(
+      "repository must contain only a safe GitHub owner/repo path",
+    );
+  return { owner: match[1], repo: match[2] };
+};
 
 const itemKey = (pr, commit) =>
   validNumber(pr?.number)
@@ -242,12 +256,23 @@ class GitHubError extends Error {
   }
 }
 const retryable = new Set([429, 500, 502, 503, 504]);
-const delayFor = (response, attempt) => {
-  const retryAfter = Number(response.headers.get("retry-after"));
-  return Number.isFinite(retryAfter)
-    ? Math.min(retryAfter * 1000, 30_000)
-    : 250 * 2 ** attempt;
+const BASE_RETRY_DELAY_MS = 250;
+const MAX_RETRY_DELAY_MS = 30_000;
+export const retryDelayMs = (retryAfterHeader, attempt) => {
+  const value =
+    typeof retryAfterHeader === "string" ? retryAfterHeader.trim() : "";
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    if (Number.isSafeInteger(seconds))
+      return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
+  }
+  return Math.min(
+    BASE_RETRY_DELAY_MS * 2 ** Math.max(0, attempt),
+    MAX_RETRY_DELAY_MS,
+  );
 };
+const delayFor = (response, attempt) =>
+  retryDelayMs(response.headers.get("retry-after"), attempt);
 export async function fetchJson(url, attempt = 0) {
   const response = await fetch(url, {
     method: "GET",
@@ -293,22 +318,74 @@ async function pages(url, errors, label) {
     }
   }
 }
+async function mapWithConcurrency(items, worker, limit) {
+  const results = new Array(items.length);
+  let next = 0;
+  const run = async () => {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await worker(items[index], index);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => run()),
+  );
+  return results;
+}
 export async function collect(repository, release) {
-  const base = `https://api.github.com/repos/${encodeURIComponent(repository)}`,
+  const { owner, repo } = validateRepository(repository);
+  const base = `https://api.github.com/repos/${owner}/${repo}`,
     errors = [];
   const releases = await pages(`${base}/releases`, errors, "releases");
   const tags = await pages(`${base}/tags`, errors, "tags");
   const commits = await pages(`${base}/commits`, errors, "commits");
   const prs = await pages(`${base}/pulls?state=closed`, errors, "pullRequests");
-  const associations = [];
-  for (const commit of commits) {
-    const found = await pages(
-      `${base}/commits/${encodeURIComponent(commit.sha)}/pulls`,
-      errors,
-      `commitPulls:${commit.sha}`,
-    );
-    associations.push({ sha: commit.sha, pullRequests: found });
+
+  // The paginated pull-request response already contains merge_commit_sha for
+  // the usual squash/merge cases. Only unresolved SHAs need the per-commit
+  // endpoint. Keep one promise per SHA so duplicate commit records never
+  // create duplicate requests.
+  const knownPullRequests = new Map();
+  for (const pr of prs) {
+    for (const sha of [
+      ...(pr.commits ?? pr.commitShas ?? []),
+      pr.merge_commit_sha,
+    ].filter(Boolean)) {
+      const existing = knownPullRequests.get(sha) ?? [];
+      existing.push(pr);
+      knownPullRequests.set(sha, existing);
+    }
   }
+  const commitPullCache = new Map();
+  const pullRequestsForCommit = (sha) => {
+    const known = knownPullRequests.get(sha);
+    if (known?.length) return Promise.resolve(known);
+    if (!commitPullCache.has(sha))
+      commitPullCache.set(
+        sha,
+        pages(
+          `${base}/commits/${encodeURIComponent(sha)}/pulls`,
+          errors,
+          `commitPulls:${sha}`,
+        ),
+      );
+    return commitPullCache.get(sha);
+  };
+  const associations = await mapWithConcurrency(
+    commits,
+    async (commit) => {
+      const sha = String(commit.sha ?? "");
+      if (!sha || /[\u0000-\u001f\u007f/\\]/.test(sha)) {
+        errors.push({
+          label: `commitPulls:${sha || "unknown"}`,
+          status: "invalid_sha",
+        });
+        return { sha, pullRequests: [] };
+      }
+      return { sha, pullRequests: await pullRequestsForCommit(sha) };
+    },
+    COMMIT_PULL_CONCURRENCY,
+  );
   const associated = associations.flatMap(
     (association) => association.pullRequests,
   );
@@ -371,6 +448,7 @@ const parseArgs = (argv) => {
 export async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv),
     repository = process.env.GITHUB_REPOSITORY ?? "ils15/open3dcalc";
+  validateRepository(repository);
   const catalog = normalize(
     options.input
       ? JSON.parse(await readFile(resolve(options.input), "utf8"))

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+/** Audited, read-only release notes generator.  It never calls a mutating API. */
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+
+export const CATEGORIES = [
+  "Highlights",
+  "Features",
+  "Improvements",
+  "Fixes",
+  "Security",
+  "CI/CD",
+  "Documentation",
+  "Dependencies",
+  "Breaking Changes",
+  "Other Changes",
+];
+const BOTS = new Set([
+  "github-actions",
+  "dependabot",
+  "renovate",
+  "dependabot[bot]",
+  "github-actions[bot]",
+]);
+const MAX = 240;
+const clean = (value, fallback = "Unknown") =>
+  String(value ?? "")
+    .replace(/[\u0000-\u001f]/g, " ")
+    .trim() || fallback;
+export const escapeMarkdown = (value) =>
+  clean(value, "Not available")
+    .replace(/([\\`*_{}\[\]()<>#+.!|])/g, "\\$1")
+    .slice(0, MAX);
+export const sha256 = (value) =>
+  createHash("sha256").update(JSON.stringify(value)).digest("hex");
+export const categoryFor = (item) => {
+  const text =
+    `${item.title ?? ""} ${item.body ?? ""} ${item.labels?.map((label) => label.name ?? label).join(" ") ?? ""}`.toLowerCase();
+  if (/breaking|!:|major change/.test(text)) return "Breaking Changes";
+  if (/security|cve|vulnerab|dependabot|renovate/.test(text))
+    return text.includes("depend") ? "Dependencies" : "Security";
+  if (/ci|workflow|github action|pipeline|build/.test(text)) return "CI/CD";
+  if (/doc|readme|typo/.test(text)) return "Documentation";
+  if (/fix|bug|patch|regression/.test(text)) return "Fixes";
+  if (/feature|add|support|implement/.test(text)) return "Features";
+  if (/improv|refactor|perf|enhanc/.test(text)) return "Improvements";
+  return "Other Changes";
+};
+const login = (person) => clean(person?.login ?? person?.name);
+export const authorFor = (item) => {
+  const candidates = [
+    item.pr?.merged_by,
+    item.pr?.user,
+    item.commit?.author,
+    item.author,
+  ];
+  for (const person of candidates) {
+    const name = login(person);
+    if (name !== "Unknown" && !BOTS.has(name.toLowerCase())) return name;
+  }
+  return "Unknown";
+};
+const version = (tag) => (/^v\d+\.\d+\.\d+$/.test(tag) ? tag : null);
+const compare = (a, b) =>
+  String(a).localeCompare(String(b), "en", { numeric: true });
+
+export const normalize = (input) => {
+  const releases = input.releases ?? [];
+  const tags = input.tags ?? [];
+  const commits = input.commits ?? [];
+  const prs = input.pullRequests ?? input.prs ?? [];
+  const assets =
+    input.assets ??
+    releases.flatMap((release) =>
+      (release.assets ?? []).map((asset) => ({
+        ...asset,
+        release: release.tag_name,
+      })),
+    );
+  const prBySha = new Map(
+    prs.flatMap((pr) =>
+      (pr.commits ?? pr.commitShas ?? []).map((sha) => [sha, pr]),
+    ),
+  );
+  const seen = new Set();
+  const items = [];
+  for (const commit of commits) {
+    const pr = commit.pullRequest ?? prBySha.get(commit.sha);
+    const key = pr?.number ? `pr:${pr.number}` : `commit:${commit.sha}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const item = {
+      key,
+      sha: clean(commit.sha),
+      title: clean(pr?.title ?? commit.message),
+      body: clean(pr?.body, ""),
+      pr,
+      commit,
+      category: categoryFor({ ...commit, ...pr }),
+      author: authorFor({ pr, commit }),
+    };
+    items.push(item);
+  }
+  for (const pr of prs.filter((pr) => pr.merged !== false)) {
+    const key = `pr:${pr.number}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      items.push({
+        key,
+        sha: clean(pr.merge_commit_sha),
+        title: clean(pr.title),
+        body: clean(pr.body, ""),
+        pr,
+        category: categoryFor(pr),
+        author: authorFor({ pr }),
+      });
+    }
+  }
+  items.sort(
+    (a, b) =>
+      compare(a.category, b.category) ||
+      compare(a.title, b.title) ||
+      compare(a.key, b.key),
+  );
+  return {
+    releases: releases
+      .map((release) => ({
+        tag: clean(release.tag_name),
+        id: release.id ?? null,
+        target: clean(release.target_commitish),
+        assets: (release.assets ?? []).map((asset) => ({
+          name: clean(asset.name),
+          digest: asset.digest ?? "Not available",
+          url: clean(asset.browser_download_url, "Not available"),
+        })),
+      }))
+      .sort((a, b) => compare(a.tag, b.tag)),
+    tags: tags.map((tag) => clean(tag.name ?? tag)).sort(compare),
+    items,
+    assets: assets
+      .map((asset) => ({
+        name: clean(asset.name),
+        digest: asset.digest ?? "Not available",
+        release: clean(asset.release, "Not available"),
+      }))
+      .sort((a, b) => compare(a.name, b.name)),
+    generatedAt: "deterministic",
+  };
+};
+
+export const render = (catalog, repository = "repository") => {
+  const tick = String.fromCharCode(96);
+  const lines = [
+    "# Release notes",
+    "",
+    `Audited release inventory for ${tick}${escapeMarkdown(repository)}${tick}.`,
+    "",
+  ];
+  for (const category of CATEGORIES) {
+    const entries = catalog.items.filter((item) => item.category === category);
+    if (!entries.length) continue;
+    lines.push(`## ${category}`, "");
+    for (const item of entries)
+      lines.push(
+        `- ${escapeMarkdown(item.title)} ([${escapeMarkdown(item.author)}](https://github.com/${encodeURIComponent(item.author)}))${item.pr?.number ? ` — PR #${item.pr.number}` : ` — commit ${tick}${escapeMarkdown(item.sha)}${tick}`}`,
+      );
+    lines.push("");
+  }
+  lines.push(
+    "## Downloads",
+    "",
+    ...(catalog.assets.length
+      ? catalog.assets.map(
+          (asset) =>
+            `- ${escapeMarkdown(asset.name)} — ${escapeMarkdown(asset.digest)}`,
+        )
+      : ["- Not available"]),
+    "",
+    "## Checksums",
+    "",
+    "- SHA-256 values are recorded in the audit inventory; Not available when GitHub provides no digest.",
+    "",
+    "## Contributors",
+    "",
+    ...[...new Set(catalog.items.map((item) => item.author))]
+      .sort(compare)
+      .map((author) => `- ${escapeMarkdown(author)}`),
+    "",
+    "## Full Changelog",
+    "",
+    "- Generated from the audited tag, commit, pull request, and asset inventory.",
+    "",
+  );
+  return lines.join("\n");
+};
+
+async function fetchJson(url, attempt = 0) {
+  const response = await fetch(url, {
+    headers: {
+      accept: "application/vnd.github+json",
+      ...(process.env.GH_TOKEN
+        ? { authorization: `Bearer ${process.env.GH_TOKEN}` }
+        : {}),
+    },
+  });
+  if ([403, 429, 500, 502, 503, 504].includes(response.status) && attempt < 4) {
+    await new Promise((resolveDelay) =>
+      setTimeout(resolveDelay, 250 * 2 ** attempt),
+    );
+    return fetchJson(url, attempt + 1);
+  }
+  if (!response.ok)
+    throw new Error(`GitHub request failed with status ${response.status}`);
+  return response.json();
+}
+async function pages(url) {
+  const result = [];
+  for (let page = 1; ; page++) {
+    const data = await fetchJson(
+      `${url}${url.includes("?") ? "&" : "?"}per_page=100&page=${page}`,
+    );
+    result.push(...(Array.isArray(data) ? data : []));
+    if (!Array.isArray(data) || data.length < 100) return result;
+  }
+}
+export async function collect(repository, release) {
+  const base = `https://api.github.com/repos/${encodeURIComponent(repository)}`;
+  const [releases, tags, commits, prs] = await Promise.all([
+    pages(`${base}/releases`),
+    pages(`${base}/tags`),
+    pages(`${base}/commits`),
+    pages(`${base}/pulls?state=closed`),
+  ]).then((values) => values);
+  const selected = release
+    ? releases.filter((item) => item.tag_name === release)
+    : releases;
+  const assets = selected.flatMap((item) => item.assets ?? []);
+  return normalize({
+    releases: selected,
+    tags,
+    commits,
+    pullRequests: prs,
+    assets,
+  });
+}
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const value = (name) => {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+};
+export async function main(argv = args) {
+  if (argv.includes("--write"))
+    throw new Error(
+      "--write is intentionally disabled in this PR; mutable backfill will be implemented in a separate workflow after approval.",
+    );
+  const inputPath = value("--input");
+  const output = resolve(value("--output") ?? "release-notes-output");
+  const repository = process.env.GITHUB_REPOSITORY ?? "ils15/open3dcalc";
+  const release = value("--release");
+  if (release && !version(release))
+    throw new Error("--release must be a tag in vX.Y.Z format");
+  const catalog = normalize(
+    inputPath
+      ? JSON.parse(await readFile(resolve(inputPath), "utf8"))
+      : await collect(repository, release),
+  );
+  const audit = {
+    schema: 1,
+    repository,
+    release: release ?? "all",
+    inputSha256: sha256(catalog),
+    outputSha256: sha256(render(catalog, repository)),
+    catalog,
+  };
+  await mkdir(output, { recursive: true });
+  await writeFile(
+    resolve(output, "inventory.json"),
+    `${JSON.stringify(catalog, null, 2)}\n`,
+  );
+  await writeFile(
+    resolve(output, "audit.json"),
+    `${JSON.stringify(audit, null, 2)}\n`,
+  );
+  if (!flag("--audit-only")) {
+    const markdown = render(catalog, repository);
+    await writeFile(resolve(output, "release-notes.md"), `${markdown}\n`);
+    await writeFile(
+      resolve(output, "release-notes.diff"),
+      `--- generated\n+++ audited\n@@\n+${markdown.split("\n").join("\n+")}\n`,
+    );
+  }
+  return audit;
+}
+if (import.meta.url === `file://${process.argv[1]}`)
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -248,8 +248,9 @@ const delayFor = (response, attempt) => {
     ? Math.min(retryAfter * 1000, 30_000)
     : 250 * 2 ** attempt;
 };
-async function fetchJson(url, attempt = 0) {
+export async function fetchJson(url, attempt = 0) {
   const response = await fetch(url, {
+    method: "GET",
     headers: {
       accept: "application/vnd.github+json",
       ...(process.env.GH_TOKEN

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-/** Audited, read-only release notes generator.  It never calls a mutating API. */
+/** Deterministic, read-only release notes generator. */
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { basename, resolve } from "node:path";
+import { resolve } from "node:path";
 
 export const CATEGORIES = [
   "Highlights",
@@ -27,16 +27,20 @@ const MAX = 240;
 const clean = (value, fallback = "Unknown") =>
   String(value ?? "")
     .replace(/[\u0000-\u001f]/g, " ")
-    .trim() || fallback;
+    .trim()
+    .slice(0, MAX) || fallback;
+const validNumber = (value) => Number.isInteger(value) && value > 0;
+const isBot = (person) => {
+  const login = String(person?.login ?? "").toLowerCase();
+  return person?.type === "Bot" || login.endsWith("[bot]") || BOTS.has(login);
+};
 export const escapeMarkdown = (value) =>
-  clean(value, "Not available")
-    .replace(/([\\`*_{}\[\]()<>#+.!|])/g, "\\$1")
-    .slice(0, MAX);
+  clean(value, "Not available").replace(/([\\`*_{}\[\]()<>#+.!|])/g, "\\$1");
 export const sha256 = (value) =>
   createHash("sha256").update(JSON.stringify(value)).digest("hex");
 export const categoryFor = (item) => {
   const text =
-    `${item.title ?? ""} ${item.body ?? ""} ${item.labels?.map((label) => label.name ?? label).join(" ") ?? ""}`.toLowerCase();
+    `${item.title ?? ""} ${item.body ?? ""} ${(item.labels ?? []).map((label) => label.name ?? label).join(" ")}`.toLowerCase();
   if (/breaking|!:|major change/.test(text)) return "Breaking Changes";
   if (/security|cve|vulnerab|dependabot|renovate/.test(text))
     return text.includes("depend") ? "Dependencies" : "Security";
@@ -47,29 +51,34 @@ export const categoryFor = (item) => {
   if (/improv|refactor|perf|enhanc/.test(text)) return "Improvements";
   return "Other Changes";
 };
-const login = (person) => clean(person?.login ?? person?.name);
+const personLogin = (person) => clean(person?.login ?? person?.name);
 export const authorFor = (item) => {
-  const candidates = [
-    item.pr?.merged_by,
-    item.pr?.user,
-    item.commit?.author,
-    item.author,
-  ];
-  for (const person of candidates) {
-    const name = login(person);
-    if (name !== "Unknown" && !BOTS.has(name.toLowerCase())) return name;
-  }
-  return "Unknown";
+  const prAuthor = item.pr?.user;
+  if (prAuthor) return isBot(prAuthor) ? "Unknown" : personLogin(prAuthor);
+  const commitAuthor = item.commit?.author ?? item.author;
+  return commitAuthor && !isBot(commitAuthor)
+    ? personLogin(commitAuthor)
+    : "Unknown";
 };
 const version = (tag) => (/^v\d+\.\d+\.\d+$/.test(tag) ? tag : null);
 const compare = (a, b) =>
   String(a).localeCompare(String(b), "en", { numeric: true });
 
+const itemKey = (pr, commit) =>
+  validNumber(pr?.number)
+    ? `pr:${pr.number}`
+    : commit?.sha
+      ? `commit:${commit.sha}`
+      : null;
 export const normalize = (input) => {
-  const releases = input.releases ?? [];
-  const tags = input.tags ?? [];
-  const commits = input.commits ?? [];
-  const prs = input.pullRequests ?? input.prs ?? [];
+  const releases = input.releases ?? [],
+    tags = input.tags ?? [],
+    commits = input.commits ?? [],
+    prs = [
+      ...(input.pullRequests ?? input.prs ?? []),
+      ...(input.associatedPullRequests ?? []),
+    ];
+  const errors = input.errors ?? [];
   const assets =
     input.assets ??
     releases.flatMap((release) =>
@@ -78,52 +87,69 @@ export const normalize = (input) => {
         release: release.tag_name,
       })),
     );
-  const prBySha = new Map(
-    prs.flatMap((pr) =>
-      (pr.commits ?? pr.commitShas ?? []).map((sha) => [sha, pr]),
-    ),
-  );
-  const seen = new Set();
-  const items = [];
-  for (const commit of commits) {
-    const pr = commit.pullRequest ?? prBySha.get(commit.sha);
-    const key = pr?.number ? `pr:${pr.number}` : `commit:${commit.sha}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
+  const prBySha = new Map();
+  for (const pr of prs)
+    for (const sha of [
+      ...(pr.commits ?? pr.commitShas ?? []),
+      pr.merge_commit_sha,
+    ].filter(Boolean)) {
+      const existing = prBySha.get(sha);
+      if (!existing || (pr.merged === true && existing.merged !== true))
+        prBySha.set(sha, pr);
+    }
+  for (const association of input.commitPullRequests ?? [])
+    for (const pr of association.pullRequests ?? []) {
+      for (const sha of [association.sha, pr.merge_commit_sha].filter(
+        Boolean,
+      )) {
+        const existing = prBySha.get(sha);
+        if (!existing || (pr.merged === true && existing.merged !== true))
+          prBySha.set(sha, pr);
+      }
+    }
+  const seen = new Map();
+  const aliases = new Map();
+  const add = (commit, pr) => {
+    if (pr && !validNumber(pr.number)) pr = undefined;
+    const key = itemKey(pr, commit);
+    if (!key) return;
+    const identityKeys = [
+      key,
+      validNumber(pr?.number) ? `pr:${pr.number}` : null,
+      pr?.merge_commit_sha ? `commit:${pr.merge_commit_sha}` : null,
+      commit?.sha ? `commit:${commit.sha}` : null,
+    ].filter(Boolean);
+    const existingKey = identityKeys
+      .map((identity) => aliases.get(identity))
+      .find(Boolean);
+    const current = existingKey ? seen.get(existingKey) : undefined;
+    if (current && !(pr?.merged === true && !current.pr?.merged)) return;
     const item = {
       key,
-      sha: clean(commit.sha),
-      title: clean(pr?.title ?? commit.message),
+      sha: clean(commit?.sha ?? pr?.merge_commit_sha),
+      title: clean(pr?.title ?? commit?.message),
       body: clean(pr?.body, ""),
       pr,
       commit,
       category: categoryFor({ ...commit, ...pr }),
       author: authorFor({ pr, commit }),
     };
-    items.push(item);
-  }
-  for (const pr of prs.filter((pr) => pr.merged !== false)) {
-    const key = `pr:${pr.number}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      items.push({
-        key,
-        sha: clean(pr.merge_commit_sha),
-        title: clean(pr.title),
-        body: clean(pr.body, ""),
-        pr,
-        category: categoryFor(pr),
-        author: authorFor({ pr }),
-      });
-    }
-  }
-  items.sort(
+    if (existingKey && existingKey !== key) seen.delete(existingKey);
+    seen.set(key, item);
+    for (const identity of identityKeys) aliases.set(identity, key);
+  };
+  for (const commit of commits) add(commit, prBySha.get(commit.sha));
+  for (const pr of prs.filter((candidate) => candidate.merged !== false))
+    add(undefined, pr);
+  const items = [...seen.values()].sort(
     (a, b) =>
       compare(a.category, b.category) ||
       compare(a.title, b.title) ||
       compare(a.key, b.key),
   );
   return {
+    partial: Boolean(input.partial || errors.length),
+    errors,
     releases: releases
       .map((release) => ({
         tag: clean(release.tag_name),
@@ -157,14 +183,26 @@ export const render = (catalog, repository = "repository") => {
     `Audited release inventory for ${tick}${escapeMarkdown(repository)}${tick}.`,
     "",
   ];
+  if (catalog.partial)
+    lines.push(
+      "> **Partial collection:** some GitHub responses failed; see the audit inventory for evidence.",
+      "",
+    );
   for (const category of CATEGORIES) {
     const entries = catalog.items.filter((item) => item.category === category);
     if (!entries.length) continue;
     lines.push(`## ${category}`, "");
-    for (const item of entries)
-      lines.push(
-        `- ${escapeMarkdown(item.title)} ([${escapeMarkdown(item.author)}](https://github.com/${encodeURIComponent(item.author)}))${item.pr?.number ? ` — PR #${item.pr.number}` : ` — commit ${tick}${escapeMarkdown(item.sha)}${tick}`}`,
-      );
+    for (const item of entries) {
+      const prNumber = validNumber(item.pr?.number);
+      const suffix = prNumber
+        ? ` — PR #${item.pr.number}`
+        : ` — commit ${tick}${escapeMarkdown(item.sha)}${tick}`;
+      const author =
+        item.author === "Unknown"
+          ? "Unknown"
+          : `[${escapeMarkdown(item.author)}](https://github.com/${encodeURIComponent(item.author)})`;
+      lines.push(`- ${escapeMarkdown(item.title)} (${author})${suffix}`);
+    }
     lines.push("");
   }
   lines.push(
@@ -195,6 +233,21 @@ export const render = (catalog, repository = "repository") => {
   return lines.join("\n");
 };
 
+class GitHubError extends Error {
+  constructor(url, status, attempts) {
+    super(`GitHub request failed with status ${status}`);
+    this.url = url;
+    this.status = status;
+    this.attempts = attempts;
+  }
+}
+const retryable = new Set([429, 500, 502, 503, 504]);
+const delayFor = (response, attempt) => {
+  const retryAfter = Number(response.headers.get("retry-after"));
+  return Number.isFinite(retryAfter)
+    ? Math.min(retryAfter * 1000, 30_000)
+    : 250 * 2 ** attempt;
+};
 async function fetchJson(url, attempt = 0) {
   const response = await fetch(url, {
     headers: {
@@ -204,91 +257,152 @@ async function fetchJson(url, attempt = 0) {
         : {}),
     },
   });
-  if ([403, 429, 500, 502, 503, 504].includes(response.status) && attempt < 4) {
+  if (retryable.has(response.status) && attempt < 4) {
     await new Promise((resolveDelay) =>
-      setTimeout(resolveDelay, 250 * 2 ** attempt),
+      setTimeout(resolveDelay, delayFor(response, attempt)),
     );
     return fetchJson(url, attempt + 1);
   }
-  if (!response.ok)
-    throw new Error(`GitHub request failed with status ${response.status}`);
+  if (response.status === 404) throw new GitHubError(url, 404, attempt + 1);
+  if (!response.ok) throw new GitHubError(url, response.status, attempt + 1);
   return response.json();
 }
-async function pages(url) {
+async function pages(url, errors, label) {
   const result = [];
   for (let page = 1; ; page++) {
-    const data = await fetchJson(
-      `${url}${url.includes("?") ? "&" : "?"}per_page=100&page=${page}`,
-    );
-    result.push(...(Array.isArray(data) ? data : []));
-    if (!Array.isArray(data) || data.length < 100) return result;
+    try {
+      const data = await fetchJson(
+        `${url}${url.includes("?") ? "&" : "?"}per_page=100&page=${page}`,
+      );
+      if (!Array.isArray(data)) {
+        errors.push({ label, page, status: "invalid_payload" });
+        return result;
+      }
+      result.push(...data);
+      if (data.length < 100) return result;
+    } catch (error) {
+      errors.push({
+        label,
+        page,
+        status: error.status ?? "network",
+        attempts: error.attempts ?? 1,
+        message: error.message,
+      });
+      return result;
+    }
   }
 }
 export async function collect(repository, release) {
-  const base = `https://api.github.com/repos/${encodeURIComponent(repository)}`;
-  const [releases, tags, commits, prs] = await Promise.all([
-    pages(`${base}/releases`),
-    pages(`${base}/tags`),
-    pages(`${base}/commits`),
-    pages(`${base}/pulls?state=closed`),
-  ]).then((values) => values);
+  const base = `https://api.github.com/repos/${encodeURIComponent(repository)}`,
+    errors = [];
+  const releases = await pages(`${base}/releases`, errors, "releases");
+  const tags = await pages(`${base}/tags`, errors, "tags");
+  const commits = await pages(`${base}/commits`, errors, "commits");
+  const prs = await pages(`${base}/pulls?state=closed`, errors, "pullRequests");
+  const associations = [];
+  for (const commit of commits) {
+    const found = await pages(
+      `${base}/commits/${encodeURIComponent(commit.sha)}/pulls`,
+      errors,
+      `commitPulls:${commit.sha}`,
+    );
+    associations.push({ sha: commit.sha, pullRequests: found });
+  }
+  const associated = associations.flatMap(
+    (association) => association.pullRequests,
+  );
+  const allPrs = [...prs, ...associated];
   const selected = release
     ? releases.filter((item) => item.tag_name === release)
     : releases;
-  const assets = selected.flatMap((item) => item.assets ?? []);
   return normalize({
     releases: selected,
     tags,
     commits,
-    pullRequests: prs,
-    assets,
+    pullRequests: allPrs,
+    commitPullRequests: associations,
+    assets: selected.flatMap((item) => item.assets ?? []),
+    errors,
+    partial: errors.length > 0,
   });
 }
-const args = process.argv.slice(2);
-const flag = (name) => args.includes(name);
-const value = (name) => {
-  const index = args.indexOf(name);
-  return index >= 0 ? args[index + 1] : undefined;
-};
-export async function main(argv = args) {
+
+const usage =
+  "Usage: node scripts/release-notes.mjs (--release vX.Y.Z | --all) [--dry-run] [--audit-only] [--input file] [--output dir]";
+const parseArgs = (argv) => {
+  const allowed = new Set([
+    "--dry-run",
+    "--audit-only",
+    "--all",
+    "--write",
+    "--release",
+    "--input",
+    "--output",
+  ]);
+  for (const arg of argv)
+    if (arg.startsWith("--") && !allowed.has(arg))
+      throw new Error(`Unknown flag: ${arg}\n${usage}`);
+  const value = (name) => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : undefined;
+  };
   if (argv.includes("--write"))
     throw new Error(
-      "--write is intentionally disabled in this PR; mutable backfill will be implemented in a separate workflow after approval.",
+      "--write is intentionally disabled; this tool never mutates GitHub.",
     );
-  const inputPath = value("--input");
-  const output = resolve(value("--output") ?? "release-notes-output");
-  const repository = process.env.GITHUB_REPOSITORY ?? "ils15/open3dcalc";
   const release = value("--release");
   if (release && !version(release))
     throw new Error("--release must be a tag in vX.Y.Z format");
+  if (!release && !argv.includes("--all"))
+    throw new Error(`${usage}\nA release tag or --all is required.`);
+  for (const name of ["--release", "--input", "--output"])
+    if (argv.includes(name) && (!value(name) || value(name).startsWith("--")))
+      throw new Error(`${name} requires a value`);
+  return {
+    release,
+    all: argv.includes("--all"),
+    dryRun: argv.includes("--dry-run"),
+    auditOnly: argv.includes("--audit-only"),
+    input: value("--input"),
+    output: resolve(value("--output") ?? "release-notes-output"),
+  };
+};
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv),
+    repository = process.env.GITHUB_REPOSITORY ?? "ils15/open3dcalc";
   const catalog = normalize(
-    inputPath
-      ? JSON.parse(await readFile(resolve(inputPath), "utf8"))
-      : await collect(repository, release),
+    options.input
+      ? JSON.parse(await readFile(resolve(options.input), "utf8"))
+      : await collect(repository, options.release),
   );
   const audit = {
-    schema: 1,
+    schema: 2,
     repository,
-    release: release ?? "all",
+    release: options.release ?? "all",
+    dryRun: options.dryRun,
+    partial: catalog.partial,
     inputSha256: sha256(catalog),
     outputSha256: sha256(render(catalog, repository)),
     catalog,
   };
-  await mkdir(output, { recursive: true });
+  await mkdir(options.output, { recursive: true });
   await writeFile(
-    resolve(output, "inventory.json"),
+    resolve(options.output, "inventory.json"),
     `${JSON.stringify(catalog, null, 2)}\n`,
   );
   await writeFile(
-    resolve(output, "audit.json"),
+    resolve(options.output, "audit.json"),
     `${JSON.stringify(audit, null, 2)}\n`,
   );
-  if (!flag("--audit-only")) {
+  if (!options.auditOnly) {
     const markdown = render(catalog, repository);
-    await writeFile(resolve(output, "release-notes.md"), `${markdown}\n`);
     await writeFile(
-      resolve(output, "release-notes.diff"),
-      `--- generated\n+++ audited\n@@\n+${markdown.split("\n").join("\n+")}\n`,
+      resolve(options.output, "release-notes.md"),
+      `${markdown}\n`,
+    );
+    await writeFile(
+      resolve(options.output, "release-notes.diff"),
+      `--- generated\n+++ audited\n@@\n+${markdown.split("\n").join("\n+\n")}`,
     );
   }
   return audit;


### PR DESCRIPTION
## What
Adds a deterministic, read-only release notes generator for English notes (OrcaSlicer-style), with audited dry-run. No GitHub mutation: only GET requests; `--write` is blocked.

## Artifacts generated
- `inventory.json` — releases/tags/commits/PRs/authors evidence
- `audit.json` — audit log with partial-failure evidence
- `release-notes.md` — generated English template (Highlights, Features, Fixes, Security, CI/CD, Docs, Dependencies, Breaking Changes, Other, Downloads, Checksums, Contributors, Full Changelog)
- `release-notes.diff` — diff vs current body

## Safety
- Workflow `release-notes-backfill.yml` is read-only (`contents: read`, `pull-requests: read`)
- Tag input validated by strict regex via env; no shell interpolation
- Retry-After fallback with cap; 4 retries max
- Cache/concurrency to avoid N+1 on commit PR lookups
- Authorship: PR author > commit author; bots -> Unknown; no invented attribution
- Backfill write/apply deferred to future human-approved phase

## Validation
- 717 tests passing
- Lint, typecheck, Prettier, YAML, node --check, offline dry-run passed
- Generator coverage: 97.32% lines
- No release/tag/asset modified
- Themis APPROVED

## Docs
- `docs/release-notes.md`
- Coverage baseline report (instructive; global thresholds unchanged)
