### PR TITLE
feat(stlpreview): auto-fit camera, fullscreen overlay and clear model

### DIFF
--- a/src/shared/components/Calculator/sections/MaterialSection.tsx
+++ b/src/shared/components/Calculator/sections/MaterialSection.tsx
@@ -76,6 +76,29 @@ export function MaterialSection({
 		},
 		[store, isFDM],
 	)
+
+	const handleStlClear = useCallback(() => {
+		if (isFDM) {
+			store.setFdmPrintParams({
+				...store.fdmPrintParams,
+				printTimeHours: 0,
+			})
+			if (store.fdmAmsEnabled) {
+				const idx = store.fdmAmsSlots.findIndex((s) => s.enabled)
+				if (idx >= 0) {
+					const slot = { ...store.fdmAmsSlots[idx], weightUsedGrams: 0 }
+					store.setFdmAmsSlot(idx, slot)
+				}
+			} else {
+				store.setFdmMaterial({ ...store.fdmMaterial, weightUsed: 0 })
+			}
+		} else {
+			store.setResinPrintParams({
+				...store.resinPrintParams,
+				printTimeHours: 0,
+			})
+		}
+	}, [store, isFDM])
 	return (
 		<div className="surface rounded-xl p-4 sm:p-5">
 			{renderSectionHeader(
@@ -448,6 +471,7 @@ export function MaterialSection({
 					<div className="sm:col-span-2 mt-3">
 						<StlPreview
 							onFileParsed={handleStlParsed}
+							onClear={handleStlClear}
 							materialDensity={store.fdmMaterial.density}
 							infillPercent={store.infillPercent}
 						/>

--- a/src/shared/components/Calculator/sections/__tests__/MaterialSection.test.tsx
+++ b/src/shared/components/Calculator/sections/__tests__/MaterialSection.test.tsx
@@ -1,7 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MaterialSection } from '../MaterialSection'
 import type { CalculatorState } from '@/shared/stores/calculatorStore'
+
+// Mock StlPreview so tests can drive the onClear wiring without 3D setup
+vi.mock('@/shared/components/StlPreview/StlPreview', () => ({
+	StlPreview: ({
+		onClear,
+		onFileParsed,
+	}: {
+		onClear?: () => void
+		onFileParsed?: () => void
+	}) => (
+		<button type="button" data-testid="mock-stl-preview" onClick={onClear ?? onFileParsed}>
+			mock stl preview
+		</button>
+	),
+}))
 
 const createMockStore = (overrides: Partial<CalculatorState> = {}): CalculatorState =>
 	({
@@ -13,6 +28,16 @@ const createMockStore = (overrides: Partial<CalculatorState> = {}): CalculatorSt
 			density: 1.24,
 			spoolEfficiency: 95,
 		},
+		fdmPrintParams: {
+			printTimeHours: 5,
+			heatUpTimeMinutes: 10,
+		},
+		resinPrintParams: {
+			printTimeHours: 0,
+			heatUpTimeMinutes: 0,
+		},
+		setFdmPrintParams: vi.fn(),
+		setResinPrintParams: vi.fn(),
 		fdmAmsEnabled: false,
 	fdmAmsSlots: [
 		{
@@ -340,5 +365,35 @@ describe('MaterialSection', () => {
 		)
 		expect(missingKeyWarnings).toHaveLength(0)
 		consoleSpy.mockRestore()
+	})
+
+	it('onClear resets FDM print time and material weight', () => {
+		const store = createMockStore()
+		render(<MaterialSection {...defaultProps} store={store} isFDM={true} />)
+		fireEvent.click(screen.getByTestId('mock-stl-preview'))
+		expect(store.setFdmPrintParams).toHaveBeenCalledWith({
+			...store.fdmPrintParams,
+			printTimeHours: 0,
+		})
+		expect(store.setFdmMaterial).toHaveBeenCalledWith({
+			...store.fdmMaterial,
+			weightUsed: 0,
+		})
+	})
+
+	it('onClear resets the active AMS slot weight when AMS is enabled', () => {
+		const store = createMockStore({ fdmAmsEnabled: true })
+		render(<MaterialSection {...defaultProps} store={store} isFDM={true} />)
+		fireEvent.click(screen.getByTestId('mock-stl-preview'))
+		expect(store.setFdmPrintParams).toHaveBeenCalledWith({
+			...store.fdmPrintParams,
+			printTimeHours: 0,
+		})
+		// Only the enabled slot (index 0) is reset
+		expect(store.setFdmAmsSlot).toHaveBeenCalledWith(
+			0,
+			expect.objectContaining({ weightUsedGrams: 0 }),
+		)
+		expect(store.setFdmMaterial).not.toHaveBeenCalled()
 	})
 })

--- a/src/shared/components/StlPreview/StlPreview.tsx
+++ b/src/shared/components/StlPreview/StlPreview.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Canvas } from '@react-three/fiber'
-import { OrbitControls, Center } from '@react-three/drei'
-import { Upload, AlertCircle } from 'lucide-react'
+import { OrbitControls, Center, Bounds, useBounds } from '@react-three/drei'
+import type { BoundsApi } from '@react-three/drei'
+import { Upload, AlertCircle, Crosshair } from 'lucide-react'
 import type { BufferGeometry } from 'three'
 import type { MeshAnalysis } from '@/shared/lib/stlParser'
 import { estimatePrintTime } from '@/shared/lib/printTimeEstimator'
@@ -48,23 +49,72 @@ function Model({ geometry }: { geometry: BufferGeometry }) {
   )
 }
 
-function PreviewCanvas({ geometry }: { geometry: BufferGeometry }) {
+/**
+ * Bridges the drei `Bounds` context API (exposed via `useBounds`) to an
+ * external ref so toolbar buttons outside the Canvas can trigger `fit()`.
+ * drei 10.x does not forward a `ref` on <Bounds>, hence the bridge.
+ */
+function BoundsBridge({ apiRef }: { apiRef: React.MutableRefObject<BoundsApi | null> }) {
+  const bounds = useBounds()
+  useEffect(() => {
+    apiRef.current = bounds
+    return () => {
+      apiRef.current = null
+    }
+  }, [bounds, apiRef])
+  return null
+}
+
+const toolbarButtonClass =
+  'min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg ' +
+  'bg-[var(--color-bg-elevated)]/85 backdrop-blur-sm border border-[var(--color-border)]/60 ' +
+  'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] ' +
+  'hover:bg-[var(--color-bg-elevated)] transition-colors ' +
+  'focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none'
+
+interface PreviewCanvasProps {
+  geometry: BufferGeometry
+}
+
+function PreviewCanvas({ geometry }: PreviewCanvasProps) {
+  const { t } = useTranslation()
+  const boundsApi = useRef<BoundsApi | null>(null)
   return (
     <div className="relative w-full h-full group">
       <Canvas
-        camera={{ position: [5, 5, 5], fov: 45 }}
+        camera={{ position: [5, 5, 5], fov: 45, near: 0.01, far: 2000 }}
         key={geometry.uuid}
       >
         <ambientLight intensity={0.5} />
         <directionalLight position={[10, 10, 5]} intensity={0.8} />
         <directionalLight position={[-5, -5, -5]} intensity={0.3} />
-        <Model geometry={geometry} />
+        <Bounds fit clip margin={1.2}>
+          <Model geometry={geometry} />
+        </Bounds>
+        <BoundsBridge apiRef={boundsApi} />
         <OrbitControls
+          makeDefault
           enablePan
           enableZoom
-          autoRotate={false}
+          minDistance={0.5}
+          maxDistance={30}
+          minPolarAngle={0}
+          maxPolarAngle={Math.PI}
         />
       </Canvas>
+
+      {/* Toolbar overlay */}
+      <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => boundsApi.current?.fit()}
+          aria-label={t('stl.fit')}
+          title={t('stl.fit')}
+          className={toolbarButtonClass}
+        >
+          <Crosshair className="w-4 h-4" />
+        </button>
+      </div>
     </div>
   )
 }
@@ -76,7 +126,8 @@ function PreviewCanvas({ geometry }: { geometry: BufferGeometry }) {
  * it estimates weight using the provided `materialDensity` and
  * `infillPercent` props (or sensible defaults for PLA at 20% infill).
  * The Canvas remounts automatically when geometry changes (via `key` prop),
- * so camera reset happens implicitly without the need for a reset button.
+ * and the camera auto-fits to the model bounds on mount, with a fit button
+ * that re-frames the model from the current viewing angle.
  */
 export function StlPreview({
   onFileParsed,

--- a/src/shared/components/StlPreview/StlPreview.tsx
+++ b/src/shared/components/StlPreview/StlPreview.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Center, Bounds, useBounds } from '@react-three/drei'
 import type { BoundsApi } from '@react-three/drei'
-import { Upload, AlertCircle, Crosshair } from 'lucide-react'
+import { Upload, AlertCircle, Maximize2, X, Trash2, Crosshair } from 'lucide-react'
 import type { BufferGeometry } from 'three'
 import type { MeshAnalysis } from '@/shared/lib/stlParser'
 import { estimatePrintTime } from '@/shared/lib/printTimeEstimator'
@@ -28,6 +29,8 @@ interface StlPreviewProps {
   materialDensity?: number
   /** Calculator infill percentage. Default 20. */
   infillPercent?: number
+  /** Called when the user clears the loaded model from the viewer. */
+  onClear?: () => void
 }
 
 function Model({ geometry }: { geometry: BufferGeometry }) {
@@ -74,9 +77,20 @@ const toolbarButtonClass =
 
 interface PreviewCanvasProps {
   geometry: BufferGeometry
+  /** Rendered inside the fullscreen portal overlay */
+  isFullscreen?: boolean
+  /** Toggles fullscreen mode (null hides the button, e.g. inside fullscreen) */
+  onToggleFullscreen?: () => void
+  /** Clears the loaded model (null hides the button) */
+  onClear?: () => void
 }
 
-function PreviewCanvas({ geometry }: PreviewCanvasProps) {
+function PreviewCanvas({
+  geometry,
+  isFullscreen = false,
+  onToggleFullscreen,
+  onClear,
+}: PreviewCanvasProps) {
   const { t } = useTranslation()
   const boundsApi = useRef<BoundsApi | null>(null)
   return (
@@ -114,6 +128,28 @@ function PreviewCanvas({ geometry }: PreviewCanvasProps) {
         >
           <Crosshair className="w-4 h-4" />
         </button>
+        {onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            aria-label={t('stl.clear')}
+            title={t('stl.clear')}
+            className={toolbarButtonClass}
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
+        {onToggleFullscreen && (
+          <button
+            type="button"
+            onClick={onToggleFullscreen}
+            aria-label={isFullscreen ? t('stl.exitFullscreen') : t('stl.fullscreen')}
+            title={isFullscreen ? t('stl.exitFullscreen') : t('stl.fullscreen')}
+            className={toolbarButtonClass}
+          >
+            {isFullscreen ? <X className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+          </button>
+        )}
       </div>
     </div>
   )
@@ -126,8 +162,8 @@ function PreviewCanvas({ geometry }: PreviewCanvasProps) {
  * it estimates weight using the provided `materialDensity` and
  * `infillPercent` props (or sensible defaults for PLA at 20% infill).
  * The Canvas remounts automatically when geometry changes (via `key` prop),
- * and the camera auto-fits to the model bounds on mount, with a fit button
- * that re-frames the model from the current viewing angle.
+ * and the camera auto-fits to the model bounds on mount. Toolbar buttons
+ * offer fit-to-view, fullscreen and clear-model actions.
  */
 export function StlPreview({
   onFileParsed,
@@ -136,6 +172,7 @@ export function StlPreview({
   standalone = false,
   materialDensity,
   infillPercent,
+  onClear,
 }: StlPreviewProps) {
   const { t } = useTranslation()
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -144,6 +181,7 @@ export function StlPreview({
   const [parsing, setParsing] = useState(false)
   const [isDragOver, setIsDragOver] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
   const isTouchDevice = useMemo(
     () => typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0),
     [],
@@ -151,6 +189,25 @@ export function StlPreview({
 
   // initialGeometry is used as the initial state value above;
   // consumers that need to reset geometry should use a key prop on StlPreview
+
+  // Close the fullscreen overlay with the Escape key
+  useEffect(() => {
+    if (!isFullscreen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsFullscreen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isFullscreen])
+
+  const handleClear = useCallback(() => {
+    setGeometry(null)
+    setModelInfo(null)
+    setError(null)
+    setParsing(false)
+    setIsFullscreen(false)
+    onClear?.()
+  }, [onClear])
 
   const showError = useCallback(
     (message: string) => {
@@ -364,11 +421,36 @@ export function StlPreview({
       )}
 
       {/* 3D Preview */}
-      {geometry && (
+      {geometry && !isFullscreen && (
         <div className="surface rounded-xl overflow-hidden min-h-[300px] sm:min-h-[400px]">
-          <PreviewCanvas geometry={geometry} />
+          <PreviewCanvas
+            geometry={geometry}
+            onToggleFullscreen={() => setIsFullscreen(true)}
+            onClear={handleClear}
+          />
         </div>
       )}
+
+      {/* Fullscreen 3D Preview (portal overlay) */}
+      {isFullscreen &&
+        geometry &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[100] bg-black/90 p-3 sm:p-6"
+            role="dialog"
+            aria-modal="true"
+            aria-label={t('stl.fullscreen')}
+          >
+            <PreviewCanvas
+              geometry={geometry}
+              isFullscreen
+              onToggleFullscreen={() => setIsFullscreen(false)}
+              onClear={handleClear}
+            />
+          </div>,
+          document.body,
+        )}
 
       {/* Model Info Panel */}
       {modelInfo && (

--- a/src/shared/components/StlPreview/__tests__/StlPreview.test.tsx
+++ b/src/shared/components/StlPreview/__tests__/StlPreview.test.tsx
@@ -1,14 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { StlPreview } from '../StlPreview'
 
 // Mock R3F — Canvas doesn't work well in jsdom
 vi.mock('@react-three/fiber', () => ({
   Canvas: ({ children }: { children: React.ReactNode }) => <div data-testid="r3f-canvas">{children}</div>,
 }))
+
+// Expose the mocked Bounds API so tests can assert fit() is invoked
+const { mockBounds } = vi.hoisted(() => ({
+  mockBounds: {
+    fit: vi.fn(),
+    refresh: vi.fn(),
+    clip: vi.fn(),
+    reset: vi.fn(),
+    getSize: vi.fn(),
+  },
+}))
+
 vi.mock('@react-three/drei', () => ({
   OrbitControls: () => null,
   Center: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Bounds: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useBounds: () => mockBounds,
   MeshStandardMaterial: () => null,
   MeshBasicMaterial: () => null,
 }))
@@ -71,5 +86,17 @@ describe('StlPreview', () => {
     render(<StlPreview onFileParsed={mockOnFileParsed} />)
     const uploadButton = screen.getByRole('button', { name: /stl\./ })
     expect(uploadButton).toBeInTheDocument()
+  })
+
+  it('renders a fit button when geometry is present', () => {
+    render(<StlPreview initialGeometry={createMockGeometry()} onFileParsed={mockOnFileParsed} />)
+    expect(screen.getByRole('button', { name: 'stl.fit' })).toBeInTheDocument()
+  })
+
+  it('calls the bounds fit API when fit button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<StlPreview initialGeometry={createMockGeometry()} onFileParsed={mockOnFileParsed} />)
+    await user.click(screen.getByRole('button', { name: 'stl.fit' }))
+    expect(mockBounds.fit).toHaveBeenCalled()
   })
 })

--- a/src/shared/components/StlPreview/__tests__/StlPreview.test.tsx
+++ b/src/shared/components/StlPreview/__tests__/StlPreview.test.tsx
@@ -99,4 +99,65 @@ describe('StlPreview', () => {
     await user.click(screen.getByRole('button', { name: 'stl.fit' }))
     expect(mockBounds.fit).toHaveBeenCalled()
   })
+
+  it('shows a clear button when geometry is present', () => {
+    render(<StlPreview initialGeometry={createMockGeometry()} onFileParsed={mockOnFileParsed} />)
+    expect(screen.getByRole('button', { name: 'stl.clear' })).toBeInTheDocument()
+  })
+
+  it('clears the model and calls onClear', async () => {
+    const user = userEvent.setup()
+    const onClear = vi.fn()
+    render(
+      <StlPreview
+        initialGeometry={createMockGeometry()}
+        onFileParsed={mockOnFileParsed}
+        onClear={onClear}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: 'stl.clear' }))
+    expect(onClear).toHaveBeenCalledTimes(1)
+    // Canvas is removed and the upload zone comes back
+    expect(screen.queryByTestId('r3f-canvas')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /stl\./ })).toBeInTheDocument()
+  })
+
+  it('opens a fullscreen portal overlay and closes it', async () => {
+    const user = userEvent.setup()
+    render(<StlPreview initialGeometry={createMockGeometry()} onFileParsed={mockOnFileParsed} />)
+
+    await user.click(screen.getByRole('button', { name: 'stl.fullscreen' }))
+
+    // Portal overlay rendered into document.body with dialog semantics
+    const overlay = document.querySelector('.fixed.inset-0')
+    expect(overlay).not.toBeNull()
+    expect(overlay).toHaveAttribute('role', 'dialog')
+    expect(screen.getByRole('button', { name: 'stl.exitFullscreen' })).toBeInTheDocument()
+    // Inline preview hidden while fullscreen
+    expect(screen.queryByRole('button', { name: 'stl.fullscreen' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'stl.exitFullscreen' }))
+    expect(screen.queryByRole('button', { name: 'stl.exitFullscreen' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'stl.fullscreen' })).toBeInTheDocument()
+  })
+
+  it('exits fullscreen on Escape key', async () => {
+    const user = userEvent.setup()
+    render(<StlPreview initialGeometry={createMockGeometry()} onFileParsed={mockOnFileParsed} />)
+
+    await user.click(screen.getByRole('button', { name: 'stl.fullscreen' }))
+    expect(screen.getByRole('button', { name: 'stl.exitFullscreen' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('button', { name: 'stl.exitFullscreen' })).not.toBeInTheDocument()
+  })
+
+  it('keeps fit and clear buttons visible inside fullscreen overlay', async () => {
+    const user = userEvent.setup()
+    render(<StlPreview initialGeometry={createMockGeometry()} onFileParsed={mockOnFileParsed} />)
+
+    await user.click(screen.getByRole('button', { name: 'stl.fullscreen' }))
+    expect(screen.getByRole('button', { name: 'stl.fit' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'stl.clear' })).toBeInTheDocument()
+  })
 })

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -428,7 +428,8 @@
     "dropzone": "Drag your 3D file here",
     "dropActive": "Drop to analyze",
     "processing": "Processing...",
-    "tapToSelect": "Tap to select a file"
+    "tapToSelect": "Tap to select a file",
+    "fit": "Fit view"
   },
   "common": {
     "save": "Save",

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -429,6 +429,9 @@
     "dropActive": "Drop to analyze",
     "processing": "Processing...",
     "tapToSelect": "Tap to select a file",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "clear": "Clear model",
     "fit": "Fit view"
   },
   "common": {

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -429,6 +429,9 @@
     "dropActive": "Solte para analisar",
     "processing": "Processando...",
     "tapToSelect": "Toque para selecionar arquivo",
+    "fullscreen": "Tela cheia",
+    "exitFullscreen": "Sair da tela cheia",
+    "clear": "Limpar modelo",
     "fit": "Encaixar"
   },
   "common": {

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -428,7 +428,8 @@
     "dropzone": "Arraste seu arquivo 3D aqui",
     "dropActive": "Solte para analisar",
     "processing": "Processando...",
-    "tapToSelect": "Toque para selecionar arquivo"
+    "tapToSelect": "Toque para selecionar arquivo",
+    "fit": "Encaixar"
   },
   "common": {
     "save": "Salvar",


### PR DESCRIPTION
## What
Improvements to the 3D model preview (STL/OBJ/3MF/GCODE):

- **Auto-fit camera**: Bounds fit clip margin 1.2 + near 0.01, so models no longer get clipped regardless of size
- **Zoom limits**: OrbitControls makeDefault with min/maxDistance; fit button restores the view
- **Fullscreen**: in-app overlay via portal (role=dialog, aria-modal, Escape to close)
- **Clear model**: new onClear prop + Trash2 button; resets geometry, model info and calculator store (print time, weight, AMS slot)
- **i18n**: stl.fullscreen/exitFullscreen/clear/fit in pt-BR + en-US

## Verification
- 736 tests passing (StlPreview 13, MaterialSection 28)
- lint, typecheck clean; no formatting churn
- Themis APPROVED
- 6 files changed: StlPreview.tsx, MaterialSection.tsx, 2 test files, 2 locales