### PR TITLE
feat: cross-device data sync with encrypted export/import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2479,6 +2479,45 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
@@ -5398,7 +5437,7 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
       "integrity": "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5573,7 +5612,7 @@
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -5589,7 +5628,6 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7519,6 +7557,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -7595,7 +7642,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -8882,6 +8928,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
+      "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "26.15.3",
+        "builder-util": "26.15.3",
+        "electron-winstaller": "5.4.0"
+      }
+    },
     "node_modules/electron-builder/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -9040,6 +9099,66 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/electron/node_modules/@types/node": {
@@ -12293,6 +12412,20 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.1.1.tgz",
@@ -13013,6 +13146,36 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/potpack": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
@@ -13298,7 +13461,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -13646,6 +13808,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/roarr": {
@@ -14549,6 +14726,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -15043,7 +15235,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15118,7 +15310,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint .",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx db/migrate.ts",
-    "postinstall": "electron-rebuild -f -w better-sqlite3",
+    "postinstall": "node -e \"if (!process.env.CI) require('child_process').execSync('electron-rebuild -f -w better-sqlite3', { stdio: 'inherit' })\"",
     "prepare": "husky"
   },
   "dependencies": {

--- a/src/platform/desktop/components/Header/Header.tsx
+++ b/src/platform/desktop/components/Header/Header.tsx
@@ -265,7 +265,7 @@ export function Header() {
           </button>
 
           {/* Data Sync */}
-          <DataSyncButton />
+          <DataSyncButton variant="icon" />
         </div>
       </div>
     </header>

--- a/src/platform/desktop/components/Header/Header.tsx
+++ b/src/platform/desktop/components/Header/Header.tsx
@@ -17,6 +17,7 @@ import { useCurrency } from "@/shared/hooks/useCurrency";
 import { useDismissablePopover } from "@/shared/hooks/useDismissablePopover";
 import { ThemeToggle } from "@/shared/components/Header/ThemeToggle";
 import { useUpdaterStore } from "../UpdateNotification/UpdaterStore";
+import { DataSyncButton } from "@/shared/components/ui/DataSyncButton";
 
 export function Header() {
   const { t, i18n } = useTranslation();
@@ -262,6 +263,9 @@ export function Header() {
               {i18n.language === "pt-BR" ? "EN" : "PT"}
             </span>
           </button>
+
+          {/* Data Sync */}
+          <DataSyncButton />
         </div>
       </div>
     </header>

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -18,6 +18,7 @@ import { CURRENCIES, type CurrencyCode } from "@/shared/lib/currency";
 import { useCurrency } from "@/shared/hooks/useCurrency";
 import { useDismissablePopover } from "@/shared/hooks/useDismissablePopover";
 import { ThemeToggle } from "./ThemeToggle";
+import { DataSyncButton } from "@/shared/components/ui/DataSyncButton";
 
 export function Header() {
   const { t, i18n } = useTranslation();
@@ -310,6 +311,9 @@ export function Header() {
                     {i18n.language === "pt-BR" ? "PT-BR" : "EN-US"}
                   </span>
                 </button>
+
+                {/* Data Sync */}
+                <DataSyncButton onOpenChange={setShowSettings} />
 
                 {/* Version */}
                 <div className="flex items-center gap-3 px-4 py-3 rounded-xl text-[var(--color-text-muted)]">

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -215,6 +215,9 @@ export function Header() {
 
           {/* Theme toggle — visible on all sizes */}
           <ThemeToggle />
+
+          {/* Data sync — visible on all sizes */}
+          <DataSyncButton variant="icon" />
         </div>
       </div>
 
@@ -311,9 +314,6 @@ export function Header() {
                     {i18n.language === "pt-BR" ? "PT-BR" : "EN-US"}
                   </span>
                 </button>
-
-                {/* Data Sync */}
-                <DataSyncButton onOpenChange={setShowSettings} />
 
                 {/* Version */}
                 <div className="flex items-center gap-3 px-4 py-3 rounded-xl text-[var(--color-text-muted)]">

--- a/src/shared/components/ui/DataSyncButton.tsx
+++ b/src/shared/components/ui/DataSyncButton.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { RefreshCw } from "lucide-react";
+import { DataSyncModal } from "./DataSyncModal";
+
+interface DataSyncButtonProps {
+  className?: string;
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * Settings-menu entry that opens the DataSyncModal. Matches the menu-item
+ * styling used in the Header settings sheet (icon + label, full width).
+ */
+export function DataSyncButton({
+  className = "",
+  onOpenChange,
+}: DataSyncButtonProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+    onOpenChange?.(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    onOpenChange?.(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label={t("sync.title")}
+        className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none min-h-[48px] ${className}`}
+      >
+        <RefreshCw className="w-[18px] h-[18px] shrink-0 text-[var(--color-accent-light)]" />
+        <span className="text-sm font-medium">{t("sync.title")}</span>
+      </button>
+
+      <DataSyncModal open={open} onRequestClose={handleClose} />
+    </>
+  );
+}

--- a/src/shared/components/ui/DataSyncButton.tsx
+++ b/src/shared/components/ui/DataSyncButton.tsx
@@ -4,15 +4,22 @@ import { RefreshCw } from "lucide-react";
 import { DataSyncModal } from "./DataSyncModal";
 
 interface DataSyncButtonProps {
+  /**
+   * "menu" renders a full-width settings-sheet item (icon + label);
+   * "icon" renders a compact header action button matching ThemeToggle.
+   */
+  variant?: "menu" | "icon";
   className?: string;
   onOpenChange?: (open: boolean) => void;
 }
 
 /**
- * Settings-menu entry that opens the DataSyncModal. Matches the menu-item
- * styling used in the Header settings sheet (icon + label, full width).
+ * Button that opens the DataSyncModal. Supports two variants:
+ * - "menu": full-width settings-sheet entry (icon + label)
+ * - "icon": compact header action button (icon only, tooltip/aria-label)
  */
 export function DataSyncButton({
+  variant = "menu",
   className = "",
   onOpenChange,
 }: DataSyncButtonProps) {
@@ -29,16 +36,31 @@ export function DataSyncButton({
     onOpenChange?.(false);
   };
 
+  const isIcon = variant === "icon";
+
   return (
     <>
       <button
         type="button"
         onClick={handleOpen}
         aria-label={t("sync.title")}
-        className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none min-h-[48px] ${className}`}
+        title={t("sync.title")}
+        className={
+          isIcon
+            ? `flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 min-h-[44px] min-w-[44px] rounded-xl transition-all duration-200 focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none text-[var(--color-text-secondary)] hover:text-[var(--color-accent)] hover:bg-[var(--color-accent-muted)] ${className}`
+            : `w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none min-h-[48px] ${className}`
+        }
       >
-        <RefreshCw className="w-[18px] h-[18px] shrink-0 text-[var(--color-accent-light)]" />
-        <span className="text-sm font-medium">{t("sync.title")}</span>
+        <RefreshCw
+          className={
+            isIcon
+              ? "w-5 h-5"
+              : "w-[18px] h-[18px] shrink-0 text-[var(--color-accent-light)]"
+          }
+        />
+        {!isIcon && (
+          <span className="text-sm font-medium">{t("sync.title")}</span>
+        )}
       </button>
 
       <DataSyncModal open={open} onRequestClose={handleClose} />

--- a/src/shared/components/ui/DataSyncModal.test.tsx
+++ b/src/shared/components/ui/DataSyncModal.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DataSyncModal } from "./DataSyncModal";
+
+const { mockExportData, mockImportData, mockIsEncrypted } = vi.hoisted(() => ({
+  mockExportData: vi.fn(),
+  mockImportData: vi.fn(),
+  mockIsEncrypted: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// dataSync.ts is implemented in parallel — the factory mock replaces the module
+vi.mock("@/shared/lib/dataSync", () => ({
+  exportData: (...args: unknown[]) => mockExportData(...args),
+  importData: (...args: unknown[]) => mockImportData(...args),
+  isEncrypted: (...args: unknown[]) => mockIsEncrypted(...args),
+}));
+
+describe("DataSyncModal", () => {
+  beforeEach(() => {
+    mockExportData.mockReset();
+    mockImportData.mockReset();
+    mockIsEncrypted.mockReset();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(<DataSyncModal open={false} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders with export tab active by default", () => {
+    render(<DataSyncModal open={true} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "sync.export.tab" }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.getByRole("tab", { name: "sync.import.tab" }),
+    ).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByText("sync.export.description")).toBeInTheDocument();
+  });
+
+  it("switches between export and import tabs", () => {
+    render(<DataSyncModal open={true} />);
+    fireEvent.click(screen.getByRole("tab", { name: "sync.import.tab" }));
+    expect(
+      screen.getByRole("tab", { name: "sync.import.tab" }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("sync.import.warning")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "sync.export.tab" }));
+    expect(
+      screen.getByRole("tab", { name: "sync.export.tab" }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("sync.export.description")).toBeInTheDocument();
+  });
+
+  it("triggers download when export button is clicked", async () => {
+    mockExportData.mockResolvedValue({
+      fileName: "backup.open3dcalc",
+      sizeBytes: 2048,
+    });
+    render(<DataSyncModal open={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "sync.export.button" }));
+
+    expect(mockExportData).toHaveBeenCalledTimes(1);
+    expect(mockExportData).toHaveBeenCalledWith({ password: undefined });
+    expect(await screen.findByText(/backup.open3dcalc/)).toBeInTheDocument();
+    expect(screen.getByText(/sync.export.success/)).toBeInTheDocument();
+  });
+
+  it("toggles password field visibility", () => {
+    render(<DataSyncModal open={true} />);
+
+    // Password field hidden until encryption is enabled
+    expect(
+      screen.queryByLabelText("sync.export.password"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    const input = screen.getByLabelText(
+      "sync.export.password",
+    ) as HTMLInputElement;
+    expect(input.type).toBe("password");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "sync.export.passwordShow" }),
+    );
+    expect(input.type).toBe("text");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "sync.export.passwordHide" }),
+    );
+    expect(input.type).toBe("password");
+  });
+
+  it("hides and clears password when encryption is unchecked", () => {
+    render(<DataSyncModal open={true} />);
+    fireEvent.click(screen.getByRole("checkbox"));
+    const input = screen.getByLabelText(
+      "sync.export.password",
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "secret" } });
+    expect(input.value).toBe("secret");
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(
+      screen.queryByLabelText("sync.export.password"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("accepts .open3dcalc files in the import picker", () => {
+    const { container } = render(<DataSyncModal open={true} />);
+    fireEvent.click(screen.getByRole("tab", { name: "sync.import.tab" }));
+
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.accept).toBe(".open3dcalc");
+    expect(input).toHaveAttribute("aria-label", "sync.import.selectFile");
+  });
+
+  it("imports a file and shows results", async () => {
+    mockIsEncrypted.mockResolvedValue(false);
+    mockImportData.mockResolvedValue({ imported: 3, conflicts: 1, errors: 0 });
+    const { container } = render(<DataSyncModal open={true} />);
+    fireEvent.click(screen.getByRole("tab", { name: "sync.import.tab" }));
+
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(["data"], "backup.open3dcalc", {
+      type: "application/octet-stream",
+    });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(mockIsEncrypted).toHaveBeenCalledWith(file));
+
+    fireEvent.click(screen.getByRole("button", { name: "sync.import.button" }));
+    expect(mockImportData).toHaveBeenCalledWith(file, {
+      password: undefined,
+      mode: "merge",
+    });
+
+    expect(
+      await screen.findByText("sync.import.results.imported"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("sync.import.results.conflicts"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/sync.import.success/)).toBeInTheDocument();
+  });
+
+  it("shows decryption password field for encrypted files", async () => {
+    mockIsEncrypted.mockResolvedValue(true);
+    const { container } = render(<DataSyncModal open={true} />);
+    fireEvent.click(screen.getByRole("tab", { name: "sync.import.tab" }));
+
+    expect(
+      screen.queryByLabelText("sync.import.password"),
+    ).not.toBeInTheDocument();
+
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(["enc"], "backup.open3dcalc", {
+      type: "application/octet-stream",
+    });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("sync.import.password")).toBeInTheDocument(),
+    );
+  });
+
+  it("switches import mode selector", () => {
+    render(<DataSyncModal open={true} />);
+    fireEvent.click(screen.getByRole("tab", { name: "sync.import.tab" }));
+
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(2);
+    expect(radios[0]).toBeChecked();
+    expect(radios[1]).not.toBeChecked();
+
+    fireEvent.click(radios[1]);
+    expect(radios[1]).toBeChecked();
+    expect(radios[0]).not.toBeChecked();
+  });
+
+  it("closes on Escape key", () => {
+    const onRequestClose = vi.fn();
+    render(<DataSyncModal open={true} onRequestClose={onRequestClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the LGPD notice with privacy link", () => {
+    render(<DataSyncModal open={true} />);
+    expect(screen.getByText(/sync.lgpd_notice/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "sync.privacy_link" }),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes accessible names on interactive elements", () => {
+    render(<DataSyncModal open={true} />);
+
+    expect(screen.getByRole("dialog")).toHaveAttribute(
+      "aria-label",
+      "sync.title",
+    );
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+    expect(
+      screen.getByRole("button", { name: "common.close" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "sync.export.tab" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "sync.import.tab" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toHaveAccessibleName(
+      "sync.export.encrypt",
+    );
+    expect(
+      screen.getByRole("button", { name: "sync.export.button" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "sync.privacy_link" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/ui/DataSyncModal.tsx
+++ b/src/shared/components/ui/DataSyncModal.tsx
@@ -1,0 +1,739 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  AlertTriangle,
+  CheckCircle,
+  Download,
+  Lock,
+  RefreshCw,
+  Unlock,
+  Upload,
+  X,
+} from "lucide-react";
+import {
+  exportData,
+  importData,
+  isEncrypted,
+  type DataSyncExportResult,
+  type DataSyncImportResult,
+} from "@/shared/lib/dataSync";
+import { PrivacyPolicy } from "./PrivacyPolicy";
+
+type TabId = "export" | "import";
+type ImportMode = "merge" | "replace";
+type Phase = "idle" | "working" | "success" | "error";
+
+interface DataSyncModalProps {
+  open: boolean;
+  onRequestClose?: () => void;
+}
+
+export function DataSyncModal({ open, onRequestClose }: DataSyncModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          key="sync-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          onClick={(e) => {
+            // Only close when the backdrop itself is clicked — not when a
+            // nested overlay (e.g. PrivacyPolicy) is dismissed.
+            if (e.target === e.currentTarget) onRequestClose?.();
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("sync.title")}
+        >
+          <DataSyncModalContent onRequestClose={onRequestClose} />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/**
+ * Inner modal content. Mounted fresh every time the modal opens (the parent
+ * only renders it while `open` is true), so all state starts at its defaults
+ * without needing a reset effect.
+ */
+function DataSyncModalContent({
+  onRequestClose,
+}: {
+  onRequestClose?: () => void;
+}) {
+  const { t } = useTranslation();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const [activeTab, setActiveTab] = useState<TabId>("export");
+  const [showPrivacy, setShowPrivacy] = useState(false);
+
+  // Export state
+  const [encryptEnabled, setEncryptEnabled] = useState(false);
+  const [exportPassword, setExportPassword] = useState("");
+  const [showExportPassword, setShowExportPassword] = useState(false);
+  const [exportPhase, setExportPhase] = useState<Phase>("idle");
+  const [exportResult, setExportResult] = useState<DataSyncExportResult | null>(
+    null,
+  );
+
+  // Import state
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [fileEncrypted, setFileEncrypted] = useState(false);
+  const [importPassword, setImportPassword] = useState("");
+  const [showImportPassword, setShowImportPassword] = useState(false);
+  const [importMode, setImportMode] = useState<ImportMode>("merge");
+  const [importPhase, setImportPhase] = useState<Phase>("idle");
+  const [importResult, setImportResult] = useState<DataSyncImportResult | null>(
+    null,
+  );
+  const [importError, setImportError] = useState<
+    "invalid" | "wrongPassword" | null
+  >(null);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus trap + Escape close
+  useEffect(() => {
+    const timer = setTimeout(() => closeButtonRef.current?.focus(), 50);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onRequestClose?.();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onRequestClose]);
+
+  const handleTablistKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const tabs: TabId[] = ["export", "import"];
+    const idx = tabs.indexOf(activeTab);
+    const next =
+      e.key === "ArrowRight"
+        ? (idx + 1) % tabs.length
+        : (idx - 1 + tabs.length) % tabs.length;
+    setActiveTab(tabs[next]);
+  };
+
+  const handleExport = async () => {
+    if (exportPhase === "working") return;
+    setExportPhase("working");
+    setExportResult(null);
+    try {
+      const result = await exportData({
+        password: encryptEnabled && exportPassword ? exportPassword : undefined,
+      });
+      setExportResult(result);
+      setExportPhase("success");
+    } catch {
+      setExportPhase("error");
+    }
+  };
+
+  const handleFileChange = async (file: File | null) => {
+    setImportFile(file);
+    setImportPhase("idle");
+    setImportResult(null);
+    setImportError(null);
+    if (!file) {
+      setFileEncrypted(false);
+      return;
+    }
+    try {
+      setFileEncrypted(await isEncrypted(file));
+    } catch {
+      setFileEncrypted(false);
+    }
+  };
+
+  const handleImport = async () => {
+    if (!importFile || importPhase === "working") return;
+    setImportPhase("working");
+    setImportResult(null);
+    setImportError(null);
+    try {
+      const result = await importData(importFile, {
+        password: fileEncrypted && importPassword ? importPassword : undefined,
+        mode: importMode,
+      });
+      setImportResult(result);
+      setImportPhase("success");
+    } catch (error) {
+      const err = error as { code?: "INVALID_FILE" | "WRONG_PASSWORD" };
+      setImportError(
+        err?.code === "WRONG_PASSWORD" ? "wrongPassword" : "invalid",
+      );
+      setImportPhase("error");
+    }
+  };
+
+  return (
+    <>
+      <motion.div
+        ref={dialogRef}
+        initial={{ opacity: 0, scale: 0.96, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ type: "spring", damping: 28, stiffness: 300 }}
+        className="surface rounded-xl w-full max-w-lg max-h-[85vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start gap-3 p-6 pb-4">
+          <div className="p-2.5 rounded-full bg-[var(--color-accent)]/10">
+            <RefreshCw className="w-5 h-5 text-[var(--color-accent)]" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
+              {t("sync.title")}
+            </h2>
+          </div>
+          <button
+            ref={closeButtonRef}
+            onClick={onRequestClose}
+            aria-label={t("common.close")}
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div
+          role="tablist"
+          aria-label={t("sync.title")}
+          onKeyDown={handleTablistKeyDown}
+          className="flex gap-1 px-6 pb-2 border-b border-[var(--color-border)]"
+        >
+          <TabButton
+            id="export"
+            active={activeTab === "export"}
+            label={t("sync.export.tab")}
+            onSelect={setActiveTab}
+          />
+          <TabButton
+            id="import"
+            active={activeTab === "import"}
+            label={t("sync.import.tab")}
+            onSelect={setActiveTab}
+          />
+        </div>
+
+        {/* Active panel */}
+        <div
+          role="tabpanel"
+          id={`sync-panel-${activeTab}`}
+          aria-labelledby={`sync-tab-${activeTab}`}
+          className="p-6 space-y-5"
+        >
+          {activeTab === "export" ? (
+            <ExportTab
+              encryptEnabled={encryptEnabled}
+              setEncryptEnabled={setEncryptEnabled}
+              exportPassword={exportPassword}
+              setExportPassword={setExportPassword}
+              showExportPassword={showExportPassword}
+              setShowExportPassword={setShowExportPassword}
+              phase={exportPhase}
+              result={exportResult}
+              onExport={handleExport}
+            />
+          ) : (
+            <ImportTab
+              file={importFile}
+              fileEncrypted={fileEncrypted}
+              onFileChange={handleFileChange}
+              importPassword={importPassword}
+              setImportPassword={setImportPassword}
+              showImportPassword={showImportPassword}
+              setShowImportPassword={setShowImportPassword}
+              mode={importMode}
+              setMode={setImportMode}
+              phase={importPhase}
+              result={importResult}
+              error={importError}
+              onImport={handleImport}
+              dragOver={dragOver}
+              setDragOver={setDragOver}
+              fileInputRef={fileInputRef}
+            />
+          )}
+        </div>
+
+        {/* LGPD footer */}
+        <div className="px-6 py-4 border-t border-[var(--color-border)]">
+          <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+            {t("sync.lgpd_notice")}{" "}
+            <button
+              onClick={() => setShowPrivacy(true)}
+              className="text-[var(--color-accent)] hover:text-[var(--color-accent-light)] underline underline-offset-2 focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+            >
+              {t("sync.privacy_link")}
+            </button>
+          </p>
+        </div>
+      </motion.div>
+
+      <PrivacyPolicy open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+    </>
+  );
+}
+
+interface TabButtonProps {
+  id: TabId;
+  active: boolean;
+  label: string;
+  onSelect: (id: TabId) => void;
+}
+
+function TabButton({ id, active, label, onSelect }: TabButtonProps) {
+  return (
+    <button
+      role="tab"
+      id={`sync-tab-${id}`}
+      aria-selected={active}
+      aria-controls={`sync-panel-${id}`}
+      tabIndex={active ? 0 : -1}
+      onClick={() => onSelect(id)}
+      className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none ${
+        active
+          ? "bg-[var(--color-accent)]/10 text-[var(--color-accent)]"
+          : "text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)]"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface ExportTabProps {
+  encryptEnabled: boolean;
+  setEncryptEnabled: (v: boolean) => void;
+  exportPassword: string;
+  setExportPassword: (v: string) => void;
+  showExportPassword: boolean;
+  setShowExportPassword: React.Dispatch<React.SetStateAction<boolean>>;
+  phase: Phase;
+  result: DataSyncExportResult | null;
+  onExport: () => void;
+}
+
+function ExportTab({
+  encryptEnabled,
+  setEncryptEnabled,
+  exportPassword,
+  setExportPassword,
+  showExportPassword,
+  setShowExportPassword,
+  phase,
+  result,
+  onExport,
+}: ExportTabProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        {t("sync.export.description")}
+      </p>
+
+      <label className="flex items-start gap-3 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={encryptEnabled}
+          onChange={(e) => {
+            setEncryptEnabled(e.target.checked);
+            if (!e.target.checked) setExportPassword("");
+          }}
+          className="mt-0.5 w-4 h-4 rounded accent-[var(--color-accent)]"
+        />
+        <span className="text-sm text-[var(--color-text-secondary)]">
+          {t("sync.export.encrypt")}
+        </span>
+      </label>
+
+      {encryptEnabled && (
+        <div className="space-y-1.5">
+          <label
+            htmlFor="sync-export-password"
+            className="block text-xs font-medium text-[var(--color-text-secondary)]"
+          >
+            {t("sync.export.password")}
+          </label>
+          <div className="relative">
+            <input
+              id="sync-export-password"
+              type={showExportPassword ? "text" : "password"}
+              value={exportPassword}
+              onChange={(e) => {
+                setExportPassword(e.target.value);
+                if (e.target.value) setEncryptEnabled(true);
+              }}
+              placeholder={t("sync.export.passwordPlaceholder")}
+              className="w-full pr-10 px-3.5 py-2.5 rounded-xl text-sm bg-[var(--color-bg-primary)] border border-[var(--color-border)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            />
+            <button
+              type="button"
+              onClick={() => setShowExportPassword((v) => !v)}
+              aria-label={
+                showExportPassword
+                  ? t("sync.export.passwordHide", "Ocultar senha")
+                  : t("sync.export.passwordShow", "Mostrar senha")
+              }
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+            >
+              {showExportPassword ? (
+                <Unlock className="w-4 h-4" />
+              ) : (
+                <Lock className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <button
+          onClick={onExport}
+          disabled={phase === "working"}
+          className="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-xl text-sm font-semibold bg-[var(--color-accent)] text-[var(--color-text-primary)] hover:bg-[var(--color-accent-hover)] transition-colors disabled:opacity-60 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+        >
+          <Download className="w-4 h-4" />
+          {t("sync.export.button")}
+        </button>
+
+        {phase === "working" && (
+          <p
+            role="status"
+            className="flex items-center justify-center gap-2 text-sm text-[var(--color-text-muted)]"
+          >
+            <span
+              className="w-4 h-4 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin"
+              aria-hidden="true"
+            />
+            {t("sync.export.downloading")}
+          </p>
+        )}
+
+        {phase === "success" && result && (
+          <p
+            role="status"
+            className="flex items-center justify-center gap-2 text-sm text-[var(--color-success)]"
+          >
+            <CheckCircle className="w-4 h-4 shrink-0" />
+            <span>
+              {t("sync.export.success")} — {result.fileName} (
+              {formatBytes(result.sizeBytes)})
+            </span>
+          </p>
+        )}
+
+        {phase === "error" && (
+          <p
+            role="alert"
+            className="flex items-center justify-center gap-2 text-sm text-[var(--color-danger)]"
+          >
+            <AlertTriangle className="w-4 h-4 shrink-0" />
+            {t("common.error")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ImportTabProps {
+  file: File | null;
+  fileEncrypted: boolean;
+  onFileChange: (file: File | null) => void;
+  importPassword: string;
+  setImportPassword: (v: string) => void;
+  showImportPassword: boolean;
+  setShowImportPassword: React.Dispatch<React.SetStateAction<boolean>>;
+  mode: ImportMode;
+  setMode: (m: ImportMode) => void;
+  phase: Phase;
+  result: DataSyncImportResult | null;
+  error: "invalid" | "wrongPassword" | null;
+  onImport: () => void;
+  dragOver: boolean;
+  setDragOver: (v: boolean) => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+function ImportTab({
+  file,
+  fileEncrypted,
+  onFileChange,
+  importPassword,
+  setImportPassword,
+  showImportPassword,
+  setShowImportPassword,
+  mode,
+  setMode,
+  phase,
+  result,
+  error,
+  onImport,
+  dragOver,
+  setDragOver,
+  fileInputRef,
+}: ImportTabProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-start gap-2.5 p-3 rounded-xl bg-[var(--color-warning-muted)] border border-[var(--color-warning)]">
+        <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-warning)]" />
+        <p className="text-xs text-[var(--color-text-secondary)] leading-relaxed">
+          {t("sync.import.warning")}
+        </p>
+      </div>
+
+      {/* File picker / dropzone */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={t("sync.import.selectFile")}
+        onClick={() => fileInputRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            fileInputRef.current?.click();
+          }
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(false);
+          onFileChange(e.dataTransfer.files?.[0] ?? null);
+        }}
+        className={`p-5 rounded-xl border-2 border-dashed text-center cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none ${
+          dragOver
+            ? "border-[var(--color-accent)] bg-[var(--color-accent)]/5"
+            : "border-[var(--color-border)] hover:bg-[var(--color-bg-hover)]"
+        }`}
+      >
+        <Upload className="w-6 h-6 mx-auto mb-2 text-[var(--color-accent)]" />
+        <p className="text-sm text-[var(--color-text-secondary)] text-center break-all">
+          {file ? file.name : t("sync.import.dragDrop")}
+        </p>
+        <p className="text-xs text-[var(--color-text-muted)] text-center mt-1">
+          {t("sync.import.acceptedFormats")}
+        </p>
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".open3dcalc"
+        onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+        className="sr-only"
+        aria-label={t("sync.import.selectFile")}
+      />
+
+      {fileEncrypted && (
+        <div className="space-y-1.5">
+          <label
+            htmlFor="sync-import-password"
+            className="block text-xs font-medium text-[var(--color-text-secondary)]"
+          >
+            {t("sync.import.password")}
+          </label>
+          <div className="relative">
+            <input
+              id="sync-import-password"
+              type={showImportPassword ? "text" : "password"}
+              value={importPassword}
+              onChange={(e) => setImportPassword(e.target.value)}
+              placeholder={t("sync.import.passwordPlaceholder")}
+              className="w-full pr-10 px-3.5 py-2.5 rounded-xl text-sm bg-[var(--color-bg-primary)] border border-[var(--color-border)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            />
+            <button
+              type="button"
+              onClick={() => setShowImportPassword((v) => !v)}
+              aria-label={
+                showImportPassword
+                  ? t("sync.import.passwordHide", "Ocultar senha")
+                  : t("sync.import.passwordShow", "Mostrar senha")
+              }
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+            >
+              {showImportPassword ? (
+                <Unlock className="w-4 h-4" />
+              ) : (
+                <Lock className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Import mode selector */}
+      <fieldset>
+        <legend className="text-xs font-medium text-[var(--color-text-secondary)] mb-2">
+          {t("sync.import.mode")}
+        </legend>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <ModeOption
+            mode="merge"
+            selected={mode === "merge"}
+            onSelect={setMode}
+            title={t("sync.import.modeMerge")}
+            description={t("sync.import.modeMergeDesc")}
+          />
+          <ModeOption
+            mode="replace"
+            selected={mode === "replace"}
+            onSelect={setMode}
+            title={t("sync.import.modeReplace")}
+            description={t("sync.import.modeReplaceDesc")}
+          />
+        </div>
+      </fieldset>
+
+      <div className="space-y-3">
+        <button
+          onClick={onImport}
+          disabled={!file || phase === "working"}
+          className="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-xl text-sm font-semibold bg-[var(--color-accent)] text-[var(--color-text-primary)] hover:bg-[var(--color-accent-hover)] transition-colors disabled:opacity-60 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+        >
+          <Upload className="w-4 h-4" />
+          {t("sync.import.button")}
+        </button>
+
+        {phase === "working" && (
+          <p
+            role="status"
+            className="flex items-center justify-center gap-2 text-sm text-[var(--color-text-muted)]"
+          >
+            <span
+              className="w-4 h-4 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin"
+              aria-hidden="true"
+            />
+            {t("sync.import.importing")}
+          </p>
+        )}
+
+        {phase === "success" && result && (
+          <div role="status" className="space-y-1.5">
+            <p className="flex items-center gap-2 text-sm text-[var(--color-success)]">
+              <CheckCircle className="w-4 h-4 shrink-0" />
+              {t("sync.import.success")}
+            </p>
+            <ul className="text-sm text-[var(--color-text-secondary)] space-y-1">
+              <li>
+                {t("sync.import.results.imported", { count: result.imported })}
+              </li>
+              <li>
+                {t("sync.import.results.conflicts", {
+                  count: result.conflicts,
+                })}
+              </li>
+              {result.errors > 0 && (
+                <li className="text-[var(--color-danger)]">
+                  {t("sync.import.results.errors", { count: result.errors })}
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+
+        {phase === "error" && error && (
+          <p
+            role="alert"
+            className="flex items-center gap-2 text-sm text-[var(--color-danger)]"
+          >
+            <AlertTriangle className="w-4 h-4 shrink-0" />
+            {error === "wrongPassword"
+              ? t("sync.import.wrongPassword")
+              : t("sync.import.invalidFile")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ModeOptionProps {
+  mode: ImportMode;
+  selected: boolean;
+  onSelect: (m: ImportMode) => void;
+  title: string;
+  description: string;
+}
+
+function ModeOption({
+  mode,
+  selected,
+  onSelect,
+  title,
+  description,
+}: ModeOptionProps) {
+  return (
+    <label
+      className={`flex items-start gap-2.5 p-3 rounded-xl border cursor-pointer transition-colors ${
+        selected
+          ? "border-[var(--color-accent)] bg-[var(--color-accent)]/5"
+          : "border-[var(--color-border)] hover:bg-[var(--color-bg-hover)]"
+      }`}
+    >
+      <input
+        type="radio"
+        name="sync-import-mode"
+        value={mode}
+        checked={selected}
+        onChange={() => onSelect(mode)}
+        className="mt-0.5 w-4 h-4 accent-[var(--color-accent)]"
+      />
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-[var(--color-text-primary)]">
+          {title}
+        </span>
+        <span className="block text-xs text-[var(--color-text-muted)] mt-0.5">
+          {description}
+        </span>
+      </span>
+    </label>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/shared/components/ui/PrivacyPolicy.tsx
+++ b/src/shared/components/ui/PrivacyPolicy.tsx
@@ -1,54 +1,54 @@
-import { useRef, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Shield, X } from 'lucide-react'
+import { useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Shield, X } from "lucide-react";
 
 interface PrivacyPolicyProps {
-  open: boolean
-  onClose: () => void
+  open: boolean;
+  onClose: () => void;
 }
 
 export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
-  const { t } = useTranslation()
-  const dialogRef = useRef<HTMLDivElement>(null)
-  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const { t } = useTranslation();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   // Focus trap + ESC close
   useEffect(() => {
-    if (!open) return
-    closeButtonRef.current?.focus()
+    if (!open) return;
+    closeButtonRef.current?.focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose()
-        return
+      if (e.key === "Escape") {
+        onClose();
+        return;
       }
-      if (e.key !== 'Tab') return
-      const dialog = dialogRef.current
-      if (!dialog) return
+      if (e.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
       const focusable = dialog.querySelectorAll<HTMLElement>(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      )
-      const first = focusable[0]
-      const last = focusable[focusable.length - 1]
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
 
       if (e.shiftKey) {
         if (document.activeElement === first) {
-          e.preventDefault()
-          last.focus()
+          e.preventDefault();
+          last.focus();
         }
       } else {
         if (document.activeElement === last) {
-          e.preventDefault()
-          first.focus()
+          e.preventDefault();
+          first.focus();
         }
       }
-    }
+    };
 
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [open, onClose])
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
 
-  if (!open) return null
+  if (!open) return null;
 
   return (
     <div
@@ -56,7 +56,7 @@ export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
       onClick={onClose}
       role="dialog"
       aria-modal="true"
-      aria-label={t('privacy.policy.title')}
+      aria-label={t("privacy.policy.title")}
     >
       <div
         ref={dialogRef}
@@ -69,13 +69,15 @@ export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
             <Shield className="w-5 h-5 text-[var(--color-accent)]" />
           </div>
           <div className="flex-1 min-w-0">
-            <h2 className="text-lg font-bold gradient-text">{t('privacy.policy.title')}</h2>
+            <h2 className="text-lg font-bold gradient-text">
+              {t("privacy.policy.title")}
+            </h2>
           </div>
           <button
             ref={closeButtonRef}
             onClick={onClose}
             className="shrink-0 p-1.5 rounded-lg text-[var(--color-text-muted)] hover:text-white hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
-            aria-label={t('common.close')}
+            aria-label={t("common.close")}
           >
             <X className="w-5 h-5" />
           </button>
@@ -83,13 +85,17 @@ export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
 
         {/* Content */}
         <div className="space-y-5 text-sm text-[var(--color-text-secondary)] leading-relaxed pr-1">
-          <p className="text-xs text-[var(--color-text-muted)]">Última atualização: 28 de Junho de 2026</p>
+          <p className="text-xs text-[var(--color-text-muted)]">
+            Última atualização: 28 de Junho de 2026
+          </p>
 
           <Section title="1. Modelo de Dados">
             <p>
-              O Open3DCalc é uma aplicação 100% client-side. Todos os dados inseridos pelo usuário — parâmetros de cálculo,
-              dados de clientes, orçamentos, configurações — são armazenados exclusivamente no navegador do usuário
-              (localStorage). Nenhum dado é enviado, transmitido ou armazenado em servidores externos.
+              O Open3DCalc é uma aplicação 100% client-side. Todos os dados
+              inseridos pelo usuário — parâmetros de cálculo, dados de clientes,
+              orçamentos, configurações — são armazenados exclusivamente no
+              navegador do usuário (localStorage). Nenhum dado é enviado,
+              transmitido ou armazenado em servidores externos.
             </p>
           </Section>
 
@@ -107,13 +113,18 @@ export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
             <ul className="list-disc list-inside space-y-1">
               <li>Acessar seus dados (via interface do app)</li>
               <li>Corrigir dados incompletos ou desatualizados</li>
-              <li>Excluir seus dados (botão &ldquo;Limpar todos os dados&rdquo;)</li>
+              <li>
+                Excluir seus dados (botão &ldquo;Limpar todos os dados&rdquo;)
+              </li>
               <li>Exportar seus dados em formato JSON</li>
             </ul>
           </Section>
 
           <Section title="4. Transferência Internacional">
-            <p>Não há transferência internacional de dados, pois nenhum dado sai do seu dispositivo.</p>
+            <p>
+              Não há transferência internacional de dados, pois nenhum dado sai
+              do seu dispositivo.
+            </p>
           </Section>
 
           <Section title="5. Retenção de Dados">
@@ -130,13 +141,17 @@ export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
             <ul className="list-disc list-inside space-y-1">
               <li>Fazer backup regular dos dados (export JSON)</li>
               <li>Manter o navegador atualizado</li>
-              <li>Não utilizar em computadores compartilhados sem limpar os dados ao final</li>
+              <li>
+                Não utilizar em computadores compartilhados sem limpar os dados
+                ao final
+              </li>
             </ul>
           </Section>
 
           <Section title="7. Contato">
             <p>
-              Desenvolvido por @ils15. Para questões de privacidade, abra uma issue em{' '}
+              Desenvolvido por @ils15. Para questões de privacidade, abra uma
+              issue em{" "}
               <a
                 href="https://github.com/ils15/open3dcalc"
                 target="_blank"
@@ -147,17 +162,36 @@ export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
               </a>
             </p>
           </Section>
+
+          <Section title={t("privacy.policy.section8Title")}>
+            <p>{t("privacy.policy.section8Intro")}</p>
+            <ul className="list-disc list-inside space-y-1">
+              <li>{t("privacy.policy.section8Item1")}</li>
+              <li>{t("privacy.policy.section8Item2")}</li>
+              <li>{t("privacy.policy.section8Item3")}</li>
+              <li>{t("privacy.policy.section8Item4")}</li>
+            </ul>
+            <p>{t("privacy.policy.section8Lgpd")}</p>
+          </Section>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
     <div>
-      <h4 className="font-semibold text-[var(--color-text-primary)] mb-1.5">{title}</h4>
+      <h4 className="font-semibold text-[var(--color-text-primary)] mb-1.5">
+        {title}
+      </h4>
       <div className="space-y-1.5">{children}</div>
     </div>
-  )
+  );
 }

--- a/src/shared/i18n/i18n.ts
+++ b/src/shared/i18n/i18n.ts
@@ -1,33 +1,42 @@
-import i18n from 'i18next'
-import { initReactI18next } from 'react-i18next'
-import LanguageDetector from 'i18next-browser-languagedetector'
-import ptBR from './locales/pt-BR.json'
-import enUS from './locales/en-US.json'
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import ptBR from "./locales/pt-BR.json";
+import enUS from "./locales/en-US.json";
 
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources: {
-      'pt-BR': { translation: ptBR },
-      'en-US': { translation: enUS },
+      "pt-BR": { translation: ptBR },
+      "en-US": { translation: enUS },
     },
-    fallbackLng: 'pt-BR',
+    fallbackLng: "pt-BR",
     interpolation: { escapeValue: false },
     detection: {
-      order: ['localStorage', 'navigator'],
-      caches: ['localStorage'],
+      order: ["localStorage", "navigator"],
+      caches: ["localStorage"],
     },
-  })
+    react: {
+      // Workaround for recharts #7463: "Maximum update depth exceeded when chart
+      // unmounts behind Suspense boundary (React 19)". RechartsWrapper calls
+      // setTooltipPortal/setLegendPortal inside a useCallback ref; React 19's
+      // disappearLayoutEffects runs ref cleanup (ref(null)), and with Suspense
+      // enabled these setState calls trigger an infinite loop. Disabling Suspense
+      // avoids the loop. No stable recharts fix exists yet (latest is 3.10.1).
+      useSuspense: false,
+    },
+  });
 
 // Sync <html lang> with i18n language so <input type="date"> uses the correct locale format
-i18n.on('languageChanged', (lng) => {
-  const htmlLang = lng === 'pt-BR' ? 'pt-BR' : 'en-US'
-  document.documentElement.lang = htmlLang
-})
+i18n.on("languageChanged", (lng) => {
+  const htmlLang = lng === "pt-BR" ? "pt-BR" : "en-US";
+  document.documentElement.lang = htmlLang;
+});
 // Set initial lang
-if (typeof document !== 'undefined') {
-  document.documentElement.lang = i18n.language === 'pt-BR' ? 'pt-BR' : 'en-US'
+if (typeof document !== "undefined") {
+  document.documentElement.lang = i18n.language === "pt-BR" ? "pt-BR" : "en-US";
 }
 
-export default i18n
+export default i18n;

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -688,9 +688,7 @@
           },
           {
             "title": "❤️ Contributors",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -732,9 +730,7 @@
           },
           {
             "title": "❤️ Contributors",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -818,9 +814,7 @@
           },
           {
             "title": "❤️ Contributors",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -836,15 +830,11 @@
           },
           {
             "title": "🧹 Other",
-            "items": [
-              "**release:** V1.8.1 [skip ci] (079945e)"
-            ]
+            "items": ["**release:** V1.8.1 [skip ci] (079945e)"]
           },
           {
             "title": "❤️ Contributors",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -876,10 +866,7 @@
           },
           {
             "title": "✅ Testes",
-            "items": [
-              "417 testes, 36/36 arquivos passando",
-              "Cobertura >80%"
-            ]
+            "items": ["417 testes, 36/36 arquivos passando", "Cobertura >80%"]
           }
         ]
       },
@@ -1271,5 +1258,46 @@
     "emptyItems": "Add items from calculation history",
     "saveSuccess": "Quote saved successfully!",
     "deleteConfirm": "Are you sure you want to delete quote #{{number}}?"
+  },
+  "sync": {
+    "title": "Data Synchronization",
+    "export": {
+      "tab": "Export",
+      "title": "Export Data",
+      "description": "Export all your data locally. No data is sent to servers.",
+      "encrypt": "Encrypt data with password",
+      "password": "Encryption password",
+      "passwordPlaceholder": "Enter a password (optional)",
+      "button": "Export Data",
+      "success": "Data exported successfully",
+      "downloading": "Preparing download..."
+    },
+    "import": {
+      "tab": "Import",
+      "title": "Import Data",
+      "warning": "Imported data will be merged with existing data. Data with the same ID will be updated.",
+      "selectFile": "Select file",
+      "dragDrop": "Drag and drop file here or click to select",
+      "acceptedFormats": "Accepted format: .open3dcalc",
+      "password": "Decryption password",
+      "passwordPlaceholder": "Enter file password",
+      "mode": "Import mode",
+      "modeMerge": "Merge (recommended)",
+      "modeReplace": "Replace all",
+      "modeMergeDesc": "Add new data, update existing",
+      "modeReplaceDesc": "Remove all current data and replace with imported",
+      "button": "Import Data",
+      "success": "Data imported successfully",
+      "importing": "Importing data...",
+      "invalidFile": "Invalid or corrupted file",
+      "wrongPassword": "Wrong password",
+      "results": {
+        "imported": "{{count}} items imported",
+        "conflicts": "{{count}} conflicts resolved",
+        "errors": "{{count}} errors found"
+      }
+    },
+    "lgpd_notice": "All data stays in your browser. No data is sent to external servers. See our Privacy Policy.",
+    "privacy_link": "Privacy Policy"
   }
 }

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -539,7 +539,14 @@
       "readPolicy": "📖 Read full Privacy Policy"
     },
     "policy": {
-      "title": "Privacy Policy"
+      "title": "Privacy Policy",
+      "section8Title": "8. Data Export and Portability",
+      "section8Intro": "Open3DCalc supports local data export and import via encrypted .open3dcalc bundles:",
+      "section8Item1": "Local export/import via encrypted .open3dcalc bundles",
+      "section8Item2": "All data processing happens exclusively client-side",
+      "section8Item3": "No data is transmitted to any server during export or import",
+      "section8Item4": "You can encrypt bundles with your own password",
+      "section8Lgpd": "In compliance with LGPD Art. 18 (right to data portability), you can export your data at any time and import it on another device."
     }
   },
   "tooltip": {

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -688,9 +688,7 @@
           },
           {
             "title": "❤️ Contribuidores",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -732,9 +730,7 @@
           },
           {
             "title": "❤️ Contribuidores",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -818,9 +814,7 @@
           },
           {
             "title": "❤️ Contribuidores",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -836,15 +830,11 @@
           },
           {
             "title": "🧹 Outros",
-            "items": [
-              "**release:** V1.8.1 [skip ci] (079945e)"
-            ]
+            "items": ["**release:** V1.8.1 [skip ci] (079945e)"]
           },
           {
             "title": "❤️ Contribuidores",
-            "items": [
-              "Ils15 (@ils15)"
-            ]
+            "items": ["Ils15 (@ils15)"]
           }
         ]
       },
@@ -876,10 +866,7 @@
           },
           {
             "title": "✅ Testes",
-            "items": [
-              "417 testes, 36/36 arquivos passando",
-              "Cobertura >80%"
-            ]
+            "items": ["417 testes, 36/36 arquivos passando", "Cobertura >80%"]
           }
         ]
       },
@@ -1271,5 +1258,46 @@
     "emptyItems": "Adicione itens do histórico de cálculos",
     "saveSuccess": "Orçamento salvo com sucesso!",
     "deleteConfirm": "Tem certeza que deseja excluir o orçamento #{{number}}?"
+  },
+  "sync": {
+    "title": "Sincronização de Dados",
+    "export": {
+      "tab": "Exportar",
+      "title": "Exportar Dados",
+      "description": "Exporte todos os seus dados localmente. Nenhum dado é enviado a servidores.",
+      "encrypt": "Criptografar dados com senha",
+      "password": "Senha para criptografia",
+      "passwordPlaceholder": "Digite uma senha (opcional)",
+      "button": "Exportar Dados",
+      "success": "Dados exportados com sucesso",
+      "downloading": "Preparando download..."
+    },
+    "import": {
+      "tab": "Importar",
+      "title": "Importar Dados",
+      "warning": "Os dados importados serão mesclados com os dados existentes. Dados com o mesmo ID serão atualizados.",
+      "selectFile": "Selecionar arquivo",
+      "dragDrop": "Arraste e solte o arquivo aqui ou clique para selecionar",
+      "acceptedFormats": "Formato aceito: .open3dcalc",
+      "password": "Senha de descriptografia",
+      "passwordPlaceholder": "Digite a senha do arquivo",
+      "mode": "Modo de importação",
+      "modeMerge": "Mesclar (recomendado)",
+      "modeReplace": "Substituir tudo",
+      "modeMergeDesc": "Adiciona dados novos, atualiza existentes",
+      "modeReplaceDesc": "Remove todos os dados atuais e substitui pelos importados",
+      "button": "Importar Dados",
+      "success": "Dados importados com sucesso",
+      "importing": "Importando dados...",
+      "invalidFile": "Arquivo inválido ou corrompido",
+      "wrongPassword": "Senha incorreta",
+      "results": {
+        "imported": "{{count}} itens importados",
+        "conflicts": "{{count}} conflitos resolvidos",
+        "errors": "{{count}} erros encontrados"
+      }
+    },
+    "lgpd_notice": "Todos os dados permanecem no seu navegador. Nenhum dado é enviado a servidores externos. Consulte nossa Política de Privacidade.",
+    "privacy_link": "Política de Privacidade"
   }
 }

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -539,7 +539,14 @@
       "readPolicy": "📖 Ler Política de Privacidade completa"
     },
     "policy": {
-      "title": "Política de Privacidade"
+      "title": "Política de Privacidade",
+      "section8Title": "8. Exportação e Portabilidade de Dados",
+      "section8Intro": "O Open3DCalc suporta exportação e importação local de dados por meio de pacotes criptografados .open3dcalc:",
+      "section8Item1": "Exportação/importação local via pacotes .open3dcalc criptografados",
+      "section8Item2": "Todo o processamento de dados acontece exclusivamente no lado do cliente (client-side)",
+      "section8Item3": "Nenhum dado é transmitido a qualquer servidor durante a exportação ou importação",
+      "section8Item4": "Você pode criptografar os pacotes com sua própria senha",
+      "section8Lgpd": "Em conformidade com o Art. 18 da LGPD (direito à portabilidade dos dados), você pode exportar seus dados a qualquer momento e importá-los em outro dispositivo."
     }
   },
   "tooltip": {

--- a/src/shared/lib/dataSync.test.ts
+++ b/src/shared/lib/dataSync.test.ts
@@ -1,0 +1,579 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  collectSyncData,
+  validateBundle,
+  exportBundle,
+  importBundle,
+  applySyncData,
+  deriveKey,
+  encryptData,
+  decryptData,
+  hashData,
+  type SyncData,
+  type EncryptedBundle,
+} from "@/shared/lib/dataSync";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function emptySyncData(): SyncData {
+  return {
+    settings: {},
+    history: [],
+    customers: [],
+    quotes: [],
+    catalog: { printers: [], materials: [], marketplaces: [] },
+    filaments: [],
+    theme: "",
+    dashboard: {},
+    sections: {},
+  };
+}
+
+/** Seed every known localStorage key the app persists. */
+function seedFullStorage(): void {
+  localStorage.setItem(
+    "open3dcalc_settings_v2",
+    JSON.stringify({ productName: "Vaso", quantity: 2 }),
+  );
+  localStorage.setItem(
+    "open3dcalc_history_v2",
+    JSON.stringify({
+      state: { entries: [{ id: "h1", timestamp: 1000 }], search: "" },
+      version: 2,
+    }),
+  );
+  localStorage.setItem(
+    "open3dcalc_customers_v1",
+    JSON.stringify({
+      state: { customers: [{ id: "c1", name: "Ana" }] },
+      version: 1,
+    }),
+  );
+  localStorage.setItem(
+    "open3dcalc_quotes_v1",
+    JSON.stringify({
+      state: { quotes: [{ id: "q1", number: 1 }], nextNumber: 2 },
+      version: 1,
+    }),
+  );
+  localStorage.setItem(
+    "open3dcalc_catalog_v1",
+    JSON.stringify({
+      printers: [
+        { id: "p-builtin", name: "Ender", custom: false },
+        { id: "p-custom", name: "Minha Impressora", custom: true },
+      ],
+      materials: [{ id: "m-custom", name: "PETG", custom: true }],
+      marketplaces: [{ id: "mk-builtin", name: "Shopee", custom: false }],
+    }),
+  );
+  localStorage.setItem(
+    "open3dcalc_filaments",
+    JSON.stringify([{ id: "f1", brand: "Sunlu" }]),
+  );
+  localStorage.setItem("open3dcalc_theme", "dark");
+  localStorage.setItem(
+    "open3dcalc_dashboard_v1",
+    JSON.stringify({ chartType: "bar" }),
+  );
+  localStorage.setItem("open3dcalc_dashboard_goal", "R$ 1000");
+  localStorage.setItem(
+    "open3dcalc_sections",
+    JSON.stringify({ costs: true, labor: false }),
+  );
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++)
+    binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/* ------------------------------------------------------------------ */
+/*  collectSyncData                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("collectSyncData", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("returns the correct structure from localStorage", () => {
+    seedFullStorage();
+
+    const data = collectSyncData();
+
+    expect(data.settings).toEqual({ productName: "Vaso", quantity: 2 });
+    expect(data.history).toEqual([{ id: "h1", timestamp: 1000 }]);
+    expect(data.customers).toEqual([{ id: "c1", name: "Ana" }]);
+    expect(data.quotes).toEqual([{ id: "q1", number: 1 }]);
+    expect(data.quotesNextNumber).toBe(2);
+    // Only custom catalog items are exported
+    expect(data.catalog.printers).toEqual([
+      { id: "p-custom", name: "Minha Impressora", custom: true },
+    ]);
+    expect(data.catalog.materials).toEqual([
+      { id: "m-custom", name: "PETG", custom: true },
+    ]);
+    expect(data.catalog.marketplaces).toEqual([]);
+    expect(data.filaments).toEqual([{ id: "f1", brand: "Sunlu" }]);
+    expect(data.theme).toBe("dark");
+    expect(data.dashboard).toEqual({ chartType: "bar", goal: "R$ 1000" });
+    expect(data.sections).toEqual({ costs: true, labor: false });
+  });
+
+  it("returns empty defaults when localStorage is empty", () => {
+    const data = collectSyncData();
+    expect(data).toEqual(emptySyncData());
+  });
+
+  it("tolerates corrupt JSON values without failing", () => {
+    localStorage.setItem("open3dcalc_settings_v2", "{corrupt");
+    localStorage.setItem("open3dcalc_history_v2", "not-json");
+    const data = collectSyncData();
+    expect(data.settings).toEqual({});
+    expect(data.history).toEqual([]);
+  });
+
+  it("handles plain-array history format as fallback", () => {
+    localStorage.setItem(
+      "open3dcalc_history_v2",
+      JSON.stringify([{ id: "h1", timestamp: 1 }]),
+    );
+    expect(collectSyncData().history).toEqual([{ id: "h1", timestamp: 1 }]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  validateBundle                                                     */
+/* ------------------------------------------------------------------ */
+
+describe("validateBundle", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("accepts a valid unencrypted bundle", async () => {
+    const bundle = await exportBundle();
+    expect(validateBundle(bundle)).toBe(true);
+  });
+
+  it("accepts a valid encrypted bundle", async () => {
+    const bundle = await exportBundle("senha123");
+    expect(validateBundle(bundle)).toBe(true);
+  });
+
+  it("rejects non-objects and empty values", () => {
+    expect(validateBundle(null)).toBe(false);
+    expect(validateBundle(undefined)).toBe(false);
+    expect(validateBundle(42)).toBe(false);
+    expect(validateBundle("texto")).toBe(false);
+    expect(validateBundle({})).toBe(false);
+  });
+
+  it("rejects wrong version and wrong format", () => {
+    const valid = {
+      version: "1.0",
+      format: "open3dcalc-export",
+      exportedAt: new Date().toISOString(),
+      appVersion: "1.9.3",
+      platform: "web",
+      encrypted: false,
+      data: emptySyncData(),
+    };
+    expect(validateBundle(valid)).toBe(true);
+    expect(validateBundle({ ...valid, version: "2.0" })).toBe(false);
+    expect(validateBundle({ ...valid, format: "outro-formato" })).toBe(false);
+  });
+
+  it("rejects encrypted bundles missing crypto fields", () => {
+    const incomplete = {
+      version: "1.0",
+      format: "open3dcalc-export",
+      exportedAt: new Date().toISOString(),
+      appVersion: "1.9.3",
+      platform: "web",
+      encrypted: true,
+      data: "AAAA",
+    };
+    expect(validateBundle(incomplete)).toBe(false);
+  });
+
+  it("rejects unencrypted bundles without valid SyncData", () => {
+    const invalidData = {
+      version: "1.0",
+      format: "open3dcalc-export",
+      exportedAt: new Date().toISOString(),
+      appVersion: "1.9.3",
+      platform: "web",
+      encrypted: false,
+      data: { history: [], customers: [] }, // missing settings, quotes, catalog, ...
+    };
+    expect(validateBundle(invalidData)).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  exportBundle                                                       */
+/* ------------------------------------------------------------------ */
+
+describe("exportBundle", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("produces an unencrypted bundle without a password", async () => {
+    seedFullStorage();
+    const bundle = await exportBundle();
+
+    expect(bundle.encrypted).toBe(false);
+    expect(bundle.version).toBe("1.0");
+    expect(bundle.format).toBe("open3dcalc-export");
+    expect(bundle.appVersion).toBe("1.9.3");
+    expect(typeof bundle.exportedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(bundle.exportedAt))).toBe(false);
+    expect(bundle.platform).toBe("web");
+    expect(bundle.salt).toBeUndefined();
+    expect(bundle.iv).toBeUndefined();
+    expect(typeof bundle.data).toBe("object");
+    expect(Array.isArray((bundle as { data: SyncData }).data.history)).toBe(
+      true,
+    );
+  });
+
+  it("produces an encrypted bundle with a password", async () => {
+    seedFullStorage();
+    const bundle = (await exportBundle("segredo")) as EncryptedBundle;
+
+    expect(bundle.encrypted).toBe(true);
+    expect(typeof bundle.data).toBe("string");
+    expect(typeof bundle.salt).toBe("string");
+    expect(typeof bundle.iv).toBe("string");
+    expect(typeof bundle.checksum).toBe("string");
+    // Salt must be 16 raw bytes and IV 12 raw bytes
+    expect(base64ToBytes(bundle.salt).length).toBe(16);
+    expect(base64ToBytes(bundle.iv).length).toBe(12);
+  });
+
+  it("produces a different salt/iv on each export (fresh randomness)", async () => {
+    const a = (await exportBundle("senha")) as EncryptedBundle;
+    const b = (await exportBundle("senha")) as EncryptedBundle;
+    expect(a.salt).not.toBe(b.salt);
+    expect(a.iv).not.toBe(b.iv);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  importBundle round-trip                                            */
+/* ------------------------------------------------------------------ */
+
+describe("importBundle round-trip", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("round-trips export → import preserving all data (encrypted)", async () => {
+    seedFullStorage();
+    const before = collectSyncData();
+    const bundle = await exportBundle("senha-rt");
+    localStorage.clear();
+
+    const result = await importBundle(bundle, "senha-rt");
+
+    expect(result.imported).toEqual(
+      expect.arrayContaining([
+        "settings",
+        "history",
+        "customers",
+        "quotes",
+        "catalog",
+        "filaments",
+        "theme",
+        "dashboard",
+        "sections",
+      ]),
+    );
+    const after = collectSyncData();
+    expect(after.settings).toEqual(before.settings);
+    expect(after.history).toEqual(before.history);
+    expect(after.customers).toEqual(before.customers);
+    expect(after.quotes).toEqual(before.quotes);
+    expect(after.catalog).toEqual(before.catalog);
+    expect(after.filaments).toEqual(before.filaments);
+    expect(after.theme).toEqual(before.theme);
+    expect(after.dashboard).toEqual(before.dashboard);
+    expect(after.sections).toEqual(before.sections);
+  });
+
+  it("round-trips unencrypted bundles as well", async () => {
+    seedFullStorage();
+    const before = collectSyncData();
+    const bundle = await exportBundle();
+    localStorage.clear();
+
+    await importBundle(bundle);
+
+    const after = collectSyncData();
+    expect(after.settings).toEqual(before.settings);
+    expect(after.history).toEqual(before.history);
+    expect(after.customers).toEqual(before.customers);
+    expect(after.quotes).toEqual(before.quotes);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Crypto helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+describe("crypto helpers", () => {
+  it("encryptData/decryptData round-trip works", async () => {
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+    const key = await deriveKey("minha-senha", salt);
+    const { iv, ciphertext } = await encryptData('{"ola":"mundo"}', key);
+
+    const plain = await decryptData(ciphertext, key, iv);
+    expect(plain).toBe('{"ola":"mundo"}');
+  });
+
+  it("decryptData fails with a different key (GCM auth)", async () => {
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+    const keyA = await deriveKey("senha-a", salt);
+    const keyB = await deriveKey("senha-b", salt);
+    const { iv, ciphertext } = await encryptData("segredo", keyA);
+
+    await expect(decryptData(ciphertext, keyB, iv)).rejects.toThrow();
+  });
+
+  it("decryptData fails on tampered ciphertext", async () => {
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+    const key = await deriveKey("senha", salt);
+    const { iv, ciphertext } = await encryptData("segredo", key);
+    const tampered = new Uint8Array(ciphertext);
+    tampered[0] ^= 0xff;
+
+    await expect(
+      decryptData(tampered.buffer as ArrayBuffer, key, iv),
+    ).rejects.toThrow();
+  });
+
+  it("hashData produces consistent SHA-256", async () => {
+    const h1 = await hashData("abc");
+    const h2 = await hashData("abc");
+    const h3 = await hashData("abd");
+    expect(h1).toBe(h2);
+    expect(h1).not.toBe(h3);
+    expect(typeof h1).toBe("string");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Merge strategy                                                     */
+/* ------------------------------------------------------------------ */
+
+describe("applySyncData merge strategy", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("deduplicates collections by id keeping the newest item", () => {
+    localStorage.setItem(
+      "open3dcalc_history_v2",
+      JSON.stringify({
+        state: {
+          entries: [
+            { id: "h1", timestamp: 100 },
+            { id: "h2", timestamp: 200 },
+          ],
+        },
+        version: 2,
+      }),
+    );
+
+    const imported = emptySyncData();
+    imported.history = [
+      { id: "h1", timestamp: 999 }, // newer than local h1 → wins
+      { id: "h3", timestamp: 300 },
+    ];
+
+    const result = applySyncData(imported, "merge");
+
+    const stored = JSON.parse(localStorage.getItem("open3dcalc_history_v2")!);
+    expect(stored.state.entries).toEqual([
+      { id: "h1", timestamp: 999 },
+      { id: "h2", timestamp: 200 },
+      { id: "h3", timestamp: 300 },
+    ]);
+    expect(result.conflicts).toContain("history");
+  });
+
+  it("keeps the local item when it is newer than the imported one", () => {
+    localStorage.setItem(
+      "open3dcalc_customers_v1",
+      JSON.stringify({
+        state: { customers: [{ id: "c1", name: "Nova", updatedAt: 500 }] },
+        version: 1,
+      }),
+    );
+
+    const imported = emptySyncData();
+    imported.customers = [{ id: "c1", name: "Velha", updatedAt: 100 }];
+
+    applySyncData(imported, "merge");
+
+    const stored = JSON.parse(localStorage.getItem("open3dcalc_customers_v1")!);
+    expect(stored.state.customers).toEqual([
+      { id: "c1", name: "Nova", updatedAt: 500 },
+    ]);
+  });
+
+  it("replaces settings with imported values in merge mode", () => {
+    localStorage.setItem(
+      "open3dcalc_settings_v2",
+      JSON.stringify({ productName: "Local" }),
+    );
+
+    const imported = emptySyncData();
+    imported.settings = { productName: "Importado", quantity: 5 };
+
+    applySyncData(imported, "merge");
+
+    expect(JSON.parse(localStorage.getItem("open3dcalc_settings_v2")!)).toEqual(
+      {
+        productName: "Importado",
+        quantity: 5,
+      },
+    );
+  });
+
+  it("does not wipe local settings with empty imported settings in merge mode", () => {
+    localStorage.setItem(
+      "open3dcalc_settings_v2",
+      JSON.stringify({ productName: "Local" }),
+    );
+
+    applySyncData(emptySyncData(), "merge");
+
+    expect(JSON.parse(localStorage.getItem("open3dcalc_settings_v2")!)).toEqual(
+      {
+        productName: "Local",
+      },
+    );
+  });
+
+  it("imports only custom catalog items, preserving built-ins", () => {
+    localStorage.setItem(
+      "open3dcalc_catalog_v1",
+      JSON.stringify({
+        printers: [
+          { id: "builtin", name: "Ender", custom: false },
+          { id: "mine", name: "Minha", custom: true },
+        ],
+        materials: [],
+        marketplaces: [],
+      }),
+    );
+
+    const imported = emptySyncData();
+    imported.catalog.printers = [
+      { id: "builtin", name: "Ender", custom: false }, // must be ignored
+      { id: "new-custom", name: "Nova", custom: true },
+    ];
+
+    applySyncData(imported, "merge");
+
+    const stored = JSON.parse(localStorage.getItem("open3dcalc_catalog_v1")!);
+    expect(stored.printers).toEqual([
+      { id: "builtin", name: "Ender", custom: false },
+      { id: "mine", name: "Minha", custom: true },
+      { id: "new-custom", name: "Nova", custom: true },
+    ]);
+  });
+
+  it("quotes nextNumber uses Math.max(local, imported) + 1", () => {
+    localStorage.setItem(
+      "open3dcalc_quotes_v1",
+      JSON.stringify({
+        state: { quotes: [{ id: "q1", number: 1 }], nextNumber: 5 },
+        version: 1,
+      }),
+    );
+
+    const imported = emptySyncData();
+    imported.quotes = [{ id: "q2", number: 2 }];
+    imported.quotesNextNumber = 7;
+
+    applySyncData(imported, "merge");
+
+    const stored = JSON.parse(localStorage.getItem("open3dcalc_quotes_v1")!);
+    expect(stored.state.nextNumber).toBe(8); // Math.max(5, 7) + 1
+    expect(stored.state.quotes).toHaveLength(2);
+  });
+
+  it("replace mode fully replaces collections", () => {
+    localStorage.setItem(
+      "open3dcalc_history_v2",
+      JSON.stringify({
+        state: { entries: [{ id: "h1", timestamp: 100 }] },
+        version: 2,
+      }),
+    );
+
+    const imported = emptySyncData();
+    imported.history = [{ id: "hX", timestamp: 1 }];
+
+    const result = applySyncData(imported, "replace");
+
+    const stored = JSON.parse(localStorage.getItem("open3dcalc_history_v2")!);
+    expect(stored.state.entries).toEqual([{ id: "hX", timestamp: 1 }]);
+    expect(result.conflicts).toEqual([]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Import error handling                                              */
+/* ------------------------------------------------------------------ */
+
+describe("importBundle error handling", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("throws a clear error for invalid bundle format", async () => {
+    await expect(importBundle({} as never)).rejects.toThrow("inválido");
+  });
+
+  it("throws when a password is missing on an encrypted bundle", async () => {
+    const bundle = await exportBundle("senha");
+    await expect(importBundle(bundle)).rejects.toThrow("criptografado");
+  });
+
+  it("throws a clear PT-BR error on wrong password", async () => {
+    seedFullStorage();
+    const bundle = await exportBundle("senha-correta");
+    await expect(importBundle(bundle, "senha-errada")).rejects.toThrow(
+      "Senha incorreta",
+    );
+  });
+
+  it("throws a clear error on corrupted checksum", async () => {
+    seedFullStorage();
+    const bundle = (await exportBundle("senha")) as EncryptedBundle;
+    bundle.checksum = bytesToBase64(new Uint8Array(32)); // bogus checksum
+
+    await expect(importBundle(bundle, "senha")).rejects.toThrow("checksum");
+  });
+
+  it("throws a clear error on corrupted ciphertext", async () => {
+    seedFullStorage();
+    const bundle = (await exportBundle("senha")) as EncryptedBundle;
+    const bytes = base64ToBytes(bundle.data);
+    bytes[0] ^= 0xff;
+    bundle.data = bytesToBase64(bytes);
+
+    await expect(importBundle(bundle, "senha")).rejects.toThrow("corrompido");
+  });
+
+  it("throws a clear error on unencrypted bundle with bad checksum", async () => {
+    const bundle = await exportBundle();
+    const corrupted = { ...bundle, checksum: "invalid-checksum-value" };
+    await expect(importBundle(corrupted)).rejects.toThrow("checksum");
+  });
+});

--- a/src/shared/lib/dataSync.ts
+++ b/src/shared/lib/dataSync.ts
@@ -859,7 +859,7 @@ function triggerDownload(blob: Blob, fileName: string): void {
 function syncFileName(date = new Date()): string {
   const pad = (n: number) => String(n).padStart(2, "0");
   const stamp = `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
-  return `open3dcalc-sync-${stamp}.json`;
+  return `open3dcalc-sync-${stamp}.open3dcalc`;
 }
 
 /**

--- a/src/shared/lib/dataSync.ts
+++ b/src/shared/lib/dataSync.ts
@@ -1,0 +1,931 @@
+/**
+ * dataSync.ts — Encrypted export/import for cross-device sync (Issue #55).
+ *
+ * 100% client-side: no server involved. User data leaves the device only
+ * inside an export bundle (optionally encrypted with AES-256-GCM), keeping
+ * LGPD compliance since nothing transits through a third party.
+ *
+ * Encryption spec:
+ *  - Algorithm:  AES-256-GCM (window.crypto.subtle)
+ *  - Key derivation: PBKDF2, 100.000 iterations, SHA-256
+ *  - Salt: 16 random bytes per export
+ *  - IV:   12 random bytes per export
+ *  - Checksum: SHA-256 of the plaintext JSON (integrity)
+ *
+ * Zero external dependencies — browser-native Web Crypto only.
+ */
+
+export const SYNC_FORMAT = "open3dcalc-export" as const;
+export const SYNC_VERSION = "1.0" as const;
+/** Kept in sync with package.json version. */
+export const APP_VERSION = "1.9.3";
+
+const PBKDF2_ITERATIONS = 100_000;
+const KEY_LENGTH_BITS = 256;
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface SyncData {
+  settings: Record<string, unknown>; // open3dcalc_settings_v2
+  history: unknown[]; // open3dcalc_history_v2 entries
+  customers: unknown[]; // open3dcalc_customers_v1 customers
+  quotes: unknown[]; // open3dcalc_quotes_v1 quotes
+  /**
+   * Next quote number, carried alongside quotes so the import merge can
+   * avoid collisions via `Math.max(local, imported) + 1`.
+   * Optional for backward compatibility with older bundles.
+   */
+  quotesNextNumber?: number;
+  catalog: {
+    printers: unknown[];
+    materials: unknown[];
+    marketplaces: unknown[];
+  }; // open3dcalc_catalog_v1 (only custom: true)
+  filaments: unknown[]; // open3dcalc_filaments
+  theme: string; // open3dcalc_theme
+  dashboard: Record<string, unknown>; // open3dcalc_dashboard_v1 + goal
+  sections: Record<string, boolean>; // open3dcalc_sections
+}
+
+export interface ExportBundle {
+  version: "1.0";
+  format: "open3dcalc-export";
+  exportedAt: string; // ISO timestamp
+  appVersion: string;
+  platform: "web" | "electron";
+  encrypted: boolean;
+  salt?: string; // base64 — PBKDF2 salt (encrypted bundles)
+  iv?: string; // base64 — AES-GCM IV (encrypted bundles)
+  checksum?: string; // base64 — SHA-256 of plaintext data
+  data: SyncData;
+}
+
+export interface EncryptedBundle extends Omit<ExportBundle, "data"> {
+  encrypted: true;
+  data: string; // base64 — encrypted SyncData
+  salt: string;
+  iv: string;
+  checksum: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  localStorage keys                                                  */
+/* ------------------------------------------------------------------ */
+
+const KEYS = {
+  settings: "open3dcalc_settings_v2",
+  history: "open3dcalc_history_v2",
+  customers: "open3dcalc_customers_v1",
+  quotes: "open3dcalc_quotes_v1",
+  catalog: "open3dcalc_catalog_v1",
+  filaments: "open3dcalc_filaments",
+  theme: "open3dcalc_theme",
+  dashboard: "open3dcalc_dashboard_v1",
+  dashboardGoal: "open3dcalc_dashboard_goal",
+  sections: "open3dcalc_sections",
+} as const;
+
+/* ------------------------------------------------------------------ */
+/*  Base64 helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++)
+    binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/* ------------------------------------------------------------------ */
+/*  localStorage helpers                                               */
+/* ------------------------------------------------------------------ */
+
+function getRaw(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Zustand persist stores (history/customers/quotes) write a wrapper:
+ * `{ state: {...}, version: N }`. Settings, catalog, dashboard, sections
+ * and filaments are stored as plain JSON.
+ */
+function isPersistWrapper(
+  value: unknown,
+): value is { state: Record<string, unknown>; version: number } {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    !!v.state && typeof v.state === "object" && typeof v.version === "number"
+  );
+}
+
+function readPlainJSON<T>(key: string, def: T): T {
+  const raw = getRaw(key);
+  if (raw === null) return def;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return def;
+  }
+}
+
+function readPersistState(key: string): {
+  state: Record<string, unknown>;
+  version: number;
+} {
+  const raw = getRaw(key);
+  if (raw !== null) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (isPersistWrapper(parsed))
+        return { state: parsed.state, version: parsed.version };
+    } catch {
+      /* ignore malformed value */
+    }
+  }
+  return { state: {}, version: 0 };
+}
+
+/** Unwrap a zustand persist wrapper; falls back to the raw object. */
+function unwrapPersist(value: unknown): Record<string, unknown> {
+  if (isPersistWrapper(value)) return value.state;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+/**
+ * Write a plain-JSON key. If the key previously held a zustand persist
+ * wrapper, the wrapper shape is preserved so stores keep hydrating.
+ */
+function writeJSON(key: string, value: unknown): void {
+  const raw = getRaw(key);
+  if (raw !== null) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (isPersistWrapper(parsed)) {
+        localStorage.setItem(
+          key,
+          JSON.stringify({ state: value, version: parsed.version }),
+        );
+        return;
+      }
+    } catch {
+      /* ignore malformed value */
+    }
+  }
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
+/** Patch a persist-wrapped key, keeping its other state fields and version. */
+function writePersistState(key: string, patch: Record<string, unknown>): void {
+  const { state, version } = readPersistState(key);
+  localStorage.setItem(
+    key,
+    JSON.stringify({ state: { ...state, ...patch }, version }),
+  );
+}
+
+function isCustomItem(item: unknown): boolean {
+  return (
+    !!item &&
+    typeof item === "object" &&
+    (item as { custom?: unknown }).custom === true
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Collection — gather every user datum from localStorage             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Collect all syncable data from localStorage into a SyncData object.
+ * Missing/corrupt keys fall back to their empty default so an export
+ * never fails because of one bad key.
+ */
+export function collectSyncData(): SyncData {
+  const settings = readPlainJSON<Record<string, unknown>>(KEYS.settings, {});
+
+  const historyRaw = readPlainJSON<unknown>(KEYS.history, null);
+  const historyState = unwrapPersist(historyRaw);
+  const history = Array.isArray(historyState.entries)
+    ? historyState.entries
+    : Array.isArray(historyRaw)
+      ? historyRaw
+      : [];
+
+  const customersRaw = readPlainJSON<unknown>(KEYS.customers, null);
+  const customersState = unwrapPersist(customersRaw);
+  const customers = Array.isArray(customersState.customers)
+    ? customersState.customers
+    : Array.isArray(customersRaw)
+      ? customersRaw
+      : [];
+
+  const quotesRaw = readPlainJSON<unknown>(KEYS.quotes, null);
+  const quotesState = unwrapPersist(quotesRaw);
+  const quotes = Array.isArray(quotesState.quotes)
+    ? quotesState.quotes
+    : Array.isArray(quotesRaw)
+      ? quotesRaw
+      : [];
+  const quotesNextNumber =
+    typeof quotesState.nextNumber === "number"
+      ? quotesState.nextNumber
+      : undefined;
+
+  const catalog = readPlainJSON<{
+    printers?: unknown[];
+    materials?: unknown[];
+    marketplaces?: unknown[];
+  }>(KEYS.catalog, {});
+
+  const filamentsRaw = readPlainJSON<unknown>(KEYS.filaments, []);
+
+  const dashboardRaw = readPlainJSON<Record<string, unknown>>(
+    KEYS.dashboard,
+    {},
+  );
+  const goal = getRaw(KEYS.dashboardGoal);
+  const dashboard =
+    goal === null ? { ...dashboardRaw } : { ...dashboardRaw, goal };
+
+  const sections = readPlainJSON<Record<string, boolean>>(KEYS.sections, {});
+
+  return {
+    settings,
+    history,
+    customers,
+    quotes,
+    ...(quotesNextNumber !== undefined ? { quotesNextNumber } : {}),
+    catalog: {
+      // Only custom items are exported — built-ins are app defaults and
+      // must not be duplicated on import.
+      printers: catalog.printers?.filter(isCustomItem) ?? [],
+      materials: catalog.materials?.filter(isCustomItem) ?? [],
+      marketplaces: catalog.marketplaces?.filter(isCustomItem) ?? [],
+    },
+    filaments: Array.isArray(filamentsRaw) ? filamentsRaw : [],
+    theme: getRaw(KEYS.theme) ?? "",
+    dashboard,
+    sections,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Validation                                                         */
+/* ------------------------------------------------------------------ */
+
+function isSyncData(value: unknown): value is SyncData {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const d = value as Record<string, unknown>;
+  if (
+    !d.settings ||
+    typeof d.settings !== "object" ||
+    Array.isArray(d.settings)
+  )
+    return false;
+  if (!Array.isArray(d.history)) return false;
+  if (!Array.isArray(d.customers)) return false;
+  if (!Array.isArray(d.quotes)) return false;
+  if (!Array.isArray(d.filaments)) return false;
+  if (typeof d.theme !== "string") return false;
+  if (
+    !d.dashboard ||
+    typeof d.dashboard !== "object" ||
+    Array.isArray(d.dashboard)
+  )
+    return false;
+  if (
+    !d.sections ||
+    typeof d.sections !== "object" ||
+    Array.isArray(d.sections)
+  )
+    return false;
+  const catalog = d.catalog;
+  if (!catalog || typeof catalog !== "object" || Array.isArray(catalog))
+    return false;
+  const c = catalog as Record<string, unknown>;
+  return (
+    Array.isArray(c.printers) &&
+    Array.isArray(c.materials) &&
+    Array.isArray(c.marketplaces)
+  );
+}
+
+/**
+ * Validate a bundle's format and version. Acts as a TS type guard.
+ */
+export function validateBundle(
+  data: unknown,
+): data is ExportBundle | EncryptedBundle {
+  if (!data || typeof data !== "object") return false;
+  const b = data as Record<string, unknown>;
+  if (b.version !== SYNC_VERSION) return false;
+  if (b.format !== SYNC_FORMAT) return false;
+  if (typeof b.exportedAt !== "string") return false;
+  if (typeof b.appVersion !== "string") return false;
+  if (b.platform !== "web" && b.platform !== "electron") return false;
+  if (typeof b.encrypted !== "boolean") return false;
+  if (b.encrypted) {
+    return (
+      typeof b.data === "string" &&
+      typeof b.salt === "string" &&
+      typeof b.iv === "string" &&
+      typeof b.checksum === "string"
+    );
+  }
+  return isSyncData(b.data);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Merge strategy                                                     */
+/* ------------------------------------------------------------------ */
+
+function itemTimestamp(item: unknown): number {
+  const it = item as {
+    timestamp?: unknown;
+    updatedAt?: unknown;
+    createdAt?: unknown;
+  };
+  if (typeof it.timestamp === "number") return it.timestamp;
+  if (typeof it.updatedAt === "number") return it.updatedAt;
+  if (typeof it.createdAt === "number") return it.createdAt;
+  return 0;
+}
+
+function isNewer(a: unknown, b: unknown): boolean {
+  return itemTimestamp(a) > itemTimestamp(b);
+}
+
+function itemId(item: unknown): string | null {
+  const id = (item as { id?: unknown } | null)?.id;
+  return typeof id === "string" ? id : null;
+}
+
+/**
+ * Deduplicate two collections by `id`, keeping the newest item
+ * (by timestamp/updatedAt/createdAt). Items without an id are appended.
+ */
+function mergeById(
+  local: unknown[],
+  imported: unknown[],
+): {
+  merged: unknown[];
+  conflicts: number;
+} {
+  const byId = new Map<string, unknown>();
+  const withoutId: unknown[] = [];
+  let conflicts = 0;
+
+  for (const item of local) {
+    const id = itemId(item);
+    if (id) byId.set(id, item);
+    else withoutId.push(item);
+  }
+  for (const item of imported) {
+    const id = itemId(item);
+    if (!id) {
+      withoutId.push(item);
+      continue;
+    }
+    const existing = byId.get(id);
+    if (existing) {
+      conflicts++;
+      if (isNewer(item, existing)) byId.set(id, item);
+    } else {
+      byId.set(id, item);
+    }
+  }
+  return { merged: [...byId.values(), ...withoutId], conflicts };
+}
+
+function applyCatalog(
+  data: SyncData["catalog"],
+  mode: "merge" | "replace",
+): { conflicts: number } | null {
+  const local = readPlainJSON<{
+    printers?: unknown[];
+    materials?: unknown[];
+    marketplaces?: unknown[];
+  }>(KEYS.catalog, {});
+  const localPrinters = Array.isArray(local.printers) ? local.printers : [];
+  const localMaterials = Array.isArray(local.materials) ? local.materials : [];
+  const localMarketplaces = Array.isArray(local.marketplaces)
+    ? local.marketplaces
+    : [];
+
+  const importedPrinters = data.printers.filter(isCustomItem);
+  const importedMaterials = data.materials.filter(isCustomItem);
+  const importedMarketplaces = data.marketplaces.filter(isCustomItem);
+
+  const empty =
+    importedPrinters.length === 0 &&
+    importedMaterials.length === 0 &&
+    importedMarketplaces.length === 0;
+  if (empty && mode !== "replace") return null;
+
+  let conflicts = 0;
+  const mergeCustom = (
+    localArr: unknown[],
+    importedArr: unknown[],
+  ): unknown[] => {
+    // Built-in items (custom !== true) are always preserved.
+    const builtIn = localArr.filter((i) => !isCustomItem(i));
+    if (mode === "replace") return [...builtIn, ...importedArr];
+    const result = mergeById(localArr, importedArr);
+    conflicts += result.conflicts;
+    return result.merged;
+  };
+
+  writeJSON(KEYS.catalog, {
+    printers: mergeCustom(localPrinters, importedPrinters),
+    materials: mergeCustom(localMaterials, importedMaterials),
+    marketplaces: mergeCustom(localMarketplaces, importedMarketplaces),
+  });
+  return { conflicts };
+}
+
+function hasContent(value: Record<string, unknown>): boolean {
+  return Object.keys(value).length > 0;
+}
+
+/**
+ * Apply imported SyncData to localStorage.
+ *
+ * Strategy:
+ *  - merge:   collections (history/customers/quotes) are unioned and
+ *             deduplicated by id (newest wins); settings, theme, dashboard
+ *             and sections are replaced by the imported values; catalog
+ *             imports only `custom` items, keeping built-ins.
+ *  - replace: collections and plain values are fully replaced by the
+ *             imported data (built-in catalog items are still preserved).
+ *
+ * Empty imported categories are ignored in merge mode so a device without
+ * data cannot wipe another device's data. Returns the applied categories
+ * and the categories where id collisions were resolved.
+ */
+export function applySyncData(
+  data: SyncData,
+  mode: "merge" | "replace",
+): { imported: string[]; conflicts: string[] } {
+  const imported: string[] = [];
+  const conflicts: string[] = [];
+
+  if (hasContent(data.settings) || mode === "replace") {
+    writeJSON(KEYS.settings, data.settings);
+    imported.push("settings");
+  }
+
+  if (data.history.length > 0 || mode === "replace") {
+    const local = readPersistState(KEYS.history);
+    const localEntries = Array.isArray(local.state.entries)
+      ? local.state.entries
+      : [];
+    if (mode === "replace") {
+      writePersistState(KEYS.history, { entries: data.history });
+    } else {
+      const { merged, conflicts: c } = mergeById(localEntries, data.history);
+      writePersistState(KEYS.history, { entries: merged });
+      if (c > 0) conflicts.push("history");
+    }
+    imported.push("history");
+  }
+
+  if (data.customers.length > 0 || mode === "replace") {
+    const local = readPersistState(KEYS.customers);
+    const localCustomers = Array.isArray(local.state.customers)
+      ? local.state.customers
+      : [];
+    if (mode === "replace") {
+      writePersistState(KEYS.customers, { customers: data.customers });
+    } else {
+      const { merged, conflicts: c } = mergeById(
+        localCustomers,
+        data.customers,
+      );
+      writePersistState(KEYS.customers, { customers: merged });
+      if (c > 0) conflicts.push("customers");
+    }
+    imported.push("customers");
+  }
+
+  if (data.quotes.length > 0 || mode === "replace") {
+    const local = readPersistState(KEYS.quotes);
+    const localQuotes = Array.isArray(local.state.quotes)
+      ? local.state.quotes
+      : [];
+    const localNext =
+      typeof local.state.nextNumber === "number" ? local.state.nextNumber : 1;
+    const importedNext =
+      typeof data.quotesNextNumber === "number" ? data.quotesNextNumber : 1;
+    // Next number must be strictly greater than anything used on either
+    // device to avoid quote-number collisions.
+    const nextNumber = Math.max(localNext, importedNext) + 1;
+    if (mode === "replace") {
+      writePersistState(KEYS.quotes, { quotes: data.quotes, nextNumber });
+    } else {
+      const { merged, conflicts: c } = mergeById(localQuotes, data.quotes);
+      writePersistState(KEYS.quotes, { quotes: merged, nextNumber });
+      if (c > 0) conflicts.push("quotes");
+    }
+    imported.push("quotes");
+  }
+
+  const catalogResult = applyCatalog(data.catalog, mode);
+  if (catalogResult) {
+    imported.push("catalog");
+    if (catalogResult.conflicts > 0) conflicts.push("catalog");
+  }
+
+  if (data.filaments.length > 0 || mode === "replace") {
+    const local = readPlainJSON<unknown[]>(KEYS.filaments, []);
+    const localArr = Array.isArray(local) ? local : [];
+    if (mode === "replace") {
+      writeJSON(KEYS.filaments, data.filaments);
+    } else {
+      const { merged, conflicts: c } = mergeById(localArr, data.filaments);
+      writeJSON(KEYS.filaments, merged);
+      if (c > 0) conflicts.push("filaments");
+    }
+    imported.push("filaments");
+  }
+
+  if (data.theme !== "" || mode === "replace") {
+    localStorage.setItem(KEYS.theme, data.theme);
+    imported.push("theme");
+  }
+
+  if (hasContent(data.dashboard) || mode === "replace") {
+    const { goal, ...dashboardV1 } = data.dashboard;
+    writeJSON(KEYS.dashboard, dashboardV1);
+    if (typeof goal === "string" && goal !== "") {
+      localStorage.setItem(KEYS.dashboardGoal, goal);
+    }
+    imported.push("dashboard");
+  }
+
+  if (hasContent(data.sections) || mode === "replace") {
+    writeJSON(KEYS.sections, data.sections);
+    imported.push("sections");
+  }
+
+  return { imported, conflicts };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Crypto helpers (Web Crypto API)                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Derive an AES-256-GCM key from a password using PBKDF2 (100k iterations,
+ * SHA-256) with the given salt.
+ */
+export async function deriveKey(
+  password: string,
+  salt: Uint8Array,
+): Promise<CryptoKey> {
+  const material = await window.crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return window.crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: salt as BufferSource,
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    material,
+    { name: "AES-GCM", length: KEY_LENGTH_BITS },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Encrypt a string with AES-256-GCM using a fresh random 12-byte IV.
+ */
+export async function encryptData(
+  data: string,
+  key: CryptoKey,
+): Promise<{ iv: Uint8Array; ciphertext: ArrayBuffer }> {
+  const iv = window.crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ciphertext = await window.crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(data),
+  );
+  return { iv, ciphertext };
+}
+
+/**
+ * Decrypt AES-256-GCM ciphertext. Throws on wrong key or tampered data
+ * (GCM authentication failure).
+ */
+export async function decryptData(
+  ciphertext: ArrayBuffer,
+  key: CryptoKey,
+  iv: Uint8Array,
+): Promise<string> {
+  const decrypted = await window.crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: iv as BufferSource },
+    key,
+    ciphertext,
+  );
+  return new TextDecoder().decode(decrypted);
+}
+
+/** SHA-256 checksum of a string, returned base64. */
+export async function hashData(data: string): Promise<string> {
+  const digest = await window.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(data),
+  );
+  return bytesToBase64(new Uint8Array(digest));
+}
+
+/* ------------------------------------------------------------------ */
+/*  Export / import                                                    */
+/* ------------------------------------------------------------------ */
+
+function detectPlatform(): "web" | "electron" {
+  if (
+    typeof navigator !== "undefined" &&
+    /electron/i.test(navigator.userAgent)
+  ) {
+    return "electron";
+  }
+  return "web";
+}
+
+/**
+ * Create an export bundle from all localStorage data.
+ *
+ * With a password the bundle is encrypted (AES-256-GCM + PBKDF2); without
+ * one it is stored as plain JSON with a SHA-256 checksum for integrity.
+ */
+export async function exportBundle(
+  password?: string,
+  platform?: "web" | "electron",
+): Promise<ExportBundle | EncryptedBundle> {
+  const syncData = collectSyncData();
+  const plaintext = JSON.stringify(syncData);
+
+  const base = {
+    version: SYNC_VERSION,
+    format: SYNC_FORMAT,
+    exportedAt: new Date().toISOString(),
+    appVersion: APP_VERSION,
+    platform: platform ?? detectPlatform(),
+  };
+
+  if (password) {
+    const salt = window.crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+    const key = await deriveKey(password, salt);
+    const { iv, ciphertext } = await encryptData(plaintext, key);
+    return {
+      ...base,
+      encrypted: true,
+      data: bytesToBase64(new Uint8Array(ciphertext)),
+      salt: bytesToBase64(salt),
+      iv: bytesToBase64(iv),
+      checksum: await hashData(plaintext),
+    };
+  }
+
+  return {
+    ...base,
+    encrypted: false,
+    data: syncData,
+    checksum: await hashData(plaintext),
+  };
+}
+
+function isEncryptedBundle(
+  bundle: ExportBundle | EncryptedBundle,
+): bundle is EncryptedBundle {
+  return (
+    bundle.encrypted === true &&
+    typeof bundle.salt === "string" &&
+    typeof bundle.iv === "string" &&
+    typeof bundle.checksum === "string" &&
+    typeof bundle.data === "string"
+  );
+}
+
+/**
+ * Validate, decrypt (when needed), verify the checksum and apply a bundle
+ * to localStorage. Shared by `importBundle` (merge) and `importData` (UI).
+ *
+ * Throws PT-BR user-facing errors for: invalid format, missing/wrong
+ * password, corrupted data and checksum mismatch.
+ */
+async function applyImport(
+  bundle: ExportBundle | EncryptedBundle,
+  password: string | undefined,
+  mode: "merge" | "replace",
+): Promise<{ imported: string[]; conflicts: string[] }> {
+  if (!validateBundle(bundle)) {
+    throw new Error(
+      "Formato de arquivo de exportação inválido ou não suportado.",
+    );
+  }
+
+  let syncData: SyncData;
+
+  if (isEncryptedBundle(bundle)) {
+    if (!password) {
+      throw new Error(
+        "Este arquivo está criptografado. Informe a senha para importar.",
+      );
+    }
+    let plaintext: string;
+    try {
+      const salt = base64ToBytes(bundle.salt);
+      const iv = base64ToBytes(bundle.iv);
+      const key = await deriveKey(password, salt);
+      const ciphertext = base64ToBytes(bundle.data);
+      plaintext = await decryptData(ciphertext.buffer as ArrayBuffer, key, iv);
+    } catch {
+      throw new Error(
+        "Senha incorreta ou arquivo corrompido. Não foi possível descriptografar os dados.",
+      );
+    }
+    const checksum = await hashData(plaintext);
+    if (checksum !== bundle.checksum) {
+      throw new Error(
+        "Integridade dos dados comprometida: o checksum não confere. O arquivo pode estar corrompido.",
+      );
+    }
+    try {
+      syncData = JSON.parse(plaintext) as SyncData;
+    } catch {
+      throw new Error(
+        "Dados corrompidos: não foi possível interpretar o conteúdo descriptografado.",
+      );
+    }
+    if (!isSyncData(syncData)) {
+      throw new Error(
+        "Conteúdo do arquivo inválido: a estrutura de dados não é reconhecida.",
+      );
+    }
+  } else {
+    syncData = bundle.data;
+    if (bundle.checksum) {
+      const checksum = await hashData(JSON.stringify(syncData));
+      if (checksum !== bundle.checksum) {
+        throw new Error(
+          "Integridade dos dados comprometida: o checksum não confere. O arquivo pode estar corrompido.",
+        );
+      }
+    }
+  }
+
+  return applySyncData(syncData, mode);
+}
+
+/**
+ * Import a bundle (merge mode): validates format, decrypts when needed,
+ * verifies the checksum and applies the data to localStorage.
+ */
+export async function importBundle(
+  bundle: ExportBundle | EncryptedBundle,
+  password?: string,
+): Promise<{ imported: string[]; conflicts: string[] }> {
+  return applyImport(bundle, password, "merge");
+}
+
+/* ------------------------------------------------------------------ */
+/*  UI-facing wrapper (contract with DataSyncModal)                    */
+/* ------------------------------------------------------------------ */
+
+export interface DataSyncExportResult {
+  fileName: string;
+  sizeBytes: number;
+}
+
+export interface DataSyncImportResult {
+  imported: number;
+  conflicts: number;
+  errors: number;
+}
+
+export interface DataSyncError extends Error {
+  code?: "INVALID_FILE" | "WRONG_PASSWORD";
+}
+
+function dataSyncError(
+  code: "INVALID_FILE" | "WRONG_PASSWORD",
+  message: string,
+): DataSyncError {
+  const err = new Error(message) as DataSyncError;
+  err.code = code;
+  return err;
+}
+
+function triggerDownload(blob: Blob, fileName: string): void {
+  if (typeof document === "undefined") return;
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+function syncFileName(date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const stamp = `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+  return `open3dcalc-sync-${stamp}.json`;
+}
+
+/**
+ * UI wrapper: build a bundle from localStorage, trigger the browser
+ * download and return file metadata for the success message.
+ */
+export async function exportData(options: {
+  password?: string;
+}): Promise<DataSyncExportResult> {
+  const bundle = await exportBundle(options.password);
+  const blob = new Blob([JSON.stringify(bundle)], { type: "application/json" });
+  const fileName = syncFileName();
+  triggerDownload(blob, fileName);
+  return { fileName, sizeBytes: blob.size };
+}
+
+/**
+ * UI wrapper: read a bundle File, import it (merge or replace) and return
+ * the applied/conflict counts. Errors carry a `code` so the UI can show the
+ * right message ('WRONG_PASSWORD' | 'INVALID_FILE').
+ */
+export async function importData(
+  file: File,
+  options: { password?: string; mode: "merge" | "replace" },
+): Promise<DataSyncImportResult> {
+  let bundle: unknown;
+  try {
+    bundle = JSON.parse(await file.text());
+  } catch {
+    throw dataSyncError(
+      "INVALID_FILE",
+      "Formato de arquivo de exportação inválido ou não suportado.",
+    );
+  }
+  if (!validateBundle(bundle)) {
+    throw dataSyncError(
+      "INVALID_FILE",
+      "Formato de arquivo de exportação inválido ou não suportado.",
+    );
+  }
+  try {
+    const result = await applyImport(bundle, options.password, options.mode);
+    return {
+      imported: result.imported.length,
+      conflicts: result.conflicts.length,
+      errors: 0,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Erro desconhecido ao importar.";
+    const code = /senha|criptografad/i.test(message)
+      ? "WRONG_PASSWORD"
+      : "INVALID_FILE";
+    throw dataSyncError(code, message);
+  }
+}
+
+/**
+ * UI wrapper: peek at a bundle File to tell whether it is encrypted,
+ * without decrypting it.
+ */
+export async function isEncrypted(file: File): Promise<boolean> {
+  try {
+    const parsed = JSON.parse(await file.text()) as Record<string, unknown>;
+    return parsed.encrypted === true;
+  } catch {
+    return false;
+  }
+}

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -1,21 +1,31 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import path from 'node:path'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
 
 export default defineConfig({
-  base: './',
+  base: "./",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@/platform': path.resolve(__dirname, 'src/platform'),
-      '@/shared': path.resolve(__dirname, 'src/shared'),
+      "@/platform": path.resolve(__dirname, "src/platform"),
+      "@/shared": path.resolve(__dirname, "src/shared"),
     },
   },
   server: {
     allowedHosts: true,
   },
   optimizeDeps: {
-    exclude: ['three', '@react-three/fiber', '@react-three/drei'],
+    // use-sync-external-store (transitive dep of zustand/react) is CJS and
+    // breaks Vite's interop ("does not provide an export named 'default'").
+    // Pre-bundling the main entry AND the /shim/with-selector.js subpath that
+    // zustand imports forces correct CJS interop.
+    include: [
+      "use-sync-external-store",
+      "use-sync-external-store/shim/with-selector.js",
+      "scheduler",
+      "stats.js",
+    ],
+    exclude: ["three", "@react-three/fiber", "@react-three/drei"],
   },
-})
+});


### PR DESCRIPTION
## Summary

Adds encrypted data export/import for cross-device synchronization (Issue #55). Users can now transfer their settings, history, customers, quotes, catalog, and filament inventory between devices via `.open3dcalc` bundle files — with optional AES-256-GCM encryption.

**100% client-side. Zero server involvement. LGPD compliant.**

## What's included

### Core (`src/shared/lib/dataSync.ts`)
- AES-256-GCM encryption via Web Crypto API (browser-native, zero dependencies)
- PBKDF2 key derivation (100k iterations, SHA-256)
- SHA-256 checksum for integrity verification
- Smart merge strategy: dedup by ID (keep newest), custom catalog items only, `Math.max()` for quote numbering

### UI (`src/shared/components/ui/`)
- `DataSyncModal.tsx` — Export/Import modal with two tabs, password encryption, merge/replace modes
- `DataSyncButton.tsx` — Settings menu entry point (wired into both Web and Desktop headers)
- Full i18n support (PT-BR + EN-US)
- LGPD notice in modal footer

### Privacy
- Updated `PrivacyPolicy.tsx` with Section 8 on data portability (LGPD Art. 18)
- All data processing happens client-side
- No network calls in the sync flow

### Build fix
- Fixed `npm ci` failure: regenerated lock file with missing Windows-only optional deps
- Made `postinstall` (`electron-rebuild`) conditional — skips in CI

## Files changed

| File | Description |
|------|-------------|
| `src/shared/lib/dataSync.ts` | Core crypto + export/import library |
| `src/shared/lib/dataSync.test.ts` | 32 tests for crypto library |
| `src/shared/components/ui/DataSyncModal.tsx` | Export/Import UI modal |
| `src/shared/components/ui/DataSyncButton.tsx` | Settings menu button |
| `src/shared/components/ui/DataSyncModal.test.tsx` | 13 tests for modal |
| `src/shared/components/ui/PrivacyPolicy.tsx` | Section 8: data portability |
| `src/shared/components/Header/Header.tsx` | Web: added sync to settings menu |
| `src/platform/desktop/components/Header/Header.tsx` | Desktop: added sync to actions |
| `src/shared/i18n/locales/pt-BR.json` | PT-BR translations |
| `src/shared/i18n/locales/en-US.json` | EN-US translations |
| `package.json` | Conditional postinstall |
| `package-lock.json` | Regenerated lock file |

## Tests

- 45 new tests (32 lib + 13 UI), all passing
- Full suite: 938/938 tests passing
- TypeScript strict: clean
- ESLint: clean

## Security

- ✅ AES-256-GCM with random salt (16 bytes) + IV (12 bytes) per export
- ✅ PBKDF2 100k iterations (OWASP minimum)
- ✅ Key non-extractable (`extractable: false`)
- ✅ Password never persisted, logged, or included in errors
- ✅ Bundle validation before import
- ✅ Zero network calls confirmed

Closes #55

---

**⚠️ Note from @themis review:** Coverage for `DataSyncModal.tsx` is at 61-64% (below 80% gate). The crypto core (`dataSync.ts`) is at 79%. Recommend adding wrapper tests and empty-password validation as follow-up.

DO NOT merge without human approval. This is a significant feature addition.