### PR TITLE
fix(layout): results sidebar only with space, portal dropdowns, ultrawide shell

### DIFF
--- a/src/platform/desktop/App.tsx
+++ b/src/platform/desktop/App.tsx
@@ -252,12 +252,12 @@ function App() {
   }, [])
 
   return (
-    <div className="min-h-dvh flex flex-col">
+    <div className="min-h-dvh flex flex-col overflow-x-clip">
       <Header />
       <UpdateNotification className="max-w-[1440px] mx-auto w-full px-6 sm:px-8 lg:px-12 pt-4" />
       <PrivacyBanner />
 
-      <div className="flex flex-1 w-full max-w-[1600px] mx-auto overflow-hidden">
+      <div className="flex flex-1 w-full max-w-[1600px] 2xl:max-w-[1920px] mx-auto overflow-x-clip">
 
         {/* ── Tablet Sidebar — icons only ── */}
         <aside className="hidden md:flex lg:hidden flex-col gap-1 w-16 shrink-0 px-2 py-6 sticky top-[68px] h-[calc(100dvh-68px)] overflow-y-auto border-r border-[var(--color-border)]">

--- a/src/platform/desktop/components/Header/Header.tsx
+++ b/src/platform/desktop/components/Header/Header.tsx
@@ -55,7 +55,7 @@ export function Header() {
         borderColor: 'var(--color-border)',
       }}
     >
-      <div className="max-w-[1440px] mx-auto px-6 sm:px-8 lg:px-12 h-[68px] flex items-center justify-between gap-4">
+      <div className="max-w-[1600px] 2xl:max-w-[1920px] mx-auto px-6 sm:px-8 lg:px-12 h-[68px] flex items-center justify-between gap-4">
 
         {/* Logo */}
         <div className="flex items-center gap-3">

--- a/src/platform/desktop/components/Header/Header.tsx
+++ b/src/platform/desktop/components/Header/Header.tsx
@@ -1,11 +1,13 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { createPortal } from 'react-dom'
 import { Box, Code2, Globe, ChevronDown, BookOpen, RefreshCw } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { useCalculatorStore } from '@/shared/stores/calculatorStore'
 import { useTutorialStore } from '@/shared/stores/tutorialStore'
 import { CURRENCIES, type CurrencyCode } from '@/shared/lib/currency'
 import { useCurrency } from '@/shared/hooks/useCurrency'
+import { useDismissablePopover } from '@/shared/hooks/useDismissablePopover'
 import { ThemeToggle } from '@/shared/components/Header/ThemeToggle'
 import { useUpdaterStore } from '../UpdateNotification/UpdaterStore'
 
@@ -15,8 +17,13 @@ export function Header() {
     useShallow((s) => ({ currency: s.currency, setCurrency: s.setCurrency })),
   )
   const { symbol } = useCurrency()
-  const [showCurrencyMenu, setShowCurrencyMenu] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
+  const {
+    open: currencyMenuOpen,
+    toggle: toggleCurrencyMenu,
+    triggerRef: currencyTriggerRef,
+    contentRef: currencyMenuContentRef,
+  } = useDismissablePopover<HTMLButtonElement>()
+  const [currencyMenuPos, setCurrencyMenuPos] = useState<{ top: number; right: number } | null>(null)
 
   // Updater state — only renders button when electronAPI is available
   const hasUpdater = !!window.electronAPI?.updater
@@ -29,15 +36,16 @@ export function Header() {
     i18n.changeLanguage(next)
   }
 
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setShowCurrencyMenu(false)
-      }
+  const handleCurrencyToggle = () => {
+    if (!currencyMenuOpen && currencyTriggerRef.current) {
+      const rect = currencyTriggerRef.current.getBoundingClientRect()
+      setCurrencyMenuPos({
+        top: rect.bottom + 6,
+        right: Math.max(12, window.innerWidth - rect.right),
+      })
     }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [])
+    toggleCurrencyMenu()
+  }
 
   return (
     <header
@@ -110,10 +118,14 @@ export function Header() {
           </button>
 
           {/* Currency selector */}
-          <div ref={menuRef} className="relative">
+          <div className="flex items-center">
             <button
-              onClick={() => setShowCurrencyMenu(v => !v)}
-              className="flex items-center gap-1 text-[13px] font-semibold px-3 py-2.5 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+              ref={currencyTriggerRef}
+              onClick={handleCurrencyToggle}
+              aria-haspopup="menu"
+              aria-expanded={currencyMenuOpen}
+              aria-controls="header-currency-menu"
+              className="flex items-center gap-1 text-[13px] font-semibold px-3 py-2.5 min-h-[44px] rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
               title={t('settings.currency')}
             >
               <span className="font-mono">{symbol}</span>
@@ -123,31 +135,44 @@ export function Header() {
               <ChevronDown className="w-3 h-3 opacity-40" />
             </button>
 
-            {showCurrencyMenu && (
-              <div className="absolute right-0 top-full mt-1.5 w-44 rounded-xl shadow-2xl z-50 overflow-hidden surface border border-[var(--color-border)]">
-                <button
-                  onClick={() => { setCurrency('auto'); setShowCurrencyMenu(false) }}
-                  className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === 'auto' ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
+            {currencyMenuOpen &&
+              currencyMenuPos &&
+              typeof document !== 'undefined' &&
+              createPortal(
+                <div
+                  ref={currencyMenuContentRef}
+                  id="header-currency-menu"
+                  role="menu"
+                  aria-label={t('settings.currency')}
+                  className="fixed z-[60] w-44 rounded-xl shadow-2xl overflow-hidden surface border border-[var(--color-border)]"
+                  style={{ position: 'fixed', top: currencyMenuPos.top, right: currencyMenuPos.right }}
                 >
-                  <span className="font-mono font-bold w-6">{symbol}</span>
-                  <span>{t('settings.currencyAuto')}</span>
-                  {currencySetting === 'auto' && <span className="ml-auto text-[var(--color-accent)]">✓</span>}
-                </button>
-                <div className="border-t border-[var(--color-border)]" />
-                {(Object.entries(CURRENCIES) as [CurrencyCode, typeof CURRENCIES[CurrencyCode]][]).map(([code, info]) => (
                   <button
-                    key={code}
-                    onClick={() => { setCurrency(code); setShowCurrencyMenu(false) }}
-                    className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === code ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
+                    role="menuitem"
+                    onClick={() => { setCurrency('auto'); toggleCurrencyMenu() }}
+                    className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === 'auto' ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
                   >
-                    <span className="font-mono font-bold w-6">{info.symbol}</span>
-                    <span>{code}</span>
-                    <span className="text-[10px] text-[var(--color-text-muted)] ml-auto">{info.name}</span>
-                    {currencySetting === code && <span className="text-[var(--color-accent)] ml-1">✓</span>}
+                    <span className="font-mono font-bold w-6">{symbol}</span>
+                    <span>{t('settings.currencyAuto')}</span>
+                    {currencySetting === 'auto' && <span className="ml-auto text-[var(--color-accent)]">✓</span>}
                   </button>
-                ))}
-              </div>
-            )}
+                  <div className="border-t border-[var(--color-border)]" />
+                  {(Object.entries(CURRENCIES) as [CurrencyCode, typeof CURRENCIES[CurrencyCode]][]).map(([code, info]) => (
+                    <button
+                      key={code}
+                      role="menuitem"
+                      onClick={() => { setCurrency(code); toggleCurrencyMenu() }}
+                      className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === code ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
+                    >
+                      <span className="font-mono font-bold w-6">{info.symbol}</span>
+                      <span>{code}</span>
+                      <span className="text-[10px] text-[var(--color-text-muted)] ml-auto">{info.name}</span>
+                      {currencySetting === code && <span className="text-[var(--color-accent)] ml-1">✓</span>}
+                    </button>
+                  ))}
+                </div>,
+                document.body,
+              )}
           </div>
 
           {/* Theme toggle */}

--- a/src/platform/desktop/index.css
+++ b/src/platform/desktop/index.css
@@ -16,6 +16,7 @@
   --color-bg-input: #f1f5f9;
   --color-border: #e2e8f0;
   --color-border-subtle: #f1f5f9;
+  --color-border-hover: #cbd5e1;
   --color-border-focus: #6366f1;
 
   --color-text-primary: #0f172a;
@@ -61,6 +62,7 @@
   --color-bg-input: rgba(0, 0, 0, 0.25);
   --color-border: #2e3348;
   --color-border-subtle: #232738;
+  --color-border-hover: #3a4057;
   --color-border-focus: #6366f1;
 
   --color-text-primary: #e2e8f0;
@@ -153,7 +155,7 @@ body {
   background-color: var(--color-bg-primary);
   color: var(--color-text-primary);
   min-height: 100dvh;
-  overflow-x: hidden;
+  overflow-x: clip;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 

--- a/src/platform/desktop/index.css
+++ b/src/platform/desktop/index.css
@@ -121,6 +121,10 @@
   --radius-lg: 10px;
   --radius-xl: 12px;
   --radius-2xl: 14px;
+
+  /* === Container queries === */
+  /* Calculator form grids only go 2-up when the container has room (~608px). */
+  --container-form: 38rem;
 }
 
 /* ===================================================================

--- a/src/platform/web/App.tsx
+++ b/src/platform/web/App.tsx
@@ -263,11 +263,11 @@ function App() {
   }, [])
 
   return (
-    <div className="min-h-dvh flex flex-col overflow-x-hidden">
+    <div className="min-h-dvh flex flex-col overflow-x-clip">
       <Header />
       <PrivacyBanner />
 
-      <div className="flex flex-1 w-full max-w-[1600px] mx-auto overflow-hidden">
+      <div className="flex flex-1 w-full max-w-[1600px] 2xl:max-w-[1920px] mx-auto overflow-x-clip">
 
         {/* ── Tablet Sidebar — icons only ── */}
         <aside className="hidden md:flex lg:hidden flex-col gap-1 w-16 shrink-0 px-2 py-6 sticky top-[68px] h-[calc(100dvh-68px)] overflow-y-auto border-r border-[var(--color-border)]">

--- a/src/platform/web/index.css
+++ b/src/platform/web/index.css
@@ -16,6 +16,7 @@
   --color-bg-input: #f1f5f9;
   --color-border: #e2e8f0;
   --color-border-subtle: #f1f5f9;
+  --color-border-hover: #cbd5e1;
   --color-border-focus: #6366f1;
 
   --color-text-primary: #0f172a;
@@ -71,6 +72,7 @@
   --color-bg-input: rgba(0, 0, 0, 0.25);
   --color-border: #2e3348;
   --color-border-subtle: #232738;
+  --color-border-hover: #3a4057;
   --color-border-focus: #6366f1;
 
   --color-text-primary: #e2e8f0;
@@ -164,7 +166,7 @@ body {
   background-color: var(--color-bg-primary);
   color: var(--color-text-primary);
   min-height: 100dvh;
-  overflow-x: hidden;
+  overflow-x: clip;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 

--- a/src/platform/web/index.css
+++ b/src/platform/web/index.css
@@ -131,6 +131,10 @@
   --radius-lg: 10px;
   --radius-xl: 12px;
   --radius-2xl: 14px;
+
+  /* === Container queries === */
+  /* Calculator form grids only go 2-up when the container has room (~608px). */
+  --container-form: 38rem;
 }
 
 /* ===================================================================

--- a/src/shared/__tests__/layoutShell.test.ts
+++ b/src/shared/__tests__/layoutShell.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const projectRoot = resolve(__dirname, "../..");
+const read = (p: string) => readFileSync(resolve(projectRoot, p), "utf-8");
+
+const webApp = read("platform/web/App.tsx");
+const desktopApp = read("platform/desktop/App.tsx");
+const webCss = read("platform/web/index.css");
+const desktopCss = read("platform/desktop/index.css");
+const webHeader = read("shared/components/Header/Header.tsx");
+const desktopHeader = read("platform/desktop/components/Header/Header.tsx");
+const inputGroup = read("shared/components/ui/InputGroup.tsx");
+const select = read("shared/components/ui/Select/Select.tsx");
+
+describe("Ultrawide shell & overflow containment", () => {
+  it("shell grows to 1920px on 2xl screens instead of staying at 1600px", () => {
+    expect(webApp).toMatch(/max-w-\[1600px\] 2xl:max-w-\[1920px\]/);
+    expect(desktopApp).toMatch(/max-w-\[1600px\] 2xl:max-w-\[1920px\]/);
+  });
+
+  it("header container matches the shell width at 2xl", () => {
+    expect(webHeader).toMatch(/max-w-\[1600px\] 2xl:max-w-\[1920px\]/);
+    expect(desktopHeader).toMatch(/max-w-\[1600px\] 2xl:max-w-\[1920px\]/);
+  });
+
+  it("app root clips horizontal overflow without creating a scroll container (sticky-safe)", () => {
+    expect(webApp).toMatch(/min-h-dvh flex flex-col overflow-x-clip/);
+    expect(desktopApp).toMatch(/min-h-dvh flex flex-col overflow-x-clip/);
+    expect(webApp).not.toMatch(/overflow-x-hidden/);
+    expect(desktopApp).not.toMatch(/overflow-x-hidden/);
+  });
+
+  it("shell uses overflow-x-clip instead of overflow-hidden", () => {
+    expect(webApp).toMatch(/max-w-\[1600px\][^"]*overflow-x-clip/);
+    expect(desktopApp).toMatch(/max-w-\[1600px\][^"]*overflow-x-clip/);
+    expect(webApp).not.toMatch(/max-w-\[1600px\][^"]*overflow-hidden/);
+  });
+
+  it("defines --color-border-hover in light (:root) and dark themes", () => {
+    for (const css of [webCss, desktopCss]) {
+      expect(css).toMatch(/:root\s*{[^}]*--color-border-hover:\s*#cbd5e1/s);
+      expect(css).toMatch(/\.dark\s*{[^}]*--color-border-hover:\s*#3a4057/s);
+    }
+  });
+
+  it("body uses overflow-x: clip to prevent horizontal scroll", () => {
+    for (const css of [webCss, desktopCss]) {
+      expect(css).toMatch(/body\s*\{[^}]*overflow-x:\s*clip/s);
+    }
+  });
+
+  it("keeps the --container-form token for section grids", () => {
+    for (const css of [webCss, desktopCss]) {
+      expect(css).toMatch(/--container-form:\s*38rem/);
+    }
+  });
+
+  it("primary form labels are at least 12px and use text-secondary", () => {
+    expect(inputGroup).toMatch(
+      /text-\[12px\][^"]*text-\[var\(--color-text-secondary\)\]/,
+    );
+    expect(select).toMatch(
+      /text-\[12px\][^"]*text-\[var\(--color-text-secondary\)\]/,
+    );
+  });
+});
+
+describe("breakpoint matrix (390 → 2000px) — shell width", () => {
+  const matrix = [
+    { width: 390, shellCap: 1600, headerCap: 1600 },
+    { width: 768, shellCap: 1600, headerCap: 1600 },
+    { width: 1024, shellCap: 1600, headerCap: 1600 },
+    { width: 1280, shellCap: 1600, headerCap: 1600 },
+    { width: 1440, shellCap: 1600, headerCap: 1600 },
+    { width: 1536, shellCap: 1920, headerCap: 1920 },
+    { width: 2000, shellCap: 1920, headerCap: 1920 },
+  ];
+
+  it.each(matrix)(
+    "at $width px the shell caps at $shellCap px",
+    ({ width, shellCap, headerCap }) => {
+      const is2xl = width >= 1536;
+      // Class-level contract: max-w-[1600px] base + 2xl:max-w-[1920px]
+      expect(shellCap).toBe(is2xl ? 1920 : 1600);
+      expect(headerCap).toBe(is2xl ? 1920 : 1600);
+      expect(webApp).toMatch(/max-w-\[1600px\] 2xl:max-w-\[1920px\]/);
+      expect(webHeader).toMatch(/max-w-\[1600px\] 2xl:max-w-\[1920px\]/);
+    },
+  );
+});

--- a/src/shared/components/Calculator/Calculator.tsx
+++ b/src/shared/components/Calculator/Calculator.tsx
@@ -81,7 +81,7 @@ export function Calculator() {
 			<h1 className="sr-only">{t('nav.calculator')}</h1>
 			<div className="flex gap-4 xl:gap-6 2xl:gap-8 pb-[72px] lg:pb-0">
 				<SectionNav activeSection={activeSection} onSectionClick={setActiveSection} />
-				<div className="flex-1 min-w-0 @container space-y-5">
+				<div className="flex-1 min-w-0 2xl:min-w-[560px] @container space-y-5">
 					<QuickStartBanner />
 						<div className="flex flex-wrap items-center gap-2 sm:gap-3 py-1">
 						<TechToggle />
@@ -101,7 +101,7 @@ export function Calculator() {
 						handlePrinterSelect={handlePrinterSelect}
 					/>
 				</div>
-				<div data-tutorial="results-sidebar" className="hidden xl:flex flex-col gap-5 w-[280px] xl:w-[320px] 2xl:w-[360px] shrink-0 sticky top-[92px] self-start max-h-[calc(100vh-120px)] overflow-y-auto">
+				<div data-tutorial="results-sidebar" className="hidden 2xl:flex flex-col gap-5 w-[360px] shrink-0 sticky top-[92px] self-start max-h-[calc(100vh-120px)] overflow-y-auto">
 					<ResultsPanel variant="sidebar" />
 				</div>
 			</div>

--- a/src/shared/components/Calculator/ResultsPanel.tsx
+++ b/src/shared/components/Calculator/ResultsPanel.tsx
@@ -446,5 +446,5 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
     return withDialogs
   }
 
-  return <div className="space-y-4 lg:hidden">{withDialogs}</div>
+  return <div className="space-y-4 2xl:hidden">{withDialogs}</div>
 }

--- a/src/shared/components/Calculator/ResultsPanel.tsx
+++ b/src/shared/components/Calculator/ResultsPanel.tsx
@@ -78,6 +78,16 @@ export function ResultsPanel({ variant }: ResultsPanelProps) {
     return () => document.removeEventListener('mousedown', handleClick)
   }, [showInventoryDropdown])
 
+  // Close dropdown with Escape
+  useEffect(() => {
+    if (!showInventoryDropdown) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowInventoryDropdown(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [showInventoryDropdown])
+
   // Auto-hide success message
   useEffect(() => {
     if (!deductSuccess) return

--- a/src/shared/components/Calculator/SectionRenderer.tsx
+++ b/src/shared/components/Calculator/SectionRenderer.tsx
@@ -184,7 +184,7 @@ export function SectionRenderer(props: SectionRendererProps) {
 						);
 					case "results":
 						return (
-							<div key="results" id="section-results" data-tutorial="results" className="scroll-mt-24 xl:hidden">
+							<div key="results" id="section-results" data-tutorial="results" className="scroll-mt-24 2xl:hidden">
 								<ResultsPanel variant="mobile" />
 							</div>
 						);

--- a/src/shared/components/Calculator/__tests__/Calculator.test.tsx
+++ b/src/shared/components/Calculator/__tests__/Calculator.test.tsx
@@ -1,7 +1,118 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-describe("Calculator", () => {
-  it("placeholder — MobileBottomBar removed, tests migrated", () => {
-    expect(true).toBe(true);
+const readRelative = (p: string) =>
+  readFileSync(resolve(__dirname, p), "utf-8");
+
+const calculatorSource = readRelative("../Calculator.tsx");
+const rendererSource = readRelative("../SectionRenderer.tsx");
+const resultsPanelSource = readRelative("../ResultsPanel.tsx");
+
+/**
+ * Tailwind v4 default breakpoints (min-width, px):
+ * md 768 · lg 1024 · xl 1280 · 2xl 1536
+ */
+const tailwindBreakpoint = (width: number): string | null => {
+  if (width >= 1536) return "2xl";
+  if (width >= 1280) return "xl";
+  if (width >= 1024) return "lg";
+  if (width >= 768) return "md";
+  return null;
+};
+
+describe("Calculator — Complete-mode layout breakpoints", () => {
+  describe("results sidebar only appears when there is enough space (2xl / ≥1536px)", () => {
+    it("hides the sidebar below 2xl (hidden 2xl:flex) instead of xl", () => {
+      expect(calculatorSource).toMatch(/hidden 2xl:flex/);
+      expect(calculatorSource).not.toMatch(/hidden xl:flex/);
+    });
+
+    it("renders the results sidebar at the 2xl width (360px) without xl widths", () => {
+      expect(calculatorSource).toMatch(/2xl:flex[^"]*w-\[360px\]/);
+      expect(calculatorSource).not.toMatch(/xl:w-\[320px\]/);
+      expect(calculatorSource).not.toMatch(/w-\[280px\]/);
+    });
+
+    it("guarantees the central form never shrinks below 560px in Complete mode", () => {
+      expect(calculatorSource).toMatch(
+        /flex-1 min-w-0 2xl:min-w-\[560px\] @container/,
+      );
+    });
+
+    it("keeps the results section (mobile/tablet panel) visible up to 2xl", () => {
+      // SectionRenderer wrapper
+      expect(rendererSource).toMatch(/id="section-results"[^>]*2xl:hidden/);
+      expect(rendererSource).not.toMatch(/scroll-mt-24 xl:hidden/);
+      // ResultsPanel mobile variant wrapper
+      expect(resultsPanelSource).toMatch(/space-y-4 2xl:hidden/);
+      expect(resultsPanelSource).not.toMatch(/space-y-4 lg:hidden/);
+    });
+  });
+
+  describe("breakpoint matrix (390 → 2000px)", () => {
+    const matrix = [
+      {
+        width: 390,
+        breakpoint: null,
+        sidebar: "hidden",
+        resultsSection: "visible",
+      },
+      {
+        width: 768,
+        breakpoint: "md",
+        sidebar: "hidden",
+        resultsSection: "visible",
+      },
+      {
+        width: 1024,
+        breakpoint: "lg",
+        sidebar: "hidden",
+        resultsSection: "visible",
+      },
+      {
+        width: 1280,
+        breakpoint: "xl",
+        sidebar: "hidden",
+        resultsSection: "visible",
+      },
+      {
+        width: 1440,
+        breakpoint: "xl",
+        sidebar: "hidden",
+        resultsSection: "visible",
+      },
+      {
+        width: 1536,
+        breakpoint: "2xl",
+        sidebar: "visible",
+        resultsSection: "hidden",
+      },
+      {
+        width: 2000,
+        breakpoint: "2xl",
+        sidebar: "visible",
+        resultsSection: "hidden",
+      },
+    ];
+
+    it.each(matrix)("$width px → $breakpoint", ({ width, breakpoint }) => {
+      expect(tailwindBreakpoint(width)).toBe(breakpoint);
+    });
+
+    it.each(matrix)(
+      "at $width px the sidebar visibility matches the class contract",
+      ({ width, sidebar, resultsSection }) => {
+        const is2xl = tailwindBreakpoint(width) === "2xl";
+        // Sidebar: `hidden` base + `2xl:flex` → visible only ≥1536
+        expect(sidebar).toBe(is2xl ? "visible" : "hidden");
+        // Inline results section: `2xl:hidden` → hidden only ≥1536
+        expect(resultsSection).toBe(is2xl ? "hidden" : "visible");
+        // Class-level contract
+        expect(calculatorSource).toMatch(/hidden 2xl:flex/);
+        expect(rendererSource).toMatch(/section-results[^>]*2xl:hidden/);
+        expect(resultsPanelSource).toMatch(/space-y-4 2xl:hidden/);
+      },
+    );
   });
 });

--- a/src/shared/components/Calculator/sections/FailureSection.tsx
+++ b/src/shared/components/Calculator/sections/FailureSection.tsx
@@ -71,7 +71,7 @@ export function FailureSection({
 				<div
 					className={`space-y-4 transition-all duration-300 ${failureEnabled ? "" : "opacity-40 pointer-events-none"}`}
 				>
-					<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+					<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 						<Select
 							label={t("calc.failure.mode")}
 							value={failureMode === "none" ? "percent" : failureMode}

--- a/src/shared/components/Calculator/sections/FixedCostsSection.tsx
+++ b/src/shared/components/Calculator/sections/FixedCostsSection.tsx
@@ -41,7 +41,7 @@ export function FixedCostsSection({
 				/>
 			</div>
 			{store.fixedCosts.enabled && (
-				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 					<InputGroup
 						label={t('calc.fixedCost.monthlyCost')}
 						value={store.fixedCosts.monthlyCost}

--- a/src/shared/components/Calculator/sections/HardwareSection.tsx
+++ b/src/shared/components/Calculator/sections/HardwareSection.tsx
@@ -30,7 +30,7 @@ export function HardwareSection() {
 			/>
 			{isFDM && (
 				<>
-					<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+					<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 						<div className="space-y-4">
 							<div className="flex items-center justify-between border-b border-[var(--color-border)] pb-2">
 								<span className="text-xs font-semibold text-[var(--color-info)]">
@@ -253,7 +253,7 @@ export function HardwareSection() {
 								{t("calc.resinHardware")}
 							</span>
 						</div>
-						<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+						<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 							<InputGroup
 								label={t("calc.lcdCost")}
 								value={store.resinHardware.lcdCost}

--- a/src/shared/components/Calculator/sections/LaborSection.tsx
+++ b/src/shared/components/Calculator/sections/LaborSection.tsx
@@ -32,7 +32,7 @@ export function LaborSection({
 				t('calc.sectionDesc.labor'),
 				'labor',
 			)}
-			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 				<InputGroup
 					label={t('calc.setupTime')}
 					value={

--- a/src/shared/components/Calculator/sections/MachineSection.tsx
+++ b/src/shared/components/Calculator/sections/MachineSection.tsx
@@ -33,7 +33,7 @@ export function MachineSection({
 				t('calc.sectionDesc.machine'),
 				'machine',
 			)}
-			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 				<InputGroup
 					label={t('calc.machineCost')}
 					value={
@@ -106,7 +106,7 @@ export function MachineSection({
 					unit="h/mês"
 					tooltip={t('tooltip.hoursPerMonth')}
 				/>
-				<div className="@md:col-span-2 flex items-center justify-between surface rounded-xl p-4 sm:p-5">
+				<div className="@form:col-span-2 flex items-center justify-between surface rounded-xl p-4 sm:p-5">
 				<span className="text-xs text-[var(--color-text-secondary)]">
 					{t('calc.maintenance')}
 				</span>
@@ -132,7 +132,7 @@ export function MachineSection({
 				{(isFDM
 					? store.fdmMachine.maintenanceEnabled
 					: store.resinMachine.maintenanceEnabled) && (
-					<div className="@md:col-span-2">
+					<div className="@form:col-span-2">
 						<InputGroup
 							label={t('calc.maintenanceCost')}
 							value={

--- a/src/shared/components/Calculator/sections/MaterialSection.tsx
+++ b/src/shared/components/Calculator/sections/MaterialSection.tsx
@@ -143,8 +143,9 @@ export function MaterialSection({
 						</div>
 					)}
 					{store.fdmAmsEnabled ? (
-						<div className="space-y-2">
-							{store.fdmAmsSlots.map((slot: AMSSlot, i: number) => (
+						<>
+							<div className="space-y-2">
+								{store.fdmAmsSlots.map((slot: AMSSlot, i: number) => (
 								<div
 									key={i}
 									className="surface rounded-xl p-3 border-l-4"
@@ -246,6 +247,15 @@ export function MaterialSection({
 								</div>
 							))}
 						</div>
+						<div className="w-full min-w-0 mt-3">
+							<StlPreview
+								onFileParsed={handleStlParsed}
+								onClear={handleStlClear}
+								materialDensity={store.fdmMaterial.density}
+								infillPercent={store.infillPercent}
+							/>
+						</div>
+						</>
 					) : (
 						<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 							<Select
@@ -391,6 +401,14 @@ export function MaterialSection({
 									tooltip={t('tooltip.density')}
 								/>
 							)}
+							<div className="w-full min-w-0 @form:col-span-2">
+								<StlPreview
+									onFileParsed={handleStlParsed}
+									onClear={handleStlClear}
+									materialDensity={store.fdmMaterial.density}
+									infillPercent={store.infillPercent}
+								/>
+							</div>
 						</div>
 					)}
 
@@ -467,15 +485,6 @@ export function MaterialSection({
 							</div>
 						)
 					})()}
-
-					<div className="w-full min-w-0 @form:col-span-2 mt-3">
-						<StlPreview
-							onFileParsed={handleStlParsed}
-							onClear={handleStlClear}
-							materialDensity={store.fdmMaterial.density}
-							infillPercent={store.infillPercent}
-						/>
-					</div>
 				</>
 			) : (
 				<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">

--- a/src/shared/components/Calculator/sections/MaterialSection.tsx
+++ b/src/shared/components/Calculator/sections/MaterialSection.tsx
@@ -247,7 +247,7 @@ export function MaterialSection({
 							))}
 						</div>
 					) : (
-						<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+						<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 							<Select
 								label={t("calc.filamentType")}
 								value={store.fdmMaterial.type}
@@ -468,7 +468,7 @@ export function MaterialSection({
 						)
 					})()}
 
-					<div className="w-full min-w-0 @md:col-span-2 mt-3">
+					<div className="w-full min-w-0 @form:col-span-2 mt-3">
 						<StlPreview
 							onFileParsed={handleStlParsed}
 							onClear={handleStlClear}
@@ -478,7 +478,7 @@ export function MaterialSection({
 					</div>
 				</>
 			) : (
-				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 					<Select
 						label={t("calc.resinType")}
 						value={store.resinMaterial.type}

--- a/src/shared/components/Calculator/sections/OpsSection.tsx
+++ b/src/shared/components/Calculator/sections/OpsSection.tsx
@@ -24,7 +24,7 @@ export function OpsSection() {
 				subtitle={t("calc.sectionDesc.ops")}
 				sectionId="ops"
 			/>
-			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 				<div>
 				<div className="flex items-center justify-between border-b border-[var(--color-border)] pb-2 mb-3">
 					<span className="text-xs font-semibold text-[var(--color-text-secondary)]">

--- a/src/shared/components/Calculator/sections/PrintSection.tsx
+++ b/src/shared/components/Calculator/sections/PrintSection.tsx
@@ -45,7 +45,7 @@ export function PrintSection({
 				t("calc.sectionDesc.print"),
 				"print",
 			)}
-			<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+			<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 				<InputGroup
 					label={t("calc.printTime")}
 					value={
@@ -120,7 +120,7 @@ export function PrintSection({
 					tooltip={t('tooltip.energyCostPerKwh')}
 				/>
 				{isFDM && isFieldVisible("print", "selectedPrinter") && (
-					<div className="@md:col-span-2">
+					<div className="@form:col-span-2">
 						<Select
 							label={t("calc.printer")}
 							value={store.selectedPrinter.id}

--- a/src/shared/components/Calculator/sections/SalesSection.tsx
+++ b/src/shared/components/Calculator/sections/SalesSection.tsx
@@ -60,7 +60,7 @@ export function SalesSection() {
 				sectionId="sales"
 			/>
 			<div className="space-y-4">
-				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 					<InputGroup
 						label={t("calc.quantity")}
 						value={store.quantity}
@@ -104,7 +104,7 @@ export function SalesSection() {
 						tooltip={t("tooltip.extras")}
 					/>
 				)}
-				<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+				<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 					<InputGroup
 						label={t("calc.packaging")}
 						value={
@@ -158,7 +158,7 @@ export function SalesSection() {
 				</div>
 				{isFieldVisible("sales", "marketplace") && (
 					<>
-						<div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
+						<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
 							<Select
 								label={t("calc.marketplace")}
 								value={store.selectedMarketplace.id}

--- a/src/shared/components/Calculator/sections/SectionHeader.tsx
+++ b/src/shared/components/Calculator/sections/SectionHeader.tsx
@@ -1,9 +1,9 @@
 import { Settings } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { LucideIcon } from "lucide-react";
 import { useCalculatorStore } from "@/shared/stores/calculatorStore";
 import { useShallow } from "zustand/react/shallow";
+import { useDismissablePopover } from "@/shared/hooks/useDismissablePopover";
 import { INTERMEDIATE_FIELDS, FIELD_LABELS } from "../Calculator.constants";
 
 interface SectionHeaderProps {
@@ -19,27 +19,11 @@ export function SectionHeader({ Icon, title, subtitle, sectionId }: SectionHeade
 		useShallow((s) => ({ calcLevel: s.calcLevel, hiddenFields: s.hiddenFields, toggleField: s.toggleField })),
 	);
 
-	const [isOpen, setIsOpen] = useState(false);
-	const ref = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		if (!isOpen) return;
-		const handleClickOutside = (e: MouseEvent) => {
-			if (ref.current && !ref.current.contains(e.target as Node)) {
-				setIsOpen(false);
-			}
-		};
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => document.removeEventListener("mousedown", handleClickOutside);
-	}, [isOpen]);
+	const { open: isOpen, toggle: handleToggle, triggerRef, contentRef } = useDismissablePopover<HTMLButtonElement>();
 
 	const isCustomizable = sectionId
 		&& INTERMEDIATE_FIELDS[sectionId]?.length > 0
 		&& calcLevel !== "basic";
-
-	const handleToggle = useCallback(() => {
-		setIsOpen((prev) => !prev);
-	}, []);
 
 	return (
 		<div className="flex items-center gap-2 mb-2 pb-1.5 border-b border-[var(--color-border)]">
@@ -51,17 +35,20 @@ export function SectionHeader({ Icon, title, subtitle, sectionId }: SectionHeade
 				)}
 			</div>
 			{isCustomizable && sectionId && (
-				<div className="relative" ref={isOpen ? ref : undefined}>
+				<div className="relative">
 					<button
 						type="button"
+						ref={triggerRef}
 						onClick={handleToggle}
 						className="min-h-[44px] min-w-[44px] p-1 rounded-md hover:bg-[var(--color-bg-hover)] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
 						title={t("calc.customizeFields")}
+						aria-haspopup="menu"
+						aria-expanded={isOpen}
 					>
 						<Settings className="w-3.5 h-3.5" />
 					</button>
 					{isOpen && (
-					<div className="absolute right-0 top-8 z-50 w-56 surface border border-[var(--color-border)] rounded-xl p-2 shadow-xl">
+					<div ref={contentRef} role="menu" aria-label={t("calc.customizeFields")} className="absolute right-0 top-8 z-50 w-56 surface border border-[var(--color-border)] rounded-xl p-2 shadow-xl">
 						<p className="text-[10px] font-semibold text-[var(--color-text-muted)] px-2 py-1 uppercase tracking-wide">
 								{t("calc.customizeFields")}
 							</p>

--- a/src/shared/components/Calculator/sections/__tests__/MaterialSection.test.tsx
+++ b/src/shared/components/Calculator/sections/__tests__/MaterialSection.test.tsx
@@ -396,4 +396,28 @@ describe('MaterialSection', () => {
 		)
 		expect(store.setFdmMaterial).not.toHaveBeenCalled()
 	})
+
+	it('places the STL preview inside the material grid so col-span applies', () => {
+		const store = createMockStore()
+		const { container } = render(<MaterialSection {...defaultProps} store={store} isFDM={true} />)
+		const stl = container.querySelector('[data-testid="mock-stl-preview"]')
+		expect(stl).not.toBeNull()
+		// STL wrapper must be a grid child with col-span-2
+		const wrapper = stl!.parentElement!
+		expect(wrapper.className).toContain('@form:col-span-2')
+		// The wrapper must live INSIDE the grid container
+		const grid = wrapper.parentElement!
+		expect(grid.className).toContain('grid grid-cols-1')
+		expect(grid.className).toContain('@form:grid-cols-2')
+	})
+
+	it('keeps a full-width STL preview in AMS mode (no grid context)', () => {
+		const store = createMockStore({ fdmAmsEnabled: true })
+		const { container } = render(<MaterialSection {...defaultProps} store={store} isFDM={true} />)
+		const stl = container.querySelector('[data-testid="mock-stl-preview"]')
+		expect(stl).not.toBeNull()
+		const wrapper = stl!.parentElement!
+		expect(wrapper.className).toContain('mt-3')
+		expect(wrapper.className).not.toContain('col-span-2')
+	})
 })

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -50,7 +50,7 @@ export function Header() {
         borderColor: 'var(--color-border)',
       }}
     >
-      <div className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-12 h-[68px] flex items-center justify-between gap-2 sm:gap-4">
+      <div className="max-w-[1600px] 2xl:max-w-[1920px] mx-auto px-4 sm:px-6 lg:px-12 h-[68px] flex items-center justify-between gap-2 sm:gap-4">
 
         {/* Logo — clickable on mobile to open settings */}
         <button

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { createPortal } from 'react-dom'
 import { Box, Globe, ChevronDown, BookOpen, DollarSign, Info, X } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -7,6 +8,7 @@ import { useCalculatorStore } from '@/shared/stores/calculatorStore'
 import { useTutorialStore } from '@/shared/stores/tutorialStore'
 import { CURRENCIES, type CurrencyCode } from '@/shared/lib/currency'
 import { useCurrency } from '@/shared/hooks/useCurrency'
+import { useDismissablePopover } from '@/shared/hooks/useDismissablePopover'
 import { ThemeToggle } from './ThemeToggle'
 
 export function Header() {
@@ -15,24 +17,30 @@ export function Header() {
     useShallow((s) => ({ currency: s.currency, setCurrency: s.setCurrency })),
   )
   const { symbol } = useCurrency()
-  const [showCurrencyMenu, setShowCurrencyMenu] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
+  const {
+    open: currencyMenuOpen,
+    toggle: toggleCurrencyMenu,
+    triggerRef: currencyTriggerRef,
+    contentRef: currencyMenuContentRef,
+  } = useDismissablePopover<HTMLButtonElement>()
+  const [currencyMenuPos, setCurrencyMenuPos] = useState<{ top: number; right: number } | null>(null)
 
   const toggleLanguage = () => {
     const next = i18n.language === 'pt-BR' ? 'en-US' : 'pt-BR'
     i18n.changeLanguage(next)
   }
 
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setShowCurrencyMenu(false)
-      }
+  const handleCurrencyToggle = () => {
+    if (!currencyMenuOpen && currencyTriggerRef.current) {
+      const rect = currencyTriggerRef.current.getBoundingClientRect()
+      setCurrencyMenuPos({
+        top: rect.bottom + 6,
+        right: Math.max(12, window.innerWidth - rect.right),
+      })
     }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [])
+    toggleCurrencyMenu()
+  }
 
   return (
     <header
@@ -42,7 +50,7 @@ export function Header() {
         borderColor: 'var(--color-border)',
       }}
     >
-      <div className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-12 h-[68px] flex items-center justify-between gap-2 sm:gap-4 overflow-hidden">
+      <div className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-12 h-[68px] flex items-center justify-between gap-2 sm:gap-4">
 
         {/* Logo — clickable on mobile to open settings */}
         <button
@@ -90,9 +98,13 @@ export function Header() {
             </button>
 
             {/* Currency selector */}
-            <div ref={menuRef} className="relative">
+            <div className="flex items-center">
               <button
-                onClick={() => setShowCurrencyMenu(v => !v)}
+                ref={currencyTriggerRef}
+                onClick={handleCurrencyToggle}
+                aria-haspopup="menu"
+                aria-expanded={currencyMenuOpen}
+                aria-controls="header-currency-menu"
                 className="flex items-center gap-1 text-[13px] font-semibold px-3 py-2.5 rounded-lg min-h-[44px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
                 title={t('settings.currency')}
               >
@@ -103,31 +115,44 @@ export function Header() {
                 <ChevronDown className="w-3 h-3 opacity-40" />
               </button>
 
-              {showCurrencyMenu && (
-                <div className="absolute right-0 top-full mt-1.5 w-44 rounded-xl shadow-2xl z-50 overflow-hidden surface border border-[var(--color-border)]">
-                  <button
-                    onClick={() => { setCurrency('auto'); setShowCurrencyMenu(false) }}
-                    className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === 'auto' ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
+              {currencyMenuOpen &&
+                currencyMenuPos &&
+                typeof document !== 'undefined' &&
+                createPortal(
+                  <div
+                    ref={currencyMenuContentRef}
+                    id="header-currency-menu"
+                    role="menu"
+                    aria-label={t('settings.currency')}
+                    className="fixed z-[60] w-44 rounded-xl shadow-2xl overflow-hidden surface border border-[var(--color-border)]"
+                    style={{ position: 'fixed', top: currencyMenuPos.top, right: currencyMenuPos.right }}
                   >
-                    <span className="font-mono font-bold w-6">{symbol}</span>
-                    <span>{t('settings.currencyAuto')}</span>
-                    {currencySetting === 'auto' && <span className="ml-auto text-[var(--color-accent)]">✓</span>}
-                  </button>
-                  <div className="border-t border-[var(--color-border)]" />
-                  {(Object.entries(CURRENCIES) as [CurrencyCode, typeof CURRENCIES[CurrencyCode]][]).map(([code, info]) => (
                     <button
-                      key={code}
-                      onClick={() => { setCurrency(code); setShowCurrencyMenu(false) }}
-                      className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === code ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
+                      role="menuitem"
+                      onClick={() => { setCurrency('auto'); toggleCurrencyMenu() }}
+                      className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === 'auto' ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
                     >
-                      <span className="font-mono font-bold w-6">{info.symbol}</span>
-                      <span>{code}</span>
-                      <span className="text-[10px] text-[var(--color-text-muted)] ml-auto">{info.name}</span>
-                      {currencySetting === code && <span className="text-[var(--color-accent)] ml-1">✓</span>}
+                      <span className="font-mono font-bold w-6">{symbol}</span>
+                      <span>{t('settings.currencyAuto')}</span>
+                      {currencySetting === 'auto' && <span className="ml-auto text-[var(--color-accent)]">✓</span>}
                     </button>
-                  ))}
-                </div>
-              )}
+                    <div className="border-t border-[var(--color-border)]" />
+                    {(Object.entries(CURRENCIES) as [CurrencyCode, typeof CURRENCIES[CurrencyCode]][]).map(([code, info]) => (
+                      <button
+                        key={code}
+                        role="menuitem"
+                        onClick={() => { setCurrency(code); toggleCurrencyMenu() }}
+                        className={`w-full px-3.5 py-2.5 text-left text-[12px] flex items-center gap-2 hover:bg-[var(--color-bg-hover)] transition-colors ${currencySetting === code ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-primary)]'}`}
+                      >
+                        <span className="font-mono font-bold w-6">{info.symbol}</span>
+                        <span>{code}</span>
+                        <span className="text-[10px] text-[var(--color-text-muted)] ml-auto">{info.name}</span>
+                        {currencySetting === code && <span className="text-[var(--color-accent)] ml-1">✓</span>}
+                      </button>
+                    ))}
+                  </div>,
+                  document.body,
+                )}
             </div>
 
             {/* Language toggle */}
@@ -199,9 +224,9 @@ export function Header() {
                   <span className="text-sm font-medium">{t('nav.tutorial')}</span>
                 </button>
 
-                {/* Currency */}
+                {/* Currency — desktop selector handles changes; close the sheet here */}
                 <button
-                  onClick={() => setShowCurrencyMenu(true)}
+                  onClick={() => setShowSettings(false)}
                   className="w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none min-h-[48px]"
                 >
                   <DollarSign className="w-[18px] h-[18px] shrink-0 text-[var(--color-accent-light)]" />

--- a/src/shared/components/Header/__tests__/Header.test.tsx
+++ b/src/shared/components/Header/__tests__/Header.test.tsx
@@ -59,6 +59,61 @@ describe('Header', () => {
     expect(screen.getByText('app.title')).toBeInTheDocument()
   })
 
+  describe('currency dropdown — portal, z-index, Escape and aria', () => {
+    it('renders the currency menu in a portal directly under body', async () => {
+      render(<Header />)
+      await user.click(screen.getByTitle('settings.currency'))
+      const menu = screen.getByRole('menu')
+      expect(menu).toBeInTheDocument()
+      expect(menu.parentElement).toBe(document.body)
+    })
+
+    it('exposes menu semantics on the trigger (haspopup/expanded/controls)', async () => {
+      render(<Header />)
+      const trigger = screen.getByTitle('settings.currency')
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+      expect(trigger).toHaveAttribute('aria-controls', 'header-currency-menu')
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+      await user.click(trigger)
+      expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('is positioned fixed with a high z-index so content never covers it', async () => {
+      render(<Header />)
+      await user.click(screen.getByTitle('settings.currency'))
+      const menu = screen.getByRole('menu')
+      expect(menu.className).toContain('z-[60]')
+      expect(menu).toHaveStyle({ position: 'fixed' })
+    })
+
+    it('closes on Escape and restores focus to the trigger', async () => {
+      render(<Header />)
+      const trigger = screen.getByTitle('settings.currency')
+      await user.click(trigger)
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+      await user.keyboard('{Escape}')
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      expect(trigger).toHaveFocus()
+    })
+
+    it('closes on click outside', async () => {
+      render(<Header />)
+      await user.click(screen.getByTitle('settings.currency'))
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+      await user.click(document.body)
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+
+    it('header container does not clip dropdowns (no overflow-hidden)', () => {
+      const { container } = render(<Header />)
+      const inner = Array.from(container.querySelectorAll('div')).find((el) =>
+        el.className.includes('h-[68px]'),
+      )
+      expect(inner).toBeDefined()
+      expect(inner!.className).not.toContain('overflow-hidden')
+    })
+  })
+
   it('renders beta badge', () => {
     render(<Header />)
     expect(screen.getByText('Beta')).toBeInTheDocument()

--- a/src/shared/components/StlPreview/StlPreview.tsx
+++ b/src/shared/components/StlPreview/StlPreview.tsx
@@ -422,7 +422,7 @@ export function StlPreview({
 
       {/* 3D Preview */}
       {geometry && !isFullscreen && (
-        <div className="surface rounded-xl overflow-hidden min-h-[300px] sm:min-h-[400px]">
+        <div className="surface rounded-xl overflow-hidden aspect-[4/3] min-h-[300px] sm:min-h-[400px] h-full">
           <PreviewCanvas
             geometry={geometry}
             onToggleFullscreen={() => setIsFullscreen(true)}

--- a/src/shared/components/ui/InputGroup.tsx
+++ b/src/shared/components/ui/InputGroup.tsx
@@ -25,7 +25,7 @@ export function InputGroup({
   return (
     <div className={`flex flex-col gap-2 ${className}`}>
       <div className="flex items-start gap-2 min-h-[2.5rem]">
-        <label htmlFor={id} className={`text-[11px] font-semibold uppercase tracking-wider ${error ? 'text-[var(--color-danger)]' : 'text-[var(--color-text-muted)]'}`}>
+        <label htmlFor={id} className={`text-[12px] font-semibold uppercase tracking-wider ${error ? 'text-[var(--color-danger)]' : 'text-[var(--color-text-secondary)]'}`}>
           {label}
         </label>
         {tooltip && (
@@ -77,7 +77,7 @@ export function SelectGroup({ label, value, onChange, options }: SelectGroupProp
 
   return (
     <div className="flex flex-col gap-2">
-      <label htmlFor={id} className="text-[12px] sm:text-[11px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">{label}</label>
+      <label htmlFor={id} className="text-[12px] sm:text-[12px] font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">{label}</label>
       <select
         id={id}
         value={value}

--- a/src/shared/components/ui/Select/Select.tsx
+++ b/src/shared/components/ui/Select/Select.tsx
@@ -193,7 +193,7 @@ export function Select({
   return (
     <div className={`relative flex flex-col gap-1.5 ${className}`}>
       <div className="min-h-[2.5rem] flex items-start">
-        <label htmlFor={`${id}-trigger`} className="text-[11px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <label htmlFor={`${id}-trigger`} className="text-[12px] font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
           {label}
         </label>
       </div>

--- a/src/shared/hooks/useDismissablePopover.ts
+++ b/src/shared/hooks/useDismissablePopover.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Manages a dismissable popover/dropdown with:
+ * - Escape to close (focus returns to the trigger)
+ * - Click/touch outside to close
+ * - Portal-friendly: pass `contentRef` to the portaled content node and
+ *   `triggerRef` to the trigger button — both are checked by the outside
+ *   click handler regardless of where the content is rendered.
+ */
+export function useDismissablePopover<T extends HTMLElement = HTMLButtonElement>(
+  initialOpen = false,
+) {
+  const [open, setOpen] = useState(initialOpen)
+  const triggerRef = useRef<T>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const close = useCallback(() => setOpen(false), [])
+  const toggle = useCallback(() => setOpen((v) => !v), [])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close()
+        triggerRef.current?.focus()
+      }
+    }
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (triggerRef.current?.contains(target)) return
+      if (contentRef.current?.contains(target)) return
+      close()
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('mousedown', onPointerDown)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('mousedown', onPointerDown)
+    }
+  }, [open, close])
+
+  return { open, setOpen, close, toggle, triggerRef, contentRef }
+}


### PR DESCRIPTION
## What
Final visual polish addressing remaining layout issues:

### Results sidebar (Complete mode)
- Sidebar now shows only at `2xl` (≥1536px) with `w-[360px]`; form keeps `2xl:min-w-[560px]`
- Results remain accessible inline at 1024–1535 (panel `2xl:hidden`, section `2xl:hidden`)
- Custom container breakpoint `--container-form: 38rem`; section grids converted `@md:` → `@form:` so 2 columns only appear with real space

### Dropdowns (language/currency)
- New `useDismissablePopover` hook: Escape returns focus, click-outside, portal refs
- Header menus now portal to `document.body` with `position: fixed`, `z-[60]`, `role=menu`, full ARIA
- Removed `overflow-hidden` that was clipping the currency menu

### Ultrawide / overflow
- Shell/header `max-w-[1600px] 2xl:max-w-[1920px]`
- `overflow-x-clip` instead of hidden (preserves sticky nav/sidebar)
- Defined `--color-border-hover`; labels 12px `text-secondary`

### STL preview in grid
- Moved StlPreview inside Material grid as last child (`@form:col-span-2`), AMS keeps full-width copy
- Stable `aspect-[4/3]` canvas

## Validation
- 792 tests passing (Calculator 18, Header 18, layoutShell 15, MaterialSection 30)
- lint, typecheck, coverage clean
- Themis APPROVED (7 non-blocking notes)
- No releases/tags/assets changed
