### PR TITLE
fix(layout): responsive calculator columns for complete mode

### DIFF
--- a/src/shared/components/Calculator/Calculator.tsx
+++ b/src/shared/components/Calculator/Calculator.tsx
@@ -79,9 +79,9 @@ export function Calculator() {
 		<>
 			<ToastContainer items={toastItems} onDismiss={dismissToast} />
 			<h1 className="sr-only">{t('nav.calculator')}</h1>
-			<div className="flex gap-5 xl:gap-8 pb-[72px] lg:pb-0">
+			<div className="flex gap-4 xl:gap-6 2xl:gap-8 pb-[72px] lg:pb-0">
 				<SectionNav activeSection={activeSection} onSectionClick={setActiveSection} />
-				<div className="flex-1 min-w-0 space-y-5">
+				<div className="flex-1 min-w-0 @container space-y-5">
 					<QuickStartBanner />
 						<div className="flex flex-wrap items-center gap-2 sm:gap-3 py-1">
 						<TechToggle />
@@ -101,7 +101,7 @@ export function Calculator() {
 						handlePrinterSelect={handlePrinterSelect}
 					/>
 				</div>
-				<div data-tutorial="results-sidebar" className="hidden lg:flex flex-col gap-5 w-[320px] xl:w-[360px] shrink-0 sticky top-[92px] self-start max-h-[calc(100vh-120px)] overflow-y-auto">
+				<div data-tutorial="results-sidebar" className="hidden xl:flex flex-col gap-5 w-[280px] xl:w-[320px] 2xl:w-[360px] shrink-0 sticky top-[92px] self-start max-h-[calc(100vh-120px)] overflow-y-auto">
 					<ResultsPanel variant="sidebar" />
 				</div>
 			</div>

--- a/src/shared/components/Calculator/SectionRenderer.tsx
+++ b/src/shared/components/Calculator/SectionRenderer.tsx
@@ -184,7 +184,7 @@ export function SectionRenderer(props: SectionRendererProps) {
 						);
 					case "results":
 						return (
-							<div key="results" id="section-results" data-tutorial="results" className="scroll-mt-24 lg:hidden">
+							<div key="results" id="section-results" data-tutorial="results" className="scroll-mt-24 xl:hidden">
 								<ResultsPanel variant="mobile" />
 							</div>
 						);

--- a/src/shared/components/Calculator/sections/FailureSection.tsx
+++ b/src/shared/components/Calculator/sections/FailureSection.tsx
@@ -71,7 +71,7 @@ export function FailureSection({
 				<div
 					className={`space-y-4 transition-all duration-300 ${failureEnabled ? "" : "opacity-40 pointer-events-none"}`}
 				>
-					<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 						<Select
 							label={t("calc.failure.mode")}
 							value={failureMode === "none" ? "percent" : failureMode}

--- a/src/shared/components/Calculator/sections/FixedCostsSection.tsx
+++ b/src/shared/components/Calculator/sections/FixedCostsSection.tsx
@@ -41,7 +41,7 @@ export function FixedCostsSection({
 				/>
 			</div>
 			{store.fixedCosts.enabled && (
-				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 					<InputGroup
 						label={t('calc.fixedCost.monthlyCost')}
 						value={store.fixedCosts.monthlyCost}

--- a/src/shared/components/Calculator/sections/HardwareSection.tsx
+++ b/src/shared/components/Calculator/sections/HardwareSection.tsx
@@ -30,7 +30,7 @@ export function HardwareSection() {
 			/>
 			{isFDM && (
 				<>
-					<div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+					<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 						<div className="space-y-4">
 							<div className="flex items-center justify-between border-b border-[var(--color-border)] pb-2">
 								<span className="text-xs font-semibold text-[var(--color-info)]">
@@ -253,7 +253,7 @@ export function HardwareSection() {
 								{t("calc.resinHardware")}
 							</span>
 						</div>
-						<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+						<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 							<InputGroup
 								label={t("calc.lcdCost")}
 								value={store.resinHardware.lcdCost}

--- a/src/shared/components/Calculator/sections/LaborSection.tsx
+++ b/src/shared/components/Calculator/sections/LaborSection.tsx
@@ -32,7 +32,7 @@ export function LaborSection({
 				t('calc.sectionDesc.labor'),
 				'labor',
 			)}
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 				<InputGroup
 					label={t('calc.setupTime')}
 					value={

--- a/src/shared/components/Calculator/sections/MachineSection.tsx
+++ b/src/shared/components/Calculator/sections/MachineSection.tsx
@@ -33,7 +33,7 @@ export function MachineSection({
 				t('calc.sectionDesc.machine'),
 				'machine',
 			)}
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 				<InputGroup
 					label={t('calc.machineCost')}
 					value={
@@ -106,7 +106,7 @@ export function MachineSection({
 					unit="h/mês"
 					tooltip={t('tooltip.hoursPerMonth')}
 				/>
-				<div className="sm:col-span-2 flex items-center justify-between surface rounded-xl p-4 sm:p-5">
+				<div className="@md:col-span-2 flex items-center justify-between surface rounded-xl p-4 sm:p-5">
 				<span className="text-xs text-[var(--color-text-secondary)]">
 					{t('calc.maintenance')}
 				</span>
@@ -132,7 +132,7 @@ export function MachineSection({
 				{(isFDM
 					? store.fdmMachine.maintenanceEnabled
 					: store.resinMachine.maintenanceEnabled) && (
-					<div className="sm:col-span-2">
+					<div className="@md:col-span-2">
 						<InputGroup
 							label={t('calc.maintenanceCost')}
 							value={

--- a/src/shared/components/Calculator/sections/MaterialSection.tsx
+++ b/src/shared/components/Calculator/sections/MaterialSection.tsx
@@ -224,7 +224,7 @@ export function MaterialSection({
 							))}
 						</div>
 					) : (
-						<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+						<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 							<Select
 								label={t("calc.filamentType")}
 								value={store.fdmMaterial.type}
@@ -445,7 +445,7 @@ export function MaterialSection({
 						)
 					})()}
 
-					<div className="sm:col-span-2 mt-3">
+					<div className="w-full min-w-0 @md:col-span-2 mt-3">
 						<StlPreview
 							onFileParsed={handleStlParsed}
 							materialDensity={store.fdmMaterial.density}
@@ -454,7 +454,7 @@ export function MaterialSection({
 					</div>
 				</>
 			) : (
-				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 					<Select
 						label={t("calc.resinType")}
 						value={store.resinMaterial.type}

--- a/src/shared/components/Calculator/sections/OpsSection.tsx
+++ b/src/shared/components/Calculator/sections/OpsSection.tsx
@@ -24,7 +24,7 @@ export function OpsSection() {
 				subtitle={t("calc.sectionDesc.ops")}
 				sectionId="ops"
 			/>
-			<div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 				<div>
 				<div className="flex items-center justify-between border-b border-[var(--color-border)] pb-2 mb-3">
 					<span className="text-xs font-semibold text-[var(--color-text-secondary)]">

--- a/src/shared/components/Calculator/sections/PrintSection.tsx
+++ b/src/shared/components/Calculator/sections/PrintSection.tsx
@@ -45,7 +45,7 @@ export function PrintSection({
 				t("calc.sectionDesc.print"),
 				"print",
 			)}
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 				<InputGroup
 					label={t("calc.printTime")}
 					value={
@@ -120,7 +120,7 @@ export function PrintSection({
 					tooltip={t('tooltip.energyCostPerKwh')}
 				/>
 				{isFDM && isFieldVisible("print", "selectedPrinter") && (
-					<div className="sm:col-span-2">
+					<div className="@md:col-span-2">
 						<Select
 							label={t("calc.printer")}
 							value={store.selectedPrinter.id}

--- a/src/shared/components/Calculator/sections/SalesSection.tsx
+++ b/src/shared/components/Calculator/sections/SalesSection.tsx
@@ -60,7 +60,7 @@ export function SalesSection() {
 				sectionId="sales"
 			/>
 			<div className="space-y-4">
-				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 					<InputGroup
 						label={t("calc.quantity")}
 						value={store.quantity}
@@ -104,7 +104,7 @@ export function SalesSection() {
 						tooltip={t("tooltip.extras")}
 					/>
 				)}
-				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 					<InputGroup
 						label={t("calc.packaging")}
 						value={
@@ -158,7 +158,7 @@ export function SalesSection() {
 				</div>
 				{isFieldVisible("sales", "marketplace") && (
 					<>
-						<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+						<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
 							<Select
 								label={t("calc.marketplace")}
 								value={store.selectedMarketplace.id}


### PR DESCRIPTION
## What
Visual polish for the calculator layout (fixes "complete mode overlapping the results sidebar" and STL preview misalignment):

- **Responsive columns**: results sidebar moves from lg to xl (hidden xl:flex), narrower widths (280/320/360), so the central column has room in Complete mode at 1024-1280px
- **Container queries**: central column becomes @container; 13 section grids converted from sm:/xl:grid-cols-2 to @md:*, collapsing to 1 column when space is tight
- **STL preview alignment**: wrapper w-full min-w-0 @md:col-span-2 aligned with material inputs
- **No results gap**: mobile results panel now xl:hidden, covering the 1024-1279 range where sidebar is hidden

## Verification
- 727 tests passing; lint, typecheck, build clean
- Container queries native in Tailwind v4 (verified in compiled CSS)
- Themis APPROVED
- 11 files changed, all under src/shared/components/Calculator/