### PR TITLE
fix(release): scope notes per tag range with root commit and hardened URLs

### DIFF
--- a/scripts/__tests__/release-notes.test.ts
+++ b/scripts/__tests__/release-notes.test.ts
@@ -101,11 +101,16 @@ describe("audited release notes", () => {
     expect(catalog.items.filter((item) => item.key === "pr:11")).toHaveLength(
       1,
     );
+    // Categories sort lexicographically; the raw docs commit is now classified
+    // as Documentation (P3) instead of Other Changes, so it leads the list.
     expect(catalog.items.map((item) => item.key)).toEqual([
+      "commit:ccc333",
       "pr:10",
       "pr:11",
-      "commit:ccc333",
     ]);
+    expect(
+      catalog.items.find((item) => item.key === "commit:ccc333")?.category,
+    ).toBe("Documentation");
     expect(catalog.tags).toContain("v1.8.1-no-release");
   });
   it("renders the English contract and escapes hostile text", async () => {
@@ -505,5 +510,243 @@ describe("audited release notes", () => {
     await expect(main(["--all", "--output"])).rejects.toThrow(
       "requires a value",
     );
+  });
+  it("classifies Conventional Commit prefixes from raw commit messages", () => {
+    // P3: raw commits carry the title in commit.message, not in title.
+    expect(categoryFor({ commit: { message: "feat: add calculator" } })).toBe(
+      "Features",
+    );
+    expect(categoryFor({ commit: { message: "fix: crash on load" } })).toBe(
+      "Fixes",
+    );
+    expect(categoryFor({ commit: { message: "docs: README" } })).toBe(
+      "Documentation",
+    );
+    expect(categoryFor({ commit: { message: "perf: cache results" } })).toBe(
+      "Improvements",
+    );
+    expect(categoryFor({ commit: { message: "refactor: split module" } })).toBe(
+      "Improvements",
+    );
+    expect(categoryFor({ commit: { message: "ci: run checks" } })).toBe(
+      "CI/CD",
+    );
+    expect(categoryFor({ commit: { message: "deps: bump vite" } })).toBe(
+      "Dependencies",
+    );
+    expect(categoryFor({ commit: { message: "chore(deps): bump x" } })).toBe(
+      "Dependencies",
+    );
+    expect(categoryFor({ commit: { message: "build(deps): bump y" } })).toBe(
+      "Dependencies",
+    );
+    expect(
+      categoryFor({ commit: { message: "chore(release): cut v1.9.2" } }),
+    ).toBe("CI/CD");
+    expect(
+      categoryFor({ commit: { message: "fix(api)!: breaking change" } }),
+    ).toBe("Breaking Changes");
+    expect(categoryFor({ commit: { message: "feat!: breaking api" } })).toBe(
+      "Breaking Changes",
+    );
+    // Conventional prefixes win over generic keywords in the body/title.
+    expect(categoryFor({ title: "feat: fix calculator" })).toBe("Features");
+  });
+  it("never routes calculator/calculadora to CI/CD", () => {
+    // P4: /ci/ matched "calculator" — anchored \bci\b must not.
+    expect(categoryFor({ title: "calculator" })).not.toBe("CI/CD");
+    expect(categoryFor({ title: "calculadora de materiais" })).not.toBe(
+      "CI/CD",
+    );
+    expect(categoryFor({ title: "add calculator support" })).not.toBe("CI/CD");
+    expect(categoryFor({ title: "ci: build pipeline" })).toBe("CI/CD");
+    expect(categoryFor({ title: "workflow: publish" })).toBe("CI/CD");
+    expect(categoryFor({ title: "build: package" })).toBe("CI/CD");
+  });
+  it("scopes --release catalogs to the previous...tag range only", async () => {
+    const originalFetch = globalThis.fetch;
+    const oldestSha = "c000";
+    const compareV150 = "aaa111";
+    const compareV192 = "bbb222";
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes("/releases"))
+        return Response.json([
+          {
+            tag_name: "v1.5.0",
+            target_commitish: "aaa111",
+            assets: [{ name: "Open3DCalc-1.5.0.exe" }],
+          },
+          {
+            tag_name: "v1.9.2",
+            target_commitish: "bbb222",
+            assets: [{ name: "latest.yml" }],
+          },
+        ]);
+      if (url.includes("/tags"))
+        return Response.json([
+          { name: "v1.5.0", commit: { sha: "aaa111" } },
+          { name: "v1.9.2", commit: { sha: "bbb222" } },
+        ]);
+      if (url.includes("/commits/") && url.includes("/pulls"))
+        return Response.json([]);
+      if (url.includes("/compare/")) {
+        if (url.includes("v1.5.0...v1.9.2"))
+          return Response.json({
+            status: "ahead",
+            commits: [
+              {
+                sha: compareV192,
+                commit: { message: "feat: v1.9.2 feature" },
+              },
+            ],
+          });
+        if (url.includes(`${oldestSha}...${compareV150}`))
+          return Response.json({
+            status: "ahead",
+            commits: [
+              {
+                sha: compareV150,
+                commit: { message: "feat: v1.5.0 feature" },
+              },
+            ],
+          });
+        return Response.json({ status: "equal", commits: [] });
+      }
+      if (url.includes("/commits"))
+        return Response.json([
+          {
+            sha: "bbb222",
+            commit: { message: "feat: v1.9.2 feature" },
+          },
+          { sha: "aaa111", commit: { message: "feat: v1.5.0 feature" } },
+          { sha: "c000", commit: { message: "chore: init" } },
+        ]);
+      if (url.includes("/pulls"))
+        return Response.json([
+          {
+            number: 20,
+            title: "feat: v1.5.0 feature",
+            merged: true,
+            merge_commit_sha: "aaa111",
+            user: { login: "alice" },
+          },
+          {
+            number: 30,
+            title: "feat: v1.9.2 feature",
+            merged: true,
+            merge_commit_sha: "bbb222",
+            user: { login: "bob" },
+          },
+        ]);
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      const v192 = await collect("owner/repo", "v1.9.2");
+      expect(v192.partial).toBe(false);
+      expect(v192.items.map((item) => item.pr?.number)).toEqual([30]);
+      expect(v192.items.map((item) => item.title)).not.toContain(
+        "feat: v1.5.0 feature",
+      );
+      expect(v192.releases.map((release) => release.tag)).toEqual(["v1.9.2"]);
+      expect(v192.assets.map((asset) => asset.name)).toEqual(["latest.yml"]);
+      expect(v192.range).toEqual({ release: "v1.9.2", previous: "v1.5.0" });
+      expect(v192.items.map((item) => item.category)).toEqual(["Features"]);
+
+      const v150 = await collect("owner/repo", "v1.5.0");
+      expect(v150.items.map((item) => item.pr?.number)).toEqual([20]);
+      expect(v150.items.map((item) => item.title)).not.toContain(
+        "feat: v1.9.2 feature",
+      );
+      expect(v150.releases.map((release) => release.tag)).toEqual(["v1.5.0"]);
+      expect(v150.assets.map((asset) => asset.name)).toEqual([
+        "Open3DCalc-1.5.0.exe",
+      ]);
+      expect(v150.range).toEqual({ release: "v1.5.0", previous: null });
+
+      // Determinism: repeated collection yields identical catalogs.
+      expect(JSON.stringify(v192)).toBe(
+        JSON.stringify(await collect("owner/repo", "v1.9.2")),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("renders real Full Changelog compare links per release range", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes("/releases"))
+        return Response.json([
+          { tag_name: "v1.5.0", target_commitish: "aaa111", assets: [] },
+          { tag_name: "v1.9.2", target_commitish: "bbb222", assets: [] },
+        ]);
+      if (url.includes("/tags"))
+        return Response.json([
+          { name: "v1.5.0", commit: { sha: "aaa111" } },
+          { name: "v1.9.2", commit: { sha: "bbb222" } },
+        ]);
+      if (url.includes("/commits/") && url.includes("/pulls"))
+        return Response.json([]);
+      if (url.includes("/compare/"))
+        return Response.json({ status: "ahead", commits: [] });
+      if (url.includes("/commits"))
+        return Response.json([
+          { sha: "bbb222", commit: { message: "feat: x" } },
+          { sha: "aaa111", commit: { message: "feat: y" } },
+        ]);
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      const v192 = await collect("owner/repo", "v1.9.2");
+      const markdown = render(v192, "ils15/open3dcalc");
+      expect(markdown).toContain(
+        "[Full Changelog](https://github.com/ils15/open3dcalc/compare/v1.5.0...v1.9.2)",
+      );
+      const v150 = await collect("owner/repo", "v1.5.0");
+      expect(render(v150, "ils15/open3dcalc")).toContain(
+        "[Full Changelog](https://github.com/ils15/open3dcalc/commits/v1.5.0)",
+      );
+      // --input catalogs can carry the range metadata directly.
+      const data = await fixture();
+      expect(
+        render(
+          normalize({
+            ...data,
+            range: { release: "v1.9.2", previous: "v1.5.0" },
+          }),
+          "ils15/open3dcalc",
+        ),
+      ).toContain(
+        "[Full Changelog](https://github.com/ils15/open3dcalc/compare/v1.5.0...v1.9.2)",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("renders deterministic Highlights from Features and keeps Features non-empty", async () => {
+    const catalog = normalize({
+      releases: [{ tag_name: "v1.0.0", assets: [] }],
+      tags: [{ name: "v1.0.0" }],
+      commits: [
+        {
+          sha: "aaa",
+          message: "feat: flagship feature",
+          author: { login: "alice" },
+        },
+        { sha: "bbb", message: "fix: crash", author: { login: "bob" } },
+      ],
+      pullRequests: [
+        {
+          number: 1,
+          title: "feat: flagship feature",
+          merged: true,
+          merge_commit_sha: "aaa",
+          user: { login: "alice" },
+        },
+      ],
+    });
+    const markdown = render(catalog, "ils15/open3dcalc");
+    expect(markdown).toContain("## Highlights");
+    expect(markdown).toContain("## Features");
+    expect(markdown).toContain("feat: flagship feature");
   });
 });

--- a/scripts/__tests__/release-notes.test.ts
+++ b/scripts/__tests__/release-notes.test.ts
@@ -653,7 +653,19 @@ describe("audited release notes", () => {
       expect(v192.items.map((item) => item.category)).toEqual(["Features"]);
 
       const v150 = await collect("owner/repo", "v1.5.0");
-      expect(v150.items.map((item) => item.pr?.number)).toEqual([20]);
+      // The first release must include every commit up to the tag: the
+      // compare API excludes its base (the default-branch root), so the
+      // root commit is prepended back onto the scoped commit list and ends
+      // up as a commit-only item (no PR association).
+      expect(v150.items.map((item) => item.pr?.number)).toEqual([
+        20,
+        undefined,
+      ]);
+      expect(v150.items.map((item) => item.title)).toEqual([
+        "feat: v1.5.0 feature",
+        "chore: init",
+      ]);
+      expect(v150.items.some((item) => item.sha === oldestSha)).toBe(true);
       expect(v150.items.map((item) => item.title)).not.toContain(
         "feat: v1.9.2 feature",
       );
@@ -699,11 +711,11 @@ describe("audited release notes", () => {
       const v192 = await collect("owner/repo", "v1.9.2");
       const markdown = render(v192, "ils15/open3dcalc");
       expect(markdown).toContain(
-        "[Full Changelog](https://github.com/ils15/open3dcalc/compare/v1.5.0...v1.9.2)",
+        "[Full Changelog](https://github.com/ils15/open3dcalc/compare/v1\\.5\\.0...v1\\.9\\.2)",
       );
       const v150 = await collect("owner/repo", "v1.5.0");
       expect(render(v150, "ils15/open3dcalc")).toContain(
-        "[Full Changelog](https://github.com/ils15/open3dcalc/commits/v1.5.0)",
+        "[Full Changelog](https://github.com/ils15/open3dcalc/commits/v1\\.5\\.0)",
       );
       // --input catalogs can carry the range metadata directly.
       const data = await fixture();
@@ -716,7 +728,7 @@ describe("audited release notes", () => {
           "ils15/open3dcalc",
         ),
       ).toContain(
-        "[Full Changelog](https://github.com/ils15/open3dcalc/compare/v1.5.0...v1.9.2)",
+        "[Full Changelog](https://github.com/ils15/open3dcalc/compare/v1\\.5\\.0...v1\\.9\\.2)",
       );
     } finally {
       globalThis.fetch = originalFetch;
@@ -748,5 +760,101 @@ describe("audited release notes", () => {
     expect(markdown).toContain("## Highlights");
     expect(markdown).toContain("## Features");
     expect(markdown).toContain("feat: flagship feature");
+  });
+  it("includes the default-branch root commit when the first release compare excludes its base", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes("/releases"))
+        return Response.json([
+          { tag_name: "v1.0.0", target_commitish: "aaa111", assets: [] },
+        ]);
+      if (url.includes("/tags"))
+        return Response.json([{ name: "v1.0.0", commit: { sha: "aaa111" } }]);
+      if (url.includes("/commits/") && url.includes("/pulls"))
+        return Response.json([]);
+      if (url.includes("/compare/"))
+        // The compare payload deliberately excludes the base (root) commit,
+        // exactly like the GitHub compare API does for oldest...tag ranges.
+        return Response.json({
+          status: "ahead",
+          commits: [
+            { sha: "aaa111", commit: { message: "feat: first release" } },
+          ],
+        });
+      if (url.includes("/commits"))
+        return Response.json([
+          { sha: "aaa111", commit: { message: "feat: first release" } },
+          { sha: "root000", commit: { message: "chore: init" } },
+        ]);
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      const catalog = await collect("owner/repo", "v1.0.0");
+      // The root commit surfaces as a commit-only item even though the
+      // compare payload excluded it from its own commits[] response.
+      expect(catalog.items.map((item) => item.sha)).toEqual(
+        expect.arrayContaining(["root000", "aaa111"]),
+      );
+      expect(catalog.items.map((item) => item.title)).toContain("chore: init");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("keeps the tag's own commit as a valid commit object when it is also the oldest commit", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes("/releases"))
+        return Response.json([
+          { tag_name: "v1.0.0", target_commitish: "root000", assets: [] },
+        ]);
+      if (url.includes("/tags"))
+        return Response.json([{ name: "v1.0.0", commit: { sha: "root000" } }]);
+      if (url.includes("/commits/") && url.includes("/pulls"))
+        return Response.json([]);
+      if (url.includes("/commits"))
+        return Response.json([
+          { sha: "root000", commit: { message: "feat: root release" } },
+        ]);
+      return Response.json([]);
+    }) as typeof fetch;
+    try {
+      const catalog = await collect("owner/repo", "v1.0.0");
+      // The single-commit edge case keeps a valid commit object so the item
+      // survives normalize() instead of being silently discarded.
+      expect(catalog.items).toHaveLength(1);
+      expect(catalog.items[0]?.sha).toBe("root000");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("escapes hostile range and repository values in Full Changelog links", () => {
+    const catalog = normalize({
+      releases: [{ tag_name: 'v1.0.0">x', assets: [] }],
+      tags: [{ name: 'v1.0.0">x' }],
+      commits: [],
+      range: { release: 'v1.0.0">x', previous: null },
+    });
+    const markdown = render(catalog, "ils15/open3dcalc");
+    expect(markdown).toContain("[Full Changelog]");
+    // The hostile value must never appear raw inside the link destination.
+    expect(markdown).not.toContain('v1.0.0">x');
+    expect(markdown).not.toContain('">');
+    // A trailing `)` would close the parens-form link destination early;
+    // the same escaping that protects the `">x` payload keeps it intact.
+    const paren = render(
+      normalize({
+        releases: [{ tag_name: "v1.0.0)", assets: [] }],
+        tags: [{ name: "v1.0.0)" }],
+        commits: [],
+        range: { release: "v1.0.0)", previous: null },
+      }),
+      "ils15/open3dcalc",
+    );
+    expect(paren).toContain("commits/v1\\.0\\.0\\)");
+    // The repository interpolation is escaped too, so a hostile repo can
+    // not close the link or inject a second Markdown link.
+    expect(render(catalog, "ils15/open3dcalc)")).toContain(
+      "https://github.com/ils15/open3dcalc\\)/commits/",
+    );
   });
 });

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -41,13 +41,41 @@ export const escapeMarkdown = (value) =>
   clean(value, "Not available").replace(/([\\`*_{}\[\]()<>#+.!|])/g, "\\$1");
 export const sha256 = (value) =>
   createHash("sha256").update(JSON.stringify(value)).digest("hex");
+const CONVENTIONAL_PREFIXES = {
+  feat: "Features",
+  fix: "Fixes",
+  perf: "Improvements",
+  refactor: "Improvements",
+  style: "Improvements",
+  docs: "Documentation",
+  ci: "CI/CD",
+  build: "CI/CD",
+  deps: "Dependencies",
+};
+const HIGHLIGHT_LIMIT = 3;
 export const categoryFor = (item) => {
+  // Raw commit payloads carry the title in commit.message (or a flat message),
+  // not in title — normalize before classifying so Conventional Commit
+  // prefixes win over generic keyword scanning (e.g. "feat: fix calculator"
+  // must be Features, and "calculator" must never match /\bci\b/).
+  const title = clean(
+    item?.title ?? item?.message ?? item?.commit?.message ?? item?.pr?.title,
+  );
   const text =
-    `${item.title ?? ""} ${item.body ?? ""} ${(item.labels ?? []).map((label) => label.name ?? label).join(" ")}`.toLowerCase();
+    `${title} ${item?.body ?? ""} ${(item?.labels ?? []).map((label) => label.name ?? label).join(" ")}`.toLowerCase();
+  const conventional = /^([a-z]+)(?:\(([^)]*)\))?(!)?:/.exec(text);
+  if (conventional) {
+    const [, prefix, scope, bang] = conventional;
+    if (bang) return "Breaking Changes";
+    if (scope && /deps?/.test(scope)) return "Dependencies";
+    if (CONVENTIONAL_PREFIXES[prefix]) return CONVENTIONAL_PREFIXES[prefix];
+    if (prefix === "chore" && /^chore\(release\)/.test(text)) return "CI/CD";
+  }
   if (/breaking|!:|major change/.test(text)) return "Breaking Changes";
   if (/security|cve|vulnerab|dependabot|renovate/.test(text))
     return text.includes("depend") ? "Dependencies" : "Security";
-  if (/ci|workflow|github action|pipeline|build/.test(text)) return "CI/CD";
+  // Anchored \bci\b so "calculator"/"calculadora" never land in CI/CD.
+  if (/\bci\b|workflow|github action|pipeline|build/.test(text)) return "CI/CD";
   if (/doc|readme|typo/.test(text)) return "Documentation";
   if (/fix|bug|patch|regression/.test(text)) return "Fixes";
   if (/feature|add|support|implement/.test(text)) return "Features";
@@ -66,6 +94,47 @@ export const authorFor = (item) => {
 const version = (tag) => (/^v\d+\.\d+\.\d+$/.test(tag) ? tag : null);
 const compare = (a, b) =>
   String(a).localeCompare(String(b), "en", { numeric: true });
+const semverOf = (tag) => {
+  const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(String(tag ?? ""));
+  return match
+    ? {
+        tag: String(tag),
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+      }
+    : null;
+};
+const semverCompare = (a, b) =>
+  a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+// Highest SemVer tag strictly older than `release`, or null for the first one.
+const previousReleaseFor = (tags, release) => {
+  const target = semverOf(release);
+  if (!target) return null;
+  const older = tags
+    .map((tag) => semverOf(tag.name ?? tag))
+    .filter((candidate) => candidate && semverCompare(candidate, target) < 0)
+    .sort((a, b) => semverCompare(b, a));
+  return older[0]?.tag ?? null;
+};
+// The /commits list is newest-first, so its last entry is the oldest
+// commit reachable from the default branch; the first tagged release is
+// compared from that commit so every commit up to the tag is included.
+const changelogEntry = (repository, range, releases) => {
+  const repositoryUrl = `https://github.com/${repository}`;
+  if (range?.release) {
+    const target = encodeURIComponent(range.release);
+    return range.previous
+      ? `[Full Changelog](${repositoryUrl}/compare/${encodeURIComponent(range.previous)}...${target})`
+      : `[Full Changelog](${repositoryUrl}/commits/${target})`;
+  }
+  const versionedTags = (releases ?? [])
+    .map((release) => release.tag)
+    .filter((tag) => version(tag));
+  return versionedTags.length >= 2
+    ? `[Full Changelog](${repositoryUrl}/compare/${encodeURIComponent(versionedTags[0])}...${encodeURIComponent(versionedTags[versionedTags.length - 1])})`
+    : "- Generated from the audited tag, commit, pull request, and asset inventory.";
+};
 
 export const validateRepository = (repository) => {
   const match = repositoryPattern.exec(
@@ -138,14 +207,17 @@ export const normalize = (input) => {
       .find(Boolean);
     const current = existingKey ? seen.get(existingKey) : undefined;
     if (current && !(pr?.merged === true && !current.pr?.merged)) return;
+    const title = clean(
+      pr?.title ?? commit?.message ?? commit?.commit?.message,
+    );
     const item = {
       key,
       sha: clean(commit?.sha ?? pr?.merge_commit_sha),
-      title: clean(pr?.title ?? commit?.message ?? commit?.commit?.message),
+      title,
       body: clean(pr?.body, ""),
       pr,
       commit,
-      category: categoryFor({ ...commit, ...pr }),
+      category: categoryFor({ ...commit, ...pr, title }),
       author: authorFor({ pr, commit }),
     };
     if (existingKey && existingKey !== key) seen.delete(existingKey);
@@ -186,6 +258,7 @@ export const normalize = (input) => {
       }))
       .sort((a, b) => compare(a.name, b.name)),
     generatedAt: "deterministic",
+    range: input.range ?? null,
   };
 };
 
@@ -203,7 +276,14 @@ export const render = (catalog, repository = "repository") => {
       "",
     );
   for (const category of CATEGORIES) {
-    const entries = catalog.items.filter((item) => item.category === category);
+    let entries = catalog.items.filter((item) => item.category === category);
+    if (category === "Highlights" && !entries.length) {
+      // Deterministic highlights: the first Features entries in canonical
+      // item order, so the section never stays empty when Features items exist.
+      entries = catalog.items
+        .filter((item) => item.category === "Features")
+        .slice(0, HIGHLIGHT_LIMIT);
+    }
     if (!entries.length) continue;
     lines.push(`## ${category}`, "");
     for (const item of entries) {
@@ -241,7 +321,7 @@ export const render = (catalog, repository = "repository") => {
     "",
     "## Full Changelog",
     "",
-    "- Generated from the audited tag, commit, pull request, and asset inventory.",
+    changelogEntry(repository, catalog.range, catalog.releases),
     "",
   );
   return lines.join("\n");
@@ -332,6 +412,103 @@ async function mapWithConcurrency(items, worker, limit) {
   );
   return results;
 }
+// compare/<base>...<head> returns { status, ahead_by, behind_by, commits }.
+// The commits[] list is paginated with per_page/page; guard against API
+// layers that ignore pagination and would echo the same first page forever.
+async function fetchCompareCommits(base, baseRef, headRef, errors) {
+  const label = `compare:${baseRef}...${headRef}`;
+  const commits = [];
+  let firstShaOfPreviousPage = null;
+  for (let page = 1; ; page++) {
+    try {
+      const data = await fetchJson(
+        `${base}/compare/${encodeURIComponent(baseRef)}...${encodeURIComponent(headRef)}?per_page=100&page=${page}`,
+      );
+      if (!Array.isArray(data?.commits)) {
+        errors.push({ label, page, status: "invalid_payload" });
+        return { commits, ok: false };
+      }
+      if (
+        data.commits.length &&
+        data.commits[0]?.sha === firstShaOfPreviousPage
+      ) {
+        // Pagination ignored by the server: the same page repeats. Stop
+        // before duplicating entries instead of looping forever.
+        return { commits, ok: true };
+      }
+      if (data.commits.length) firstShaOfPreviousPage = data.commits[0]?.sha;
+      commits.push(...data.commits);
+      if (data.commits.length < 100) return { commits, ok: true };
+    } catch (error) {
+      errors.push({
+        label,
+        page,
+        status: error.status ?? "network",
+        attempts: error.attempts ?? 1,
+        message: error.message,
+      });
+      return { commits, ok: false };
+    }
+  }
+}
+// Narrow the catalog to the commits introduced by `release`:
+// - previous SemVer tag: compare/<previous>...<tag> (exact range);
+// - first tagged release: compare/<oldest known commit>...<tag sha> (every
+//   commit up to the tag, including the tag's own commit; the GitHub compare
+//   API rejects the empty-tree base, so the oldest default-branch commit is
+//   used instead);
+// - compare unavailable: fall back to the full commit list and record the
+//   failure so the rendered notes stay clearly "Partial collection".
+async function scopeForRelease({
+  base,
+  errors,
+  release,
+  releases,
+  tags,
+  commits,
+}) {
+  const previous = previousReleaseFor(tags, release);
+  if (previous) {
+    const range = await fetchCompareCommits(base, previous, release, errors);
+    return {
+      commits: range.ok ? range.commits : commits,
+      range: { release, previous },
+    };
+  }
+  const tag = tags.find(
+    (candidate) => (candidate.name ?? candidate) === release,
+  );
+  const targetRelease = releases.find(
+    (candidate) => candidate.tag_name === release,
+  );
+  const head = tag?.commit?.sha ?? targetRelease?.target_commitish;
+  // The /commits list is newest-first, so its last entry is the oldest
+  // commit reachable from the default branch.
+  const oldest = commits[commits.length - 1]?.sha;
+  if (head && oldest) {
+    if (oldest === head) {
+      // Single-commit edge case: the tag IS the oldest commit, so a compare
+      // against itself would return zero commits; keep the tag's own commit.
+      return { commits: [head], range: { release, previous: null } };
+    }
+    const range = await fetchCompareCommits(base, oldest, head, errors);
+    return {
+      commits: range.ok ? range.commits : commits,
+      range: { release, previous: null },
+    };
+  }
+  return { commits, range: { release, previous: null } };
+}
+const dedupePullRequests = (list) => {
+  const unique = new Map();
+  for (const pr of list) {
+    const key = validNumber(pr?.number)
+      ? `pr:${pr.number}`
+      : (pr?.id ?? pr?.merge_commit_sha ?? JSON.stringify(pr));
+    if (!unique.has(key)) unique.set(key, pr);
+  }
+  return [...unique.values()];
+};
 export async function collect(repository, release) {
   const { owner, repo } = validateRepository(repository);
   const base = `https://api.github.com/repos/${owner}/${repo}`,
@@ -340,6 +517,12 @@ export async function collect(repository, release) {
   const tags = await pages(`${base}/tags`, errors, "tags");
   const commits = await pages(`${base}/commits`, errors, "commits");
   const prs = await pages(`${base}/pulls?state=closed`, errors, "pullRequests");
+
+  // Per-release catalogs scope commits to the previous...tag range; --all
+  // keeps the aggregated repository-wide inventory.
+  const scope = release
+    ? await scopeForRelease({ base, errors, release, releases, tags, commits })
+    : { commits, range: null };
 
   // The paginated pull-request response already contains merge_commit_sha for
   // the usual squash/merge cases. Only unresolved SHAs need the per-commit
@@ -372,7 +555,7 @@ export async function collect(repository, release) {
     return commitPullCache.get(sha);
   };
   const associations = await mapWithConcurrency(
-    commits,
+    scope.commits,
     async (commit) => {
       const sha = String(commit.sha ?? "");
       if (!sha || /[\u0000-\u001f\u007f/\\]/.test(sha)) {
@@ -389,19 +572,24 @@ export async function collect(repository, release) {
   const associated = associations.flatMap(
     (association) => association.pullRequests,
   );
-  const allPrs = [...prs, ...associated];
+  // Per-release catalogs must never include PRs from other releases: keep
+  // only PRs associated with scoped commits instead of the full closed list.
+  const allPrs = release
+    ? dedupePullRequests(associated)
+    : [...prs, ...associated];
   const selected = release
     ? releases.filter((item) => item.tag_name === release)
     : releases;
   return normalize({
     releases: selected,
     tags,
-    commits,
+    commits: scope.commits,
     pullRequests: allPrs,
     commitPullRequests: associations,
     assets: selected.flatMap((item) => item.assets ?? []),
     errors,
     partial: errors.length > 0,
+    range: scope.range,
   });
 }
 

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -121,18 +121,23 @@ const previousReleaseFor = (tags, release) => {
 // commit reachable from the default branch; the first tagged release is
 // compared from that commit so every commit up to the tag is included.
 const changelogEntry = (repository, range, releases) => {
-  const repositoryUrl = `https://github.com/${repository}`;
+  // The same escaping used across the render: URL components are
+  // encodeURIComponent'd first (neutralizing quotes/angles/whitespace) and
+  // then escapeMarkdown'd so the parens and brackets that
+  // encodeURIComponent leaves behind can never break or inject into the
+  // parens-form Markdown link destination.
+  const repositoryUrl = `https://github.com/${escapeMarkdown(repository)}`;
   if (range?.release) {
-    const target = encodeURIComponent(range.release);
+    const target = escapeMarkdown(encodeURIComponent(range.release));
     return range.previous
-      ? `[Full Changelog](${repositoryUrl}/compare/${encodeURIComponent(range.previous)}...${target})`
+      ? `[Full Changelog](${repositoryUrl}/compare/${escapeMarkdown(encodeURIComponent(range.previous))}...${target})`
       : `[Full Changelog](${repositoryUrl}/commits/${target})`;
   }
   const versionedTags = (releases ?? [])
     .map((release) => release.tag)
     .filter((tag) => version(tag));
   return versionedTags.length >= 2
-    ? `[Full Changelog](${repositoryUrl}/compare/${encodeURIComponent(versionedTags[0])}...${encodeURIComponent(versionedTags[versionedTags.length - 1])})`
+    ? `[Full Changelog](${repositoryUrl}/compare/${escapeMarkdown(encodeURIComponent(versionedTags[0]))}...${escapeMarkdown(encodeURIComponent(versionedTags[versionedTags.length - 1]))})`
     : "- Generated from the audited tag, commit, pull request, and asset inventory.";
 };
 
@@ -483,17 +488,29 @@ async function scopeForRelease({
   );
   const head = tag?.commit?.sha ?? targetRelease?.target_commitish;
   // The /commits list is newest-first, so its last entry is the oldest
-  // commit reachable from the default branch.
-  const oldest = commits[commits.length - 1]?.sha;
+  // commit reachable from the default branch (the root for the first
+  // tagged release).
+  const oldestCommit = commits[commits.length - 1];
+  const oldest = oldestCommit?.sha;
   if (head && oldest) {
     if (oldest === head) {
       // Single-commit edge case: the tag IS the oldest commit, so a compare
-      // against itself would return zero commits; keep the tag's own commit.
-      return { commits: [head], range: { release, previous: null } };
+      // against itself would return zero commits; keep the tag's own commit
+      // as a valid commit object so normalize() never drops it.
+      return { commits: [{ sha: head }], range: { release, previous: null } };
     }
     const range = await fetchCompareCommits(base, oldest, head, errors);
+    // The compare API excludes its base commit from the commits[] payload,
+    // so when the base is the default-branch root the first release would
+    // silently miss the root commit. Prepend it — unless the server already
+    // included it — so "all commits up to the tag, including the root" holds.
+    const scoped = range.ok
+      ? range.commits.some((commit) => commit?.sha === oldest)
+        ? range.commits
+        : [oldestCommit, ...range.commits]
+      : commits;
     return {
-      commits: range.ok ? range.commits : commits,
+      commits: scoped,
       range: { release, previous: null },
     };
   }


### PR DESCRIPTION
## What
Fixes the release notes generator so `--release vX.Y.Z` produces a scoped body per tag (OrcaSlicer-style) instead of an aggregated one.

- **Per-tag scoping** (`1d97030`): collect only commits/PRs in `previous...tag` via compare API (SemVer previous); first release includes all commits up to the tag.
- **Dynamic Full Changelog**: `compare/PREVIOUS...TAG` (or `commits/TAG` for the first release).
- **Commit-only categorization**: conventional commit prefixes (`feat:`, `fix:`, `docs:`, `ci:`, etc.) now map to the right English sections; `calculator` no longer matches CI/CD.
- **Root commit + hardening** (`37116e4`): first release includes the repo root commit `b8ea1e4`; `oldest===head` edge case preserves the item; changelog URLs escaped.

## Verification
- Dry-runs clean (`partial: false`, 0 errors): v1.5.0 → 67 scoped commits / 54 items; v1.9.2 → 13 items (all real PRs, no cross-release leaks)
- 727 tests passing; 5 regression tests RED→GREEN confirmed
- lint, typecheck, node --check, Prettier clean
- No release/tag/asset modified; no new dependencies
- Themis APPROVED (PASS_WITH_NOTES, non-blocking)
