### PR TITLE
feat(changelog): sync in-app changelog automatically on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,15 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "reused=false" >> "$GITHUB_OUTPUT"
 
+      - name: Sync in-app changelog
+        shell: bash
+        run: node scripts/sync-changelog.mjs --write
+
       - name: Validate changed release files
         shell: bash
         run: |
           set -euo pipefail
-          ALLOWED=$'package.json\npackage-lock.json\nCHANGELOG.md'
+          ALLOWED=$'package.json\npackage-lock.json\nCHANGELOG.md\nsrc/shared/i18n/locales/pt-BR.json\nsrc/shared/i18n/locales/en-US.json'
           while IFS= read -r file; do
             [ -z "$file" ] || grep -Fxq "$file" <<< "$ALLOWED" || {
               echo "Unexpected release change: $file" >&2
@@ -130,7 +134,7 @@ jobs:
             }
           done < <(git diff --name-only)
           if [ "${{ steps.version.outputs.reused }}" != "true" ]; then
-            git add package.json package-lock.json CHANGELOG.md
+            git add package.json package-lock.json CHANGELOG.md src/shared/i18n/locales/pt-BR.json src/shared/i18n/locales/en-US.json
             git diff --cached --check
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,4 +104,4 @@
 
 ---
 
-Para histórico completo anterior à v1.8.0, veja [web/CHANGELOG.md](web/CHANGELOG.md)
+Para histórico completo anterior à v1.8.0, veja as [releases no GitHub](https://github.com/ils15/open3dcalc/releases).

--- a/scripts/__fixtures__/changelog/CHANGELOG.md
+++ b/scripts/__fixtures__/changelog/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## v1.2.0
+
+[compare changes](https://github.com/example/open3dcalc/compare/v1.1.1...v1.2.0)
+
+### 🚀 Enhancements
+
+- **ui:** Add dark mode ([abc123](https://github.com/example/open3dcalc/commit/abc123))
+- **ci:** Ship release automation ([#12](https://github.com/example/open3dcalc/pull/12))
+
+### 🩹 Bug Fixes
+
+- **core:** Fix crash on startup ([def456](https://github.com/example/open3dcalc/commit/def456))
+
+### 🏡 Chore
+
+- Remove stale web/ copies ([ffc68bb](https://github.com/example/open3dcalc/commit/ffc68bb))
+
+### 🤖 CI
+
+- Add opencode github integration ([#13](https://github.com/example/open3dcalc/pull/13))
+
+### ❤️ Contributors
+
+- Ils15 ([@ils15](https://github.com/ils15))
+
+## v1.1.1
+
+[compare changes](https://github.com/example/open3dcalc/compare/v1.1.0...v1.1.1)
+
+## v1.1.0 — Big Refactor (2026-05-20)
+
+### 🎨 UI/UX
+
+- Redesign surfaces
+- Tema claro/escuro
+
+### 🔧 Técnico
+
+- Monorepo unificado (`src/shared/` + `src/platform/`)
+
+### ✅ Testes
+
+- 417 testes, 36/36 arquivos passando
+
+---
+
+Para histórico completo anterior à v1.1.0, veja [web/CHANGELOG.md](web/CHANGELOG.md)

--- a/scripts/__fixtures__/changelog/en-US.json
+++ b/scripts/__fixtures__/changelog/en-US.json
@@ -1,0 +1,36 @@
+{
+  "changelog": {
+    "header": "{{versions}} versions · {{changes}} changes",
+    "viewAllOnGitHub": "View all releases on GitHub",
+    "versions": [
+      {
+        "version": "1.2.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "🧪 Tests",
+            "items": ["**old** item replaced by CHANGELOG.md"]
+          }
+        ]
+      },
+      {
+        "version": "1.0.0",
+        "date": "2026-05-01",
+        "sections": [
+          {
+            "title": "✨ Release",
+            "items": ["first app release"]
+          }
+        ]
+      }
+    ]
+  },
+  "common": {
+    "appName": "Open3DCalc",
+    "tagline": "Free & Open-Source 3D Calculator"
+  },
+  "nav": {
+    "changelog": "Changelog",
+    "calculator": "Calculator"
+  }
+}

--- a/scripts/__fixtures__/changelog/pt-BR.json
+++ b/scripts/__fixtures__/changelog/pt-BR.json
@@ -1,0 +1,36 @@
+{
+  "changelog": {
+    "header": "{{versions}} versões · {{changes}} mudanças",
+    "viewAllOnGitHub": "Ver todas as releases no GitHub",
+    "versions": [
+      {
+        "version": "1.2.0",
+        "date": "2026-05-25",
+        "sections": [
+          {
+            "title": "🧪 Testes",
+            "items": ["**old** item que será substituído pelo CHANGELOG.md"]
+          }
+        ]
+      },
+      {
+        "version": "1.0.0",
+        "date": "2026-05-01",
+        "sections": [
+          {
+            "title": "✨ Lançamento",
+            "items": ["primeira versão do app"]
+          }
+        ]
+      }
+    ]
+  },
+  "common": {
+    "appName": "Open3DCalc",
+    "tagline": "Calculadora 3D Livre & Open-Source"
+  },
+  "nav": {
+    "changelog": "Novidades",
+    "calculator": "Calculadora"
+  }
+}

--- a/scripts/__tests__/sync-changelog.test.ts
+++ b/scripts/__tests__/sync-changelog.test.ts
@@ -1,0 +1,361 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildVersions,
+  cleanItem,
+  findVersionsArraySpan,
+  formatReport,
+  main,
+  parseArgs,
+  parseChangelog,
+  replaceVersionsArray,
+  sectionTitleFor,
+  semverDesc,
+} from "../sync-changelog.mjs";
+
+const FIXTURES = resolve("scripts/__fixtures__/changelog");
+const fixtureChangelog = () =>
+  readFile(resolve(FIXTURES, "CHANGELOG.md"), "utf8");
+const fixtureLocale = async (name) =>
+  JSON.parse(await readFile(resolve(FIXTURES, `${name}.json`), "utf8"));
+
+/** Materialize a temporary repo root mirroring the fixture layout. */
+const tempRoot = async (changelogOverrides = "") => {
+  const root = await mkdtemp(resolve(tmpdir(), "sync-changelog-"));
+  const changelog = changelogOverrides || (await fixtureChangelog());
+  await writeFile(resolve(root, "CHANGELOG.md"), changelog);
+  const locales = resolve(root, "src/shared/i18n/locales");
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(locales, { recursive: true });
+  await writeFile(
+    resolve(locales, "pt-BR.json"),
+    JSON.stringify(await fixtureLocale("pt-BR"), null, 2),
+  );
+  await writeFile(
+    resolve(locales, "en-US.json"),
+    JSON.stringify(await fixtureLocale("en-US"), null, 2),
+  );
+  return root;
+};
+
+describe("sync-changelog parsing", () => {
+  it("parses versions, inline dates and section categories from markdown", async () => {
+    const entries = parseChangelog(await fixtureChangelog());
+    expect(entries.map((entry) => entry.version)).toEqual([
+      "1.2.0",
+      "1.1.1",
+      "1.1.0",
+    ]);
+    expect(entries.map((entry) => entry.date)).toEqual(["", "", "2026-05-20"]);
+    const v120 = entries[0];
+    expect(v120.sections.map((section) => section.raw)).toEqual([
+      "🚀 Enhancements",
+      "🩹 Bug Fixes",
+      "🏡 Chore",
+      "🤖 CI",
+      "❤️ Contributors",
+    ]);
+    // Empty releases (only a compare link) yield an entry with no sections.
+    expect(entries[1].sections).toEqual([]);
+    // Custom headings (v1.1.0) are kept raw, emoji included.
+    expect(entries[2].sections.map((section) => section.raw)).toEqual([
+      "🎨 UI/UX",
+      "🔧 Técnico",
+      "✅ Testes",
+    ]);
+  });
+
+  it("cleans items: strips markdown links and emoji, keeps **bold** and `code`", () => {
+    expect(
+      cleanItem("**ui:** Add dark mode ([abc123](https://example.com/abc123))"),
+    ).toBe("**ui:** Add dark mode (abc123)");
+    expect(
+      cleanItem("Ship release automation ([#12](https://example.com/pull/12))"),
+    ).toBe("Ship release automation (#12)");
+    expect(
+      cleanItem("Monorepo unificado (`src/shared/` + `src/platform/`)"),
+    ).toBe("Monorepo unificado (`src/shared/` + `src/platform/`)");
+    expect(cleanItem("🚀 emoji leading item")).toBe("emoji leading item");
+    expect(cleanItem("  extra   whitespace  ")).toBe("extra whitespace");
+  });
+
+  it("classifies changelogen headings into canonical per-locale titles", () => {
+    expect(sectionTitleFor("pt", "🚀 Enhancements")).toBe("🚀 Novidades");
+    expect(sectionTitleFor("pt", "🩹 Bug Fixes")).toBe("🐛 Correções");
+    expect(sectionTitleFor("pt", "🏡 Chore")).toBe("🧹 Outros");
+    expect(sectionTitleFor("pt", "🤖 CI")).toBe("🤖 CI/CD");
+    expect(sectionTitleFor("pt", "📖 Documentation")).toBe("📖 Documentação");
+    expect(sectionTitleFor("pt", "❤️ Contributors")).toBe("❤️ Contribuidores");
+    expect(sectionTitleFor("en", "🚀 Enhancements")).toBe("🚀 Features");
+    expect(sectionTitleFor("en", "🩹 Bug Fixes")).toBe("🐛 Fixes");
+    expect(sectionTitleFor("en", "🏡 Chore")).toBe("🧹 Other");
+    expect(sectionTitleFor("en", "🤖 CI")).toBe("🤖 CI");
+    // Unmapped headings keep their original text.
+    expect(sectionTitleFor("en", "🎨 UI/UX")).toBe("🎨 UI/UX");
+    expect(sectionTitleFor("pt", "🔧 Técnico")).toBe("🔧 Técnico");
+  });
+});
+
+describe("sync-changelog generation", () => {
+  it("merges md-wins entries with preserved locale-only versions, semver desc", async () => {
+    const parsed = parseChangelog(await fixtureChangelog());
+    const existing = (await fixtureLocale("pt-BR")).changelog.versions;
+    const versions = buildVersions("pt", parsed, existing);
+    expect(versions.map((entry) => entry.version)).toEqual([
+      "1.2.0",
+      "1.1.1",
+      "1.1.0",
+      "1.0.0",
+    ]);
+    // CHANGELOG.md wins for 1.2.0 (replaces the handwritten 🧪 Testes entry)…
+    const v120 = versions[0];
+    expect(v120.date).toBe("2026-05-25"); // …but keeps the existing date.
+    expect(v120.sections.map((section) => section.title)).toEqual([
+      "🚀 Novidades",
+      "🐛 Correções",
+      "🧹 Outros",
+      "🤖 CI/CD",
+      "❤️ Contribuidores",
+    ]);
+    expect(v120.sections[0].items).toEqual([
+      "**ui:** Add dark mode (abc123)",
+      "**ci:** Ship release automation (#12)",
+    ]);
+    // Locale-only versions are preserved untouched.
+    expect(versions[3]).toEqual(existing[1]);
+  });
+
+  it("generates per-locale section titles with shared raw item text", async () => {
+    const parsed = parseChangelog(await fixtureChangelog());
+    const pt = buildVersions("pt", parsed, []);
+    const en = buildVersions("en", parsed, []);
+    const ptV120 = pt[0];
+    const enV120 = en[0];
+    expect(ptV120.sections.map((section) => section.title)).toEqual([
+      "🚀 Novidades",
+      "🐛 Correções",
+      "🧹 Outros",
+      "🤖 CI/CD",
+      "❤️ Contribuidores",
+    ]);
+    expect(enV120.sections.map((section) => section.title)).toEqual([
+      "🚀 Features",
+      "🐛 Fixes",
+      "🧹 Other",
+      "🤖 CI",
+      "❤️ Contributors",
+    ]);
+    // Items are the raw markdown text, identical across locales.
+    expect(ptV120.sections[0].items).toEqual(enV120.sections[0].items);
+    // Custom v1.1.0 headings stay raw in both locales; inline date preserved.
+    const ptV110 = pt.find((entry) => entry.version === "1.1.0");
+    expect(ptV110.date).toBe("2026-05-20");
+    expect(ptV110.sections.map((section) => section.title)).toEqual([
+      "🎨 UI/UX",
+      "🔧 Técnico",
+      "✅ Testes",
+    ]);
+  });
+
+  it("sorts merged versions by semver descending", () => {
+    expect(semverDesc("1.9.2", "1.9.1")).toBeLessThan(0);
+    expect(semverDesc("1.9.1", "1.9.2")).toBeGreaterThan(0);
+    expect(semverDesc("1.9.2", "1.10.0")).toBeGreaterThan(0);
+    expect(semverDesc("1.9.2", "1.9.2")).toBe(0);
+  });
+
+  it("is idempotent", async () => {
+    const parsed = parseChangelog(await fixtureChangelog());
+    const existing = (await fixtureLocale("en-US")).changelog.versions;
+    const once = buildVersions("en", parsed, existing);
+    const twice = buildVersions("en", parsed, once);
+    expect(twice).toEqual(once);
+  });
+});
+
+describe("sync-changelog CLI", () => {
+  it("parses flags and rejects conflicting or unknown ones", () => {
+    expect(parseArgs([])).toEqual({
+      mode: "--dry-run",
+      fromGithub: false,
+      githubTag: null,
+    });
+    expect(parseArgs(["--write"])).toMatchObject({ mode: "--write" });
+    expect(parseArgs(["--check"])).toMatchObject({ mode: "--check" });
+    expect(parseArgs(["--from-github", "v1.9.2"])).toMatchObject({
+      fromGithub: true,
+      githubTag: "v1.9.2",
+    });
+    expect(parseArgs(["--from-github", "--write"])).toMatchObject({
+      fromGithub: true,
+      githubTag: null,
+      mode: "--write",
+    });
+    expect(() => parseArgs(["--write", "--check"])).toThrow("Conflicting");
+    expect(() => parseArgs(["--from-github", "banana"])).toThrow(
+      "Invalid release tag",
+    );
+    expect(() => parseArgs(["--bogus"])).toThrow("Unknown flag");
+  });
+
+  it("writes only changelog.versions and preserves every other JSON key", async () => {
+    const root = await tempRoot();
+    const before = await fixtureLocale("pt-BR");
+    await main(["--write"], { root });
+    const written = JSON.parse(
+      await readFile(
+        resolve(root, "src/shared/i18n/locales/pt-BR.json"),
+        "utf8",
+      ),
+    );
+    expect(written.common).toEqual(before.common);
+    expect(written.nav).toEqual(before.nav);
+    expect(written.changelog.header).toBe(before.changelog.header);
+    expect(written.changelog.versions.map((entry) => entry.version)).toEqual([
+      "1.2.0",
+      "1.1.1",
+      "1.1.0",
+      "1.0.0",
+    ]);
+  });
+
+  it("is file-level idempotent: a second --write changes nothing", async () => {
+    const root = await tempRoot();
+    await main(["--write"], { root });
+    const first = await readFile(
+      resolve(root, "src/shared/i18n/locales/en-US.json"),
+      "utf8",
+    );
+    const report = await main(["--write"], { root });
+    expect(report.wrote).toBe(false);
+    const second = await readFile(
+      resolve(root, "src/shared/i18n/locales/en-US.json"),
+      "utf8",
+    );
+    expect(second).toBe(first);
+  });
+
+  it("--check passes when in sync and fails when the locale diverges", async () => {
+    const root = await tempRoot();
+    await main(["--write"], { root });
+    await expect(main(["--check"], { root })).resolves.toMatchObject({
+      ok: true,
+    });
+
+    // Divergence: drop an item from the synced pt-BR 1.2.0 entry.
+    const ptPath = resolve(root, "src/shared/i18n/locales/pt-BR.json");
+    const diverged = JSON.parse(await readFile(ptPath, "utf8"));
+    diverged.changelog.versions[0].sections[0].items.pop();
+    await writeFile(ptPath, `${JSON.stringify(diverged, null, 2)}\n`);
+    await expect(main(["--check"], { root })).rejects.toThrow("out of sync");
+    // A --dry-run reports the stale locale without writing.
+    const report = await main(["--dry-run"], { root });
+    expect(report.reports["pt-BR"].changed).toContain("1.2.0");
+    expect(await readFile(ptPath, "utf8")).toContain("dark mode");
+  });
+
+  it("reports additions, removals and updates per locale", async () => {
+    const report = formatReport("pt-BR", {
+      added: ["1.2.0"],
+      removed: ["1.0.0"],
+      changed: ["1.1.0"],
+      before: 2,
+      after: 3,
+    });
+    expect(report).toContain("pt-BR.json: 2 → 3 version entries");
+    expect(report).toContain("+ 1.2.0");
+    expect(report).toContain("- 1.0.0");
+    expect(report).toContain("~ 1.1.0 (updated)");
+  });
+
+  it("--check detects additions from the changelog source", async () => {
+    const root = await tempRoot();
+    // The fixture locale already lacks 1.1.1 and 1.1.0 entries.
+    await expect(main(["--check"], { root })).rejects.toThrow("out of sync");
+  });
+
+  it("surgically replaces only the versions array span", () => {
+    const raw = [
+      "{",
+      '  "changelog": {',
+      '    "header": "x",',
+      '    "versions": [',
+      '      { "version": "1.0.0", "date": "", "sections": [] }',
+      "    ],",
+      '    "viewAllOnGitHub": "y"',
+      "  },",
+      '\t"legacy": "\tindented with a literal tab"',
+      "}",
+    ].join("\n");
+    const next = [{ version: "2.0.0", date: "", sections: [] }];
+    const updated = replaceVersionsArray(raw, next);
+    expect(updated).toBe([
+      "{",
+      '  "changelog": {',
+      '    "header": "x",',
+      '    "versions": [',
+      "      {",
+      '        "version": "2.0.0",',
+      '        "date": "",',
+      '        "sections": []',
+      "      }",
+      "    ],",
+      '    "viewAllOnGitHub": "y"',
+      "  },",
+      '\t"legacy": "\tindented with a literal tab"',
+      "}",
+    ].join("\n"));
+    const span = findVersionsArraySpan(raw);
+    expect(span).not.toBeNull();
+    expect(raw.slice(span.start, span.start + 1)).toBe("[");
+    expect(raw.slice(span.end - 1, span.end)).toBe("]");
+  });
+
+  it("preserves non-changelog bytes exactly (mixed indentation)", async () => {
+    const root = await tempRoot();
+    const ptPath = resolve(root, "src/shared/i18n/locales/pt-BR.json");
+    const raw = await readFile(ptPath, "utf8");
+    // The repo's real locales mix tabs and spaces outside changelog.versions.
+    const withTab = raw.replace(
+      '"appName": "Open3DCalc"',
+      '\t"appName": "Open3DCalc"',
+    );
+    await writeFile(ptPath, withTab);
+    await main(["--write"], { root });
+    const after = await readFile(ptPath, "utf8");
+    // The tab-indented key outside the changelog section is byte-identical.
+    expect(after).toContain('\t"appName": "Open3DCalc"');
+    // Everything before "versions" and after its closing bracket is untouched.
+    const versionsSpan = findVersionsArraySpan(after);
+    const beforeSpan = findVersionsArraySpan(withTab);
+    expect(after.slice(0, versionsSpan.start)).toBe(
+      withTab.slice(0, beforeSpan.start),
+    );
+    expect(after.slice(versionsSpan.end)).toBe(withTab.slice(beforeSpan.end));
+  });
+});
+
+describe("sync-changelog release workflow", () => {
+  it("keeps the release workflow in sync with the in-app changelog", async () => {
+    const workflow = await readFile(
+      resolve(".github/workflows/release.yml"),
+      "utf8",
+    );
+    const allowed = workflow.match(/ALLOWED=\$'([^']+)'/)?.[1] ?? "";
+    expect(allowed).toContain("src/shared/i18n/locales/pt-BR.json");
+    expect(allowed).toContain("src/shared/i18n/locales/en-US.json");
+    const syncIndex = workflow.indexOf("Sync in-app changelog");
+    const commitIndex = workflow.indexOf("Commit and push release branch");
+    expect(syncIndex).toBeGreaterThan(-1);
+    expect(commitIndex).toBeGreaterThan(syncIndex);
+    expect(workflow).toContain("node scripts/sync-changelog.mjs --write");
+    expect(workflow).toContain(
+      "git add package.json package-lock.json CHANGELOG.md",
+    );
+    expect(workflow).toContain(
+      "src/shared/i18n/locales/pt-BR.json src/shared/i18n/locales/en-US.json",
+    );
+  });
+});

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+/**
+ * Deterministic in-app changelog sync.
+ *
+ * Parses the root CHANGELOG.md (offline, deterministic) and regenerates the
+ * `changelog.versions` section of src/shared/i18n/locales/{pt-BR,en-US}.json.
+ *
+ * Merge semantics:
+ * - Versions defined by CHANGELOG.md win: the app entry is regenerated from
+ *   the markdown sections (per-locale section titles, raw item text).
+ * - Versions present only in the locale files are preserved untouched (the
+ *   rich handwritten entries for releases the root changelog does not cover,
+ *   e.g. 1.9.1/1.7.0) so the in-app history is never gutted.
+ * - Dates: inline `(YYYY-MM-DD)` in the version heading wins; otherwise the
+ *   existing locale date is kept; otherwise empty.
+ * - The final list is sorted by SemVer descending.
+ *
+ * Source of truth:
+ * - Default: parse CHANGELOG.md (offline, deterministic — used by CI).
+ * - `--from-github [vX.Y.Z]`: fetch the audited catalog from release-notes.mjs
+ *   via the GitHub API (fallback when CHANGELOG.md misses a release).
+ *
+ * Flags:
+ *   --dry-run   print per-locale version diff, write nothing (default)
+ *   --write     update changelog.versions in both locale files
+ *   --check     exit 1 if the locales are out of sync with the source
+ *
+ * Only `changelog.versions` is touched; every other JSON key is preserved
+ * byte-for-byte (same 2-space indentation, key order, trailing newline).
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const LOCALE_NAMES = ["pt-BR", "en-US"];
+const DEFAULT_REPOSITORY = "ils15/open3dcalc";
+/** File basename → SECTION_TITLES key. */
+const LOCALE_KEYS = Object.freeze({ "pt-BR": "pt", "en-US": "en" });
+
+// Lazy: under vitest's module runner import.meta.url is not a file:// URL.
+const repoRoot = () => {
+  const url = String(import.meta.url);
+  return url.startsWith("file:")
+    ? fileURLToPath(new URL("..", url))
+    : process.cwd();
+};
+
+const VERSION_HEADING = /^##\s+v(\d+\.\d+\.\d+)(.*)$/;
+const DATE_INLINE = /\((\d{4}-\d{2}-\d{2})\)/;
+const SECTION_HEADING = /^###\s+(.+)$/;
+const ITEM_LINE = /^[-*]\s+(.+)$/;
+const MARKDOWN_LINK = /\[([^\]]*)\]\([^)]*\)/g;
+const HTML_TAG = /<[^>]+>/g;
+const EMOJI = /[\p{Extended_Pictographic}\uFE0F\u200D]/gu;
+const LEADING_EMOJI = /^[\p{Extended_Pictographic}\uFE0F\u200D\s]+/u;
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
+const RELEASE_TAG = /^v\d+\.\d+\.\d+$/;
+
+/**
+ * CHANGELOG.md headings (emoji-stripped, lowercased) and release-notes.mjs
+ * category names both funnel into these canonical keys.
+ */
+export const CATEGORY_KEYS = Object.freeze({
+  enhancements: "features",
+  features: "features",
+  "bug fixes": "fixes",
+  fixes: "fixes",
+  chore: "other",
+  "other changes": "other",
+  other: "other",
+  ci: "ci",
+  "ci/cd": "ci",
+  documentation: "documentation",
+  contributors: "contributors",
+  "breaking changes": "breaking",
+  security: "security",
+  dependencies: "dependencies",
+  "performance improvements": "improvements",
+  improvements: "improvements",
+  refactors: "other",
+  styles: "other",
+  builds: "other",
+});
+
+/** Per-locale section titles for the canonical category keys. */
+export const SECTION_TITLES = Object.freeze({
+  en: Object.freeze({
+    features: "🚀 Features",
+    improvements: "🚀 Enhancements",
+    fixes: "🐛 Fixes",
+    other: "🧹 Other",
+    ci: "🤖 CI",
+    documentation: "📖 Documentation",
+    contributors: "❤️ Contributors",
+    breaking: "💥 Breaking Changes",
+    security: "🔒 Security",
+    dependencies: "⬆️ Dependencies",
+  }),
+  pt: Object.freeze({
+    features: "🚀 Novidades",
+    improvements: "🚀 Melhorias",
+    fixes: "🐛 Correções",
+    other: "🧹 Outros",
+    ci: "🤖 CI/CD",
+    documentation: "📖 Documentação",
+    contributors: "❤️ Contribuidores",
+    breaking: "💥 Mudanças Quebradas",
+    security: "🔒 Segurança",
+    dependencies: "⬆️ Dependências",
+  }),
+});
+
+/** Strip markdown links, HTML and emoji; keep `**bold**` and `` `code` ``. */
+export const cleanItem = (text) =>
+  String(text ?? "")
+    .replace(MARKDOWN_LINK, "$1")
+    .replace(HTML_TAG, "")
+    .replace(EMOJI, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+export const parseSemver = (value) => {
+  const match = SEMVER.exec(String(value ?? ""));
+  return match
+    ? {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+      }
+    : { major: 0, minor: 0, patch: 0 };
+};
+
+export const semverDesc = (a, b) => {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  return pb.major - pa.major || pb.minor - pa.minor || pb.patch - pa.patch;
+};
+
+export const emojiStrip = (text) =>
+  String(text ?? "")
+    .replace(LEADING_EMOJI, "")
+    .trim();
+
+export const categoryKeyFor = (heading) => {
+  const key = emojiStrip(heading).toLowerCase();
+  return CATEGORY_KEYS[key] ?? null;
+};
+
+export const sectionTitleFor = (locale, heading) => {
+  const key = categoryKeyFor(heading);
+  return key ? SECTION_TITLES[locale][key] : String(heading).trim();
+};
+
+/**
+ * Parse `## vX.Y.Z` sections from markdown into
+ * `{ version, date, sections: [{ raw, items }] }` entries.
+ * Version headings may carry an inline `(YYYY-MM-DD)` date; dates default to
+ * empty. Loose text (compare links, `---`, footer prose) is ignored.
+ */
+export function parseChangelog(markdown) {
+  const entries = [];
+  let entry = null;
+  let section = null;
+  for (const rawLine of String(markdown).split(/\r?\n/)) {
+    const versionHeading = VERSION_HEADING.exec(rawLine);
+    if (versionHeading) {
+      const [, version, rest] = versionHeading;
+      const inlineDate = DATE_INLINE.exec(rest);
+      entry = { version, date: inlineDate?.[1] ?? "", sections: [] };
+      section = null;
+      entries.push(entry);
+      continue;
+    }
+    if (!entry) continue; // prose before the first version heading
+    const sectionHeading = SECTION_HEADING.exec(rawLine);
+    if (sectionHeading) {
+      section = { raw: sectionHeading[1].trim(), items: [] };
+      entry.sections.push(section);
+      continue;
+    }
+    const itemLine = ITEM_LINE.exec(rawLine);
+    if (itemLine && section) section.items.push(cleanItem(itemLine[1].trim()));
+  }
+  return entries;
+}
+
+/** Map parsed sections to per-locale titles, merging duplicates by title. */
+export function localizeSections(locale, sections) {
+  const merged = [];
+  const byTitle = new Map();
+  for (const section of sections) {
+    const title = sectionTitleFor(locale, section.raw);
+    if (!byTitle.has(title)) {
+      const localized = { title, items: [] };
+      byTitle.set(title, localized);
+      merged.push(localized);
+    }
+    byTitle.get(title).items.push(...section.items);
+  }
+  return merged;
+}
+
+/**
+ * CHANGELOG.md wins for the versions it defines; locale-only versions are
+ * preserved. Missing dates fall back to the existing locale entry date.
+ */
+export function mergeEntries(parsed, existing) {
+  const existingByVersion = new Map(
+    existing.map((entry) => [entry.version, entry]),
+  );
+  const merged = parsed.map((entry) => {
+    const old = existingByVersion.get(entry.version);
+    return old && !entry.date ? { ...entry, date: old.date ?? "" } : entry;
+  });
+  const parsedVersions = new Set(parsed.map((entry) => entry.version));
+  for (const entry of existing)
+    if (!parsedVersions.has(entry.version)) merged.push(entry);
+  merged.sort((a, b) => semverDesc(a.version, b.version));
+  return merged;
+}
+
+export function buildVersions(locale, parsed, existing) {
+  const localized = parsed.map((entry) => ({
+    version: entry.version,
+    date: entry.date,
+    sections: localizeSections(locale, entry.sections),
+  }));
+  return mergeEntries(localized, existing);
+}
+
+export function diffVersions(before, after) {
+  const added = after
+    .filter((entry) => !before.some((old) => old.version === entry.version))
+    .map((entry) => entry.version);
+  const removed = before
+    .filter((old) => !after.some((entry) => entry.version === old.version))
+    .map((old) => old.version);
+  const changed = after
+    .filter((entry) => {
+      const old = before.find(
+        (candidate) => candidate.version === entry.version,
+      );
+      return old && JSON.stringify(old) !== JSON.stringify(entry);
+    })
+    .map((entry) => entry.version);
+  return {
+    added,
+    removed,
+    changed,
+    before: before.length,
+    after: after.length,
+  };
+}
+
+export function formatReport(name, report) {
+  const lines = [
+    `${name}.json: ${report.before} → ${report.after} version entries`,
+  ];
+  for (const version of report.added) lines.push(`  + ${version}`);
+  for (const version of report.removed) lines.push(`  - ${version}`);
+  for (const version of report.changed) lines.push(`  ~ ${version} (updated)`);
+  return lines.join("\n");
+}
+
+/**
+ * Locate the `"versions": [...]` array span in the raw locale JSON. The
+ * changelog section uses 2-space indentation while other sections use mixed
+ * tabs/spaces, so the array is spliced surgically to preserve every other
+ * byte (JSON.stringify would normalize unrelated formatting).
+ */
+export function findVersionsArraySpan(raw) {
+  const keyIndex = raw.indexOf('"versions":');
+  if (keyIndex < 0) return null;
+  const open = raw.indexOf("[", keyIndex);
+  if (open < 0) return null;
+  let depth = 0;
+  let inString = false;
+  for (let index = open; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (inString) {
+      if (char === "\\") index += 1;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "[") depth += 1;
+    else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) return { start: open, end: index + 1 };
+    }
+  }
+  return null;
+}
+
+/** Serialize the versions array at the changelog section's nesting depth. */
+export const serializeVersionsBlock = (versions) =>
+  JSON.stringify(versions, null, 2)
+    .split("\n")
+    .map((line, index) => (index === 0 ? line : `    ${line}`))
+    .join("\n");
+
+/** Replace only the `"versions": [...]` span; every other byte is kept. */
+export function replaceVersionsArray(raw, versions) {
+  const span = findVersionsArraySpan(raw);
+  if (!span)
+    throw new Error(
+      "changelog.versions array not found; refusing to rewrite the locale",
+    );
+  return `${raw.slice(0, span.start)}${serializeVersionsBlock(versions)}${raw.slice(span.end)}`;
+}
+
+function entryFromCatalog(catalog) {
+  const release = catalog.releases?.[0];
+  const version = String(release?.tag ?? "").replace(/^v/, "");
+  const sections = [];
+  const byCategory = new Map();
+  for (const item of catalog.items ?? []) {
+    const raw = item.category ?? "Other Changes";
+    if (!byCategory.has(raw)) {
+      byCategory.set(raw, { raw, items: [] });
+      sections.push(byCategory.get(raw));
+    }
+    byCategory.get(raw).items.push(cleanItem(item.title ?? ""));
+  }
+  return { version, date: "", sections };
+}
+
+/** Fallback source: audited per-release catalogs from release-notes.mjs. */
+async function entriesFromGitHub(repository, tag) {
+  const { collect } = await import("./release-notes.mjs");
+  if (tag) return [entryFromCatalog(await collect(repository, tag))];
+  const catalog = await collect(repository);
+  const tags = catalog.releases
+    .map((release) => release.tag)
+    .filter((candidate) => RELEASE_TAG.test(candidate))
+    .sort((a, b) => semverDesc(a.replace("v", ""), b.replace("v", "")));
+  const entries = [];
+  for (const releaseTag of tags)
+    entries.push(entryFromCatalog(await collect(repository, releaseTag)));
+  return entries;
+}
+
+const usage = [
+  "Usage: node scripts/sync-changelog.mjs [--dry-run|--write|--check]",
+  "                                    [--from-github [vX.Y.Z]]",
+  "  default mode: --dry-run (show what would change, write nothing)",
+  "  --dry-run       print per-locale version diff without writing",
+  "  --write         update changelog.versions in both locale files",
+  "  --check         exit 1 when the locales are out of sync with the source",
+  "  --from-github   use release-notes.mjs (GitHub API) instead of CHANGELOG.md",
+  "                  as the source; optionally scope to one vX.Y.Z release",
+].join("\n");
+
+export function parseArgs(argv) {
+  const modes = new Set(["--dry-run", "--write", "--check"]);
+  const modeFlags = argv.filter((arg) => modes.has(arg));
+  if (modeFlags.length > 1)
+    throw new Error(`Conflicting modes: ${modeFlags.join(" and ")}\n${usage}`);
+  let fromGithub = false;
+  let githubTag = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (modes.has(arg)) continue;
+    if (arg === "--from-github") {
+      fromGithub = true;
+      const next = argv[index + 1];
+      if (next && !next.startsWith("--")) {
+        if (!RELEASE_TAG.test(next))
+          throw new Error(`Invalid release tag: ${next}\n${usage}`);
+        githubTag = next;
+        index += 1;
+      }
+      continue;
+    }
+    throw new Error(`Unknown flag: ${arg}\n${usage}`);
+  }
+  return {
+    mode: modeFlags[0] ?? "--dry-run",
+    fromGithub,
+    githubTag,
+  };
+}
+
+export async function main(argv = process.argv.slice(2), overrides = {}) {
+  const options = parseArgs(argv);
+  const root = overrides.root ?? repoRoot();
+  const changelogPath = overrides.changelog ?? resolve(root, "CHANGELOG.md");
+  const localesDir =
+    overrides.localesDir ?? resolve(root, "src/shared/i18n/locales");
+  const repository = process.env.GITHUB_REPOSITORY ?? DEFAULT_REPOSITORY;
+  const parsed = options.fromGithub
+    ? await entriesFromGitHub(repository, options.githubTag)
+    : parseChangelog(await readFile(changelogPath, "utf8"));
+
+  const reports = {};
+  for (const name of LOCALE_NAMES) {
+    const filePath = resolve(localesDir, `${name}.json`);
+    const raw = await readFile(filePath, "utf8");
+    const data = JSON.parse(raw);
+    if (!data.changelog) data.changelog = {};
+    const existing = Array.isArray(data.changelog.versions)
+      ? data.changelog.versions
+      : [];
+    const versions = buildVersions(LOCALE_KEYS[name], parsed, existing);
+    reports[name] = diffVersions(existing, versions);
+    if (options.mode === "--write") {
+      // Surgical splice keeps every byte outside changelog.versions intact.
+      await writeFile(filePath, replaceVersionsArray(raw, versions), "utf8");
+    }
+  }
+
+  const stale = Object.entries(reports).filter(
+    ([, report]) =>
+      report.added.length || report.removed.length || report.changed.length,
+  );
+  if (options.mode === "--check") {
+    if (stale.length)
+      throw new Error(
+        stale
+          .map(
+            ([name, report]) =>
+              `${name}.json is out of sync with the changelog source\n${formatReport(name, report)}`,
+          )
+          .join("\n"),
+      );
+    return { mode: options.mode, reports, ok: true };
+  }
+  if (stale.length) {
+    for (const [name, report] of stale) console.log(formatReport(name, report));
+  } else if (options.mode === "--dry-run") {
+    console.log("Locales are already in sync; nothing to write.");
+  }
+  return {
+    mode: options.mode,
+    reports,
+    wrote: options.mode === "--write" && stale.length > 0,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`)
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -620,8 +620,51 @@
     "header": "{{versions}} versions · {{changes}} changes",
     "viewAllOnGitHub": "View all releases on GitHub",
     "versions": [
-
-    {
+      {
+        "version": "1.9.2",
+        "date": "",
+        "sections": [
+          {
+            "title": "🚀 Features",
+            "items": [
+              "**ci:** Add AI code review workflow via Bifrost LLM Gateway (8287e51)",
+              "**ci:** Switch AI review to alibaba/open-code-review, fix release artifacts (#11)",
+              "CI/CD otimizado — self-hosted runner, husky-only, AI commit review, i18n (#12)",
+              "Auto-deduct filament + date filters (Issue #16) (#17, #16)",
+              "Phase 2+3 — STL & Dashboard optimization (dead code removal, calc integration) (#20)"
+            ]
+          },
+          {
+            "title": "🐛 Fixes",
+            "items": [
+              "**changelog:** Sort versions by semver + add v1.9.1 entry (ffc68bb)",
+              "Safety Sprint — security & quality hardening (#19)",
+              "**release:** Remove [skip ci] from release commit (#21)",
+              "**release:** Push tag only, use release branch + PR for version bump (#22)",
+              "**release:** Padronizar pipeline protegido e idempotente (#23)"
+            ]
+          },
+          {
+            "title": "🧹 Other",
+            "items": [
+              "Translate missing pt-BR keys, remove stale web/ and desktop/ copies (cc5b0e9)"
+            ]
+          },
+          {
+            "title": "🤖 CI",
+            "items": [
+              "Remove themis review, add opencode github integration (#13)"
+            ]
+          },
+          {
+            "title": "❤️ Contributors",
+            "items": [
+              "Ils15 (@ils15)"
+            ]
+          }
+        ]
+      },
+      {
         "version": "1.9.1",
         "date": "2026-07-02",
         "sections": [
@@ -658,6 +701,110 @@
             "items": [
               "**latest.yml** now included in GitHub releases — auto-updater finds updates",
               "**Blockmap** for delta updates"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.9.0",
+        "date": "2026-07-01",
+        "sections": [
+          {
+            "title": "🚀 Features",
+            "items": [
+              "**ui:** Usability improvements — tooltips, quick mode labels, tutorial overhaul (72720a4)",
+              "**ui:** Accessibility and i18n fixes (1e30bc0)",
+              "**ui:** Quick Start, Empty States, Scroll, Keyboard Shortcuts (80c2f29)"
+            ]
+          },
+          {
+            "title": "🐛 Fixes",
+            "items": [
+              "**release:** Use bash array for artifact upload (a719447)",
+              "**ui:** Resolve 5 audit bugs — tutorial navigation, H1, touch targets, export (5b032ca)",
+              "**ui:** Tutorial spotlight positioning + remaining touch targets (5d6b8ae)",
+              "**ui:** Remaining touch targets in SectionNav + MobileBottomBar (87e1cd9)",
+              "**ui:** Min-h-[44px] in SectionNav buttons (d875147)",
+              "Lint error in useKeyboardShortcuts + enforce CI/CD gate in AGENTS.md (60a72b1)",
+              "Type error document.querySelector().click() → cast to HTMLElement (61ebfab)"
+            ]
+          },
+          {
+            "title": "📖 Documentation",
+            "items": [
+              "Add RELEASE.md with step-by-step release process (01d42fb)"
+            ]
+          },
+          {
+            "title": "🧹 Other",
+            "items": [
+              "**release:** V1.8.1 [skip ci] (079945e)",
+              "**release:** V1.8.2 [skip ci] (7e1508d)"
+            ]
+          },
+          {
+            "title": "❤️ Contributors",
+            "items": [
+              "Ils15 (@ils15)"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.8.2",
+        "date": "2026-06-29",
+        "sections": [
+          {
+            "title": "🐛 Fixes",
+            "items": [
+              "**release:** Use bash array for artifact upload (a719447)"
+            ]
+          },
+          {
+            "title": "🧹 Other",
+            "items": [
+              "**release:** V1.8.1 [skip ci] (079945e)"
+            ]
+          },
+          {
+            "title": "❤️ Contributors",
+            "items": [
+              "Ils15 (@ils15)"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.8.1",
+        "date": "",
+        "sections": []
+      },
+      {
+        "version": "1.8.0",
+        "date": "2026-06-29",
+        "sections": [
+          {
+            "title": "🎨 UI/UX",
+            "items": [
+              "Redesign Bifrost: superfícies planas, sem glassmorphism",
+              "Tema claro/escuro no web",
+              "Badges retangulares (6px), border-radius reduzido (14px)",
+              "Sistema de CSS variables unificado"
+            ]
+          },
+          {
+            "title": "🔧 Técnico",
+            "items": [
+              "Codebase unificada em monorepo (`src/shared/` + `src/platform/`)",
+              "Git migrado para raiz (história preservada)",
+              "`web/` e `desktop/` mantidos para referência histórica"
+            ]
+          },
+          {
+            "title": "✅ Testes",
+            "items": [
+              "417 testes, 36/36 arquivos passando",
+              "Cobertura >80%"
             ]
           }
         ]
@@ -721,90 +868,6 @@
               "`src/data/printers-database.json` — 385 impressoras com specs detalhadas",
               "`src/types/customer.ts` — interfaces Customer e CustomerFormData",
               "`src/types/quote.ts` — interfaces Quote, QuoteItem, QuoteFormData"
-            ]
-          }
-        ]
-      },
-      {
-        "version": "1.9.0",
-        "date": "2026-07-01",
-        "sections": [
-          {
-            "title": "🎨 UX — Usability & Accessibility",
-            "items": [
-              "**53 tooltips** on calculator fields with Floating UI (touch + a11y)",
-              "**LevelToggle renamed**: Quick/Detailed/Complete with descriptions",
-              "**Interactive tutorial rewritten**: 7 steps, non-blocking, overlay dismiss",
-              "**Quick Start**: \"Fill with Example\" button with realistic values",
-              "**Empty States**: History, Inventory, Quotes empty with helpful messages",
-              "**Smooth scroll** + keyboard shortcuts (Ctrl+Z, Ctrl+E, Ctrl+P)"
-            ]
-          },
-          {
-            "title": "♿ Accessibility",
-            "items": [
-              "**Skip link** to bypass navigation",
-              "**Heading hierarchy** fixed (h1→h2→h3, no gaps)",
-              "**Touch targets** ≥ 44px on all interactive elements",
-              "**Tooltips migrated** to i18n (pt-BR + en-US)"
-            ]
-          },
-          {
-            "title": "🐛 Fixes",
-            "items": [
-              "Tutorial navigation: MutationObserver ignores tutorial card",
-              "Tutorial card positioning: fixed position (no Floating UI)",
-              "Export: buttons no longer overlap",
-              "Mobile nav: horizontal scroll removed",
-              "Desktop sidebar: full page height, no unnecessary scroll"
-            ]
-          },
-          {
-            "title": "🧪 Tests",
-            "items": [
-              "**483 tests passing** (was 448)",
-              "+35 new tests (tutorialStore, Tutorial, QuickStart, EmptyState)"
-            ]
-          }
-        ]
-      },
-      {
-        "version": "1.8.2",
-        "date": "2026-06-29",
-        "sections": [
-          {
-            "title": "🐛 Fixes",
-            "items": [
-              "Fix: database module import in Electron (.js extension)",
-              "Fix: icon references in electron-builder"
-            ]
-          },
-          {
-            "title": "🏡 Chore",
-            "items": [
-              "Release workflow: artifact upload with bash array"
-            ]
-          }
-        ]
-      },
-      {
-        "version": "1.8.0",
-        "date": "2026-06-29",
-        "sections": [
-          {
-            "title": "🚀 Bifrost — Major Refactor",
-            "items": [
-              "**Calculator.tsx refactored**: from 1459 to 234 lines — 11 components extracted",
-              "**calculatorStore.ts refactored**: from 561 to 278 lines",
-              "**Unified types** in `src/shared/types/index.ts`",
-              "**Automatic migration** from old data format to new one"
-            ]
-          },
-          {
-            "title": "🧪 Tests",
-            "items": [
-              "**417 tests** (was 321), coverage maintained at 93%",
-              "historyStore +12, filamentInventory +11, Calculator mobile export +3"
             ]
           }
         ]

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -620,8 +620,51 @@
     "header": "{{versions}} versões · {{changes}} mudanças",
     "viewAllOnGitHub": "Ver todas as releases no GitHub",
     "versions": [
-
-    {
+      {
+        "version": "1.9.2",
+        "date": "",
+        "sections": [
+          {
+            "title": "🚀 Novidades",
+            "items": [
+              "**ci:** Add AI code review workflow via Bifrost LLM Gateway (8287e51)",
+              "**ci:** Switch AI review to alibaba/open-code-review, fix release artifacts (#11)",
+              "CI/CD otimizado — self-hosted runner, husky-only, AI commit review, i18n (#12)",
+              "Auto-deduct filament + date filters (Issue #16) (#17, #16)",
+              "Phase 2+3 — STL & Dashboard optimization (dead code removal, calc integration) (#20)"
+            ]
+          },
+          {
+            "title": "🐛 Correções",
+            "items": [
+              "**changelog:** Sort versions by semver + add v1.9.1 entry (ffc68bb)",
+              "Safety Sprint — security & quality hardening (#19)",
+              "**release:** Remove [skip ci] from release commit (#21)",
+              "**release:** Push tag only, use release branch + PR for version bump (#22)",
+              "**release:** Padronizar pipeline protegido e idempotente (#23)"
+            ]
+          },
+          {
+            "title": "🧹 Outros",
+            "items": [
+              "Translate missing pt-BR keys, remove stale web/ and desktop/ copies (cc5b0e9)"
+            ]
+          },
+          {
+            "title": "🤖 CI/CD",
+            "items": [
+              "Remove themis review, add opencode github integration (#13)"
+            ]
+          },
+          {
+            "title": "❤️ Contribuidores",
+            "items": [
+              "Ils15 (@ils15)"
+            ]
+          }
+        ]
+      },
+      {
         "version": "1.9.1",
         "date": "2026-07-02",
         "sections": [
@@ -658,6 +701,110 @@
             "items": [
               "**latest.yml** now included in GitHub releases — auto-updater finds updates",
               "**Blockmap** for delta updates"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.9.0",
+        "date": "2026-07-01",
+        "sections": [
+          {
+            "title": "🚀 Novidades",
+            "items": [
+              "**ui:** Usability improvements — tooltips, quick mode labels, tutorial overhaul (72720a4)",
+              "**ui:** Accessibility and i18n fixes (1e30bc0)",
+              "**ui:** Quick Start, Empty States, Scroll, Keyboard Shortcuts (80c2f29)"
+            ]
+          },
+          {
+            "title": "🐛 Correções",
+            "items": [
+              "**release:** Use bash array for artifact upload (a719447)",
+              "**ui:** Resolve 5 audit bugs — tutorial navigation, H1, touch targets, export (5b032ca)",
+              "**ui:** Tutorial spotlight positioning + remaining touch targets (5d6b8ae)",
+              "**ui:** Remaining touch targets in SectionNav + MobileBottomBar (87e1cd9)",
+              "**ui:** Min-h-[44px] in SectionNav buttons (d875147)",
+              "Lint error in useKeyboardShortcuts + enforce CI/CD gate in AGENTS.md (60a72b1)",
+              "Type error document.querySelector().click() → cast to HTMLElement (61ebfab)"
+            ]
+          },
+          {
+            "title": "📖 Documentação",
+            "items": [
+              "Add RELEASE.md with step-by-step release process (01d42fb)"
+            ]
+          },
+          {
+            "title": "🧹 Outros",
+            "items": [
+              "**release:** V1.8.1 [skip ci] (079945e)",
+              "**release:** V1.8.2 [skip ci] (7e1508d)"
+            ]
+          },
+          {
+            "title": "❤️ Contribuidores",
+            "items": [
+              "Ils15 (@ils15)"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.8.2",
+        "date": "2026-06-29",
+        "sections": [
+          {
+            "title": "🐛 Correções",
+            "items": [
+              "**release:** Use bash array for artifact upload (a719447)"
+            ]
+          },
+          {
+            "title": "🧹 Outros",
+            "items": [
+              "**release:** V1.8.1 [skip ci] (079945e)"
+            ]
+          },
+          {
+            "title": "❤️ Contribuidores",
+            "items": [
+              "Ils15 (@ils15)"
+            ]
+          }
+        ]
+      },
+      {
+        "version": "1.8.1",
+        "date": "",
+        "sections": []
+      },
+      {
+        "version": "1.8.0",
+        "date": "2026-06-29",
+        "sections": [
+          {
+            "title": "🎨 UI/UX",
+            "items": [
+              "Redesign Bifrost: superfícies planas, sem glassmorphism",
+              "Tema claro/escuro no web",
+              "Badges retangulares (6px), border-radius reduzido (14px)",
+              "Sistema de CSS variables unificado"
+            ]
+          },
+          {
+            "title": "🔧 Técnico",
+            "items": [
+              "Codebase unificada em monorepo (`src/shared/` + `src/platform/`)",
+              "Git migrado para raiz (história preservada)",
+              "`web/` e `desktop/` mantidos para referência histórica"
+            ]
+          },
+          {
+            "title": "✅ Testes",
+            "items": [
+              "417 testes, 36/36 arquivos passando",
+              "Cobertura >80%"
             ]
           }
         ]
@@ -721,90 +868,6 @@
               "`src/data/printers-database.json` — 385 impressoras com specs detalhadas",
               "`src/types/customer.ts` — interfaces Customer e CustomerFormData",
               "`src/types/quote.ts` — interfaces Quote, QuoteItem, QuoteFormData"
-            ]
-          }
-        ]
-      },
-      {
-        "version": "1.9.0",
-        "date": "2026-07-01",
-        "sections": [
-          {
-            "title": "🎨 UX — Usability & Accessibility",
-            "items": [
-              "**53 tooltips** on calculator fields with Floating UI (touch + a11y)",
-              "**LevelToggle renamed**: Quick/Detailed/Complete with descriptions",
-              "**Interactive tutorial rewritten**: 7 steps, non-blocking, overlay dismiss",
-              "**Quick Start**: \"Fill with Example\" button with realistic values",
-              "**Empty States**: History, Inventory, Quotes empty with helpful messages",
-              "**Smooth scroll** + keyboard shortcuts (Ctrl+Z, Ctrl+E, Ctrl+P)"
-            ]
-          },
-          {
-            "title": "♿ Accessibility",
-            "items": [
-              "**Skip link** to bypass navigation",
-              "**Heading hierarchy** fixed (h1→h2→h3, no gaps)",
-              "**Touch targets** ≥ 44px on all interactive elements",
-              "**Tooltips migrated** to i18n (pt-BR + en-US)"
-            ]
-          },
-          {
-            "title": "🐛 Fixes",
-            "items": [
-              "Tutorial navigation: MutationObserver ignores tutorial card",
-              "Tutorial card positioning: fixed position (no Floating UI)",
-              "Export: buttons no longer overlap",
-              "Mobile nav: horizontal scroll removed",
-              "Desktop sidebar: full page height, no unnecessary scroll"
-            ]
-          },
-          {
-            "title": "🧪 Tests",
-            "items": [
-              "**483 tests passing** (was 448)",
-              "+35 new tests (tutorialStore, Tutorial, QuickStart, EmptyState)"
-            ]
-          }
-        ]
-      },
-      {
-        "version": "1.8.2",
-        "date": "2026-06-29",
-        "sections": [
-          {
-            "title": "🐛 Fixes",
-            "items": [
-              "Fix: database module import in Electron (.js extension)",
-              "Fix: icon references in electron-builder"
-            ]
-          },
-          {
-            "title": "🏡 Chore",
-            "items": [
-              "Release workflow: artifact upload with bash array"
-            ]
-          }
-        ]
-      },
-      {
-        "version": "1.8.0",
-        "date": "2026-06-29",
-        "sections": [
-          {
-            "title": "🚀 Bifrost — Major Refactor",
-            "items": [
-              "**Calculator.tsx refactored**: from 1459 to 234 lines — 11 components extracted",
-              "**calculatorStore.ts refactored**: from 561 to 278 lines",
-              "**Unified types** in `src/shared/types/index.ts`",
-              "**Automatic migration** from old data format to new one"
-            ]
-          },
-          {
-            "title": "🧪 Tests",
-            "items": [
-              "**417 tests** (was 321), coverage maintained at 93%",
-              "historyStore +12, filamentInventory +11, Calculator mobile export +3"
             ]
           }
         ]


### PR DESCRIPTION
## What
The in-app changelog (ChangelogPage reads `changelog.versions` from i18n locale JSONs) was written by hand, so it drifted from the auto-generated `CHANGELOG.md` — v1.9.2 was missing in the app.

- **`scripts/sync-changelog.mjs`**: deterministic parser of `CHANGELOG.md` → regenerates `changelog.versions` in pt-BR + en-US locales, semantic merge (markdown wins, locale-only entries preserved), byte-preserving surgical edit, `--dry-run`/`--write`/`--check`/`--from-github` flags
- **CI**: `release.yml` now runs the sync step after version bump, locales added to ALLOWED and git add
- **Backfill**: app changelog now shows 15 versions (added v1.9.2, v1.8.1, etc.); dead `web/CHANGELOG.md` link replaced with GitHub releases link

## Verification
- 752 tests passing (16 new sync-changelog tests)
- lint, typecheck, node --check, JSON validity clean
- `sync-changelog.mjs --check` passes
- Diff confined to `changelog.versions` in locale files
- Themis APPROVED (3 non-blocking notes)