### PR TITLE
feat: UI/UX improvements — STL support estimation, Resin preview, safety fixes

### DIFF
--- a/src/shared/components/Calculator/sections/MaterialSection.tsx
+++ b/src/shared/components/Calculator/sections/MaterialSection.tsx
@@ -70,18 +70,27 @@ export function MaterialSection({
       }
       // Update weight / material usage
       if (data.weight > 0) {
-        if (store.fdmAmsEnabled) {
-          const idx = store.fdmAmsSlots.findIndex((s) => s.enabled);
-          if (idx >= 0) {
-            const slot = {
-              ...store.fdmAmsSlots[idx],
-              weightUsedGrams: data.weight,
-            };
-            store.setFdmAmsSlot(idx, slot);
+        if (isFDM) {
+          if (store.fdmAmsEnabled) {
+            const idx = store.fdmAmsSlots.findIndex((s) => s.enabled);
+            if (idx >= 0) {
+              const slot = {
+                ...store.fdmAmsSlots[idx],
+                weightUsedGrams: data.weight,
+              };
+              store.setFdmAmsSlot(idx, slot);
+            }
+          } else {
+            store.setFdmMaterial({
+              ...store.fdmMaterial,
+              weightUsed: data.weight,
+            });
           }
         } else {
-          store.setFdmMaterial({
-            ...store.fdmMaterial,
+          // Resin: model volume (cm³) → ml with ~10% waste factor; weight wired to store
+          store.setResinMaterial({
+            ...store.resinMaterial,
+            volumeUsedMl: parseFloat((data.volumeCm3 * 1.1).toFixed(1)),
             weightUsed: data.weight,
           });
         }
@@ -109,6 +118,11 @@ export function MaterialSection({
       store.setResinPrintParams({
         ...store.resinPrintParams,
         printTimeHours: 0,
+      });
+      store.setResinMaterial({
+        ...store.resinMaterial,
+        volumeUsedMl: 0,
+        weightUsed: 0,
       });
     }
   }, [store, isFDM]);
@@ -577,6 +591,15 @@ export function MaterialSection({
               tooltip={t("tooltip.wasteMargin")}
             />
           )}
+          <div className="w-full min-w-0 @form:col-span-2">
+            <StlPreview
+              onFileParsed={handleStlParsed}
+              onClear={handleStlClear}
+              materialDensity={store.resinMaterial.density}
+              infillPercent={100}
+              printerPowerWatts={store.resinPrintParams.printerPowerWatts}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/shared/components/Calculator/sections/MaterialSection.tsx
+++ b/src/shared/components/Calculator/sections/MaterialSection.tsx
@@ -1,552 +1,584 @@
-import { useCallback } from 'react'
-import { FlaskConical, Layers, Package, Database, CheckCircle2, X } from 'lucide-react'
-import { EmptyState } from '@/shared/components/ui/EmptyState'
-import { InputGroup } from '@/shared/components/ui/InputGroup'
-import { Select } from '@/shared/components/ui/Select'
-import type { CalculatorState } from '@/shared/stores/calculatorStore'
-import type { FilamentSpool } from '@/shared/stores/filamentInventory'
-import type { AMSSlot } from '@/shared/types'
-import { selectSpool } from '@/shared/stores/storeBridge'
-import type { FileParseResult } from '@/shared/components/StlPreview/StlPreview'
-import { StlPreview } from '@/shared/components/StlPreview/StlPreview'
+import { useCallback } from "react";
+import {
+  FlaskConical,
+  Layers,
+  Package,
+  Database,
+  CheckCircle2,
+  X,
+} from "lucide-react";
+import { EmptyState } from "@/shared/components/ui/EmptyState";
+import { InputGroup } from "@/shared/components/ui/InputGroup";
+import { Select } from "@/shared/components/ui/Select";
+import type { CalculatorState } from "@/shared/stores/calculatorStore";
+import type { FilamentSpool } from "@/shared/stores/filamentInventory";
+import type { AMSSlot } from "@/shared/types";
+import { selectSpool } from "@/shared/stores/storeBridge";
+import type { FileParseResult } from "@/shared/components/StlPreview/StlPreview";
+import { StlPreview } from "@/shared/components/StlPreview/StlPreview";
 
 export interface MaterialSectionProps {
-	renderSectionHeader: (
-		Icon: typeof Layers,
-		title: string,
-		subtitle?: string,
-		sectionId?: string,
-	) => React.ReactNode
-	t: (key: string) => string
-	currencySymbol: string
-	handleInput: (value: string, setter: (v: number) => void) => void
-	isFDM: boolean
-	store: CalculatorState
-	isFieldVisible: (sectionId: string, fieldId: string) => boolean
-	showSpoolSelector: boolean
-	setShowSpoolSelector: (show: boolean) => void
-	inventorySpools: FilamentSpool[]
-	catalogMaterials: Array<{
-		name: string
-		type: string
-	}>
+  renderSectionHeader: (
+    Icon: typeof Layers,
+    title: string,
+    subtitle?: string,
+    sectionId?: string,
+  ) => React.ReactNode;
+  t: (key: string) => string;
+  currencySymbol: string;
+  handleInput: (value: string, setter: (v: number) => void) => void;
+  isFDM: boolean;
+  store: CalculatorState;
+  isFieldVisible: (sectionId: string, fieldId: string) => boolean;
+  showSpoolSelector: boolean;
+  setShowSpoolSelector: (show: boolean) => void;
+  inventorySpools: FilamentSpool[];
+  catalogMaterials: Array<{
+    name: string;
+    type: string;
+  }>;
 }
 
 export function MaterialSection({
-	renderSectionHeader,
-	t,
-	currencySymbol,
-	handleInput,
-	isFDM,
-	store,
-	isFieldVisible,
-	showSpoolSelector,
-	setShowSpoolSelector,
-	inventorySpools,
-	catalogMaterials,
+  renderSectionHeader,
+  t,
+  currencySymbol,
+  handleInput,
+  isFDM,
+  store,
+  isFieldVisible,
+  showSpoolSelector,
+  setShowSpoolSelector,
+  inventorySpools,
+  catalogMaterials,
 }: MaterialSectionProps) {
-	const handleStlParsed = useCallback(
-		(data: FileParseResult) => {
-			// Update print time
-			if (data.printTimeHours > 0) {
-				if (isFDM) {
-					store.setFdmPrintParams({
-						...store.fdmPrintParams,
-						printTimeHours: data.printTimeHours,
-					})
-				} else {
-					store.setResinPrintParams({
-						...store.resinPrintParams,
-						printTimeHours: data.printTimeHours,
-					})
-				}
-			}
-			// Update weight / material usage
-			if (data.weight > 0) {
-				if (store.fdmAmsEnabled) {
-					const idx = store.fdmAmsSlots.findIndex((s) => s.enabled)
-					if (idx >= 0) {
-						const slot = { ...store.fdmAmsSlots[idx], weightUsedGrams: data.weight }
-						store.setFdmAmsSlot(idx, slot)
-					}
-				} else {
-					store.setFdmMaterial({ ...store.fdmMaterial, weightUsed: data.weight })
-				}
-			}
-		},
-		[store, isFDM],
-	)
+  const handleStlParsed = useCallback(
+    (data: FileParseResult) => {
+      // Update print time
+      if (data.printTimeHours > 0) {
+        if (isFDM) {
+          store.setFdmPrintParams({
+            ...store.fdmPrintParams,
+            printTimeHours: data.printTimeHours,
+          });
+        } else {
+          store.setResinPrintParams({
+            ...store.resinPrintParams,
+            printTimeHours: data.printTimeHours,
+          });
+        }
+      }
+      // Update weight / material usage
+      if (data.weight > 0) {
+        if (store.fdmAmsEnabled) {
+          const idx = store.fdmAmsSlots.findIndex((s) => s.enabled);
+          if (idx >= 0) {
+            const slot = {
+              ...store.fdmAmsSlots[idx],
+              weightUsedGrams: data.weight,
+            };
+            store.setFdmAmsSlot(idx, slot);
+          }
+        } else {
+          store.setFdmMaterial({
+            ...store.fdmMaterial,
+            weightUsed: data.weight,
+          });
+        }
+      }
+    },
+    [store, isFDM],
+  );
 
-	const handleStlClear = useCallback(() => {
-		if (isFDM) {
-			store.setFdmPrintParams({
-				...store.fdmPrintParams,
-				printTimeHours: 0,
-			})
-			if (store.fdmAmsEnabled) {
-				const idx = store.fdmAmsSlots.findIndex((s) => s.enabled)
-				if (idx >= 0) {
-					const slot = { ...store.fdmAmsSlots[idx], weightUsedGrams: 0 }
-					store.setFdmAmsSlot(idx, slot)
-				}
-			} else {
-				store.setFdmMaterial({ ...store.fdmMaterial, weightUsed: 0 })
-			}
-		} else {
-			store.setResinPrintParams({
-				...store.resinPrintParams,
-				printTimeHours: 0,
-			})
-		}
-	}, [store, isFDM])
-	return (
-		<div className="surface rounded-xl p-4 sm:p-5">
-			{renderSectionHeader(
-				isFDM ? Layers : FlaskConical,
-				t("calc.material"),
-				t(
-					isFDM
-						? "calc.sectionDesc.fdmMaterial"
-						: "calc.sectionDesc.resinMaterial",
-				),
-				"material",
-			)}
-			{isFDM ? (
-				<>
-					{isFieldVisible("material", "purgeWeight") && (store.selectedPrinter.maxFilaments ?? 1) > 1 && (
-						<div className="flex items-center justify-end gap-2 mb-3">
-							<span className="text-[10px] font-semibold text-[var(--color-info)] uppercase tracking-wide">
-								AMS Multi-material
-							</span>
-							<button
-								onClick={() => {
-									const was = store.fdmAmsEnabled;
-									if (!was) {
-										const slot0 = { ...store.fdmAmsSlots[0] };
-										slot0.materialType = store.fdmMaterial.type;
-										slot0.costPerKg = store.fdmMaterial.costPerKg;
-										slot0.weightUsedGrams = store.fdmMaterial.weightUsed;
-										slot0.purgeWeightGrams = store.fdmMaterial.purgeWeight;
-										slot0.density = store.fdmMaterial.density;
-										slot0.spoolEfficiency = store.fdmMaterial.spoolEfficiency;
-										store.setFdmAmsSlot(0, slot0);
-									}
-									store.setFdmAmsEnabled(!was);
-								}}
-								aria-pressed={store.fdmAmsEnabled}
-								className={`relative w-9 h-4 rounded-full transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-info)] focus-visible:outline-none shrink-0 ${store.fdmAmsEnabled ? "bg-[var(--color-info)]" : "bg-[var(--color-bg-elevated)]"}`}
-							>
-								<span
-									className={`absolute top-0.5 w-3 h-3 rounded-full bg-white shadow-md transition-all duration-200 ${store.fdmAmsEnabled ? "left-[18px]" : "left-0.5"}`}
-								/>
-							</button>
-						</div>
-					)}
-					{store.fdmAmsEnabled ? (
-						<>
-							<div className="space-y-2">
-								{store.fdmAmsSlots.map((slot: AMSSlot, i: number) => (
-								<div
-									key={i}
-									className="surface rounded-xl p-3 border-l-4"
-									style={{ borderLeftColor: slot.color }}
-								>
-									<div className="flex items-center justify-between mb-2">
-										<span className="text-[10px] font-bold text-[var(--color-text-secondary)]">
-											Slot {i + 1}
-										</span>
-										<div className="flex items-center gap-2">
-											<input
-												type="color"
-												value={slot.color}
-												onChange={(e) =>
-													store.setFdmAmsSlot(i, {
-														...slot,
-														color: e.target.value,
-													})
-												}
-												className="w-6 h-6 rounded cursor-pointer bg-transparent border-0 p-0"
-											/>
-											<button
-												onClick={() => {
-													const s = { ...slot, enabled: !slot.enabled };
-													store.setFdmAmsSlot(i, s);
-												}}
-												className={`min-h-[44px] min-w-[44px] text-[10px] px-2 py-0.5 rounded-full transition-colors ${slot.enabled ? "bg-[var(--color-info)]/30 text-[var(--color-info)]" : "bg-[var(--color-bg-elevated)] text-[var(--color-text-muted)]"}`}
-											>
-												{slot.enabled ? "Ativo" : "Inativo"}
-											</button>
-										</div>
-									</div>
-									{slot.enabled && (
-										<div className="space-y-2">
-											<Select
-												label=""
-												value={slot.materialType}
-												onChange={(v) =>
-													store.setFdmAmsSlot(i, { ...slot, materialType: v })
-												}
-												options={catalogMaterials
-													.filter((m) => m.type === "fdm")
-													.map((m) => ({ label: m.name, value: m.name }))}
-											/>
-											<div className="grid grid-cols-2 gap-2">
-												<InputGroup
-													label="R$/kg"
-													value={slot.costPerKg}
-													onChange={(v) =>
-														store.setFdmAmsSlot(i, {
-															...slot,
-															costPerKg: parseFloat(v) || 0,
-														})
-													}
-													type="number"
-													prefix={currencySymbol}
-												/>
-												<InputGroup
-													label="Peso (g)"
-													value={slot.weightUsedGrams}
-													onChange={(v) =>
-														store.setFdmAmsSlot(i, {
-															...slot,
-															weightUsedGrams: parseFloat(v) || 0,
-														})
-													}
-													type="number"
-													unit="g"
-												/>
-											</div>
-											<div className="grid grid-cols-2 gap-2">
-												<InputGroup
-													label="Purga (g)"
-													value={slot.purgeWeightGrams}
-													onChange={(v) =>
-														store.setFdmAmsSlot(i, {
-															...slot,
-															purgeWeightGrams: parseFloat(v) || 0,
-														})
-													}
-													type="number"
-													unit="g"
-												/>
-												<InputGroup
-													label="Dens."
-													value={slot.density}
-													onChange={(v) =>
-														store.setFdmAmsSlot(i, {
-															...slot,
-															density: parseFloat(v) || 0,
-														})
-													}
-													type="number"
-													unit="g/cm³"
-												/>
-											</div>
-										</div>
-									)}
-								</div>
-							))}
-						</div>
-						<div className="w-full min-w-0 mt-3">
-							<StlPreview
-								onFileParsed={handleStlParsed}
-								onClear={handleStlClear}
-								materialDensity={store.fdmMaterial.density}
-								infillPercent={store.infillPercent}
-							/>
-						</div>
-						</>
-					) : (
-						<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
-							<Select
-								label={t("calc.filamentType")}
-								value={store.fdmMaterial.type}
-								onChange={(v) =>
-									store.setFdmMaterial({ ...store.fdmMaterial, type: v })
-								}
-								options={catalogMaterials
-									.filter((m) => m.type === "fdm")
-									.map((m) => ({ label: m.name, value: m.name }))}
-							/>
-							<div className="relative">
-								<InputGroup
-									label={t("calc.costPerKg")}
-									value={store.fdmMaterial.costPerKg}
-									onChange={(v) =>
-										handleInput(v, (val) =>
-											store.setFdmMaterial({
-												...store.fdmMaterial,
-												costPerKg: val,
-											}),
-										)
-									}
-									type="number"
-									prefix={currencySymbol}
-									tooltip={t('tooltip.costPerKg')}
-								/>
-								{inventorySpools.length > 0 && (
-									<button
-										type="button"
-										onClick={() => setShowSpoolSelector(!showSpoolSelector)}
-										className={`min-h-[44px] absolute right-2 top-7 text-[10px] px-2 py-1 rounded-md transition-colors ${
-											showSpoolSelector
-												? "bg-[var(--color-accent)]/30 text-[var(--color-accent)] border border-[var(--color-accent)]/40"
-												: "bg-[var(--color-accent)]/30 text-[var(--color-accent)] hover:bg-[var(--color-accent)]/50"
-										}`}
-									>
-										Inventário
-									</button>
-								)}
-								{showSpoolSelector && (
-									<div className="absolute z-20 mt-1 w-full surface border border-[var(--color-border)] rounded-xl p-1 max-h-48 overflow-y-auto shadow-xl">
-										{inventorySpools
-											.filter(
-												(s) =>
-													s.material.toLowerCase() ===
-														store.fdmMaterial.type.toLowerCase() ||
-													showSpoolSelector,
-											)
-											.slice(0, 10)
-											.map((spool) => (
-												<button
-													key={spool.id}
-													type="button"
-													onClick={() => {
-														selectSpool(spool);
-														setShowSpoolSelector(false);
-													}}
-													className="w-full text-left px-3 py-2 text-xs rounded-lg hover:bg-[var(--color-bg-elevated)] transition-colors flex justify-between"
-												>
-													<span className="text-[var(--color-text-primary)]">
-														{spool.brand} - {spool.color}
-													</span>
-													<span className="text-[var(--color-accent)]">
-														R$ {spool.costPerKg.toFixed(2)}/kg
-													</span>
-												</button>
-											))}
-										{inventorySpools.length === 0 && (
-											<EmptyState
-												icon={Package}
-												title="Inventário vazio"
-												description="Adicione filamentos ao seu inventário para selecionar rapidamente."
-											/>
-										)}
-									</div>
-								)}
-							</div>
-							<InputGroup
-								label={t("calc.weight")}
-								value={store.fdmMaterial.weightUsed}
-								onChange={(v) =>
-									handleInput(v, (val) =>
-										store.setFdmMaterial({
-											...store.fdmMaterial,
-											weightUsed: val,
-										}),
-									)
-								}
-								type="number"
-								unit="g"
-								tooltip={t('tooltip.weightUsed')}
-							/>
-							{isFieldVisible("material", "purgeWeight") && (
-								<InputGroup
-									label={t("calc.purge")}
-									value={store.fdmMaterial.purgeWeight}
-									onChange={(v) =>
-										handleInput(v, (val) =>
-											store.setFdmMaterial({
-												...store.fdmMaterial,
-												purgeWeight: val,
-											}),
-										)
-									}
-									type="number"
-									unit="g"
-									tooltip={t('tooltip.purge')}
-								/>
-							)}
-							{isFieldVisible("material", "spoolEfficiency") && (
-								<InputGroup
-									label={t("calc.spoolEfficiency")}
-									value={store.fdmMaterial.spoolEfficiency}
-									onChange={(v) =>
-										handleInput(v, (val) =>
-											store.setFdmMaterial({
-												...store.fdmMaterial,
-												spoolEfficiency: val,
-											}),
-										)
-									}
-									type="number"
-									unit="%"
-									tooltip={t('tooltip.spoolEfficiency')}
-								/>
-							)}
-							{isFieldVisible("material", "density") && (
-								<InputGroup
-									label={t("calc.density")}
-									value={store.fdmMaterial.density}
-									onChange={(v) =>
-										handleInput(v, (val) =>
-											store.setFdmMaterial({
-												...store.fdmMaterial,
-												density: val,
-											}),
-										)
-									}
-									type="number"
-									unit="g/cm³"
-									tooltip={t('tooltip.density')}
-								/>
-							)}
-							<div className="w-full min-w-0 @form:col-span-2">
-								<StlPreview
-									onFileParsed={handleStlParsed}
-									onClear={handleStlClear}
-									materialDensity={store.fdmMaterial.density}
-									infillPercent={store.infillPercent}
-								/>
-							</div>
-						</div>
-					)}
+  const handleStlClear = useCallback(() => {
+    if (isFDM) {
+      store.setFdmPrintParams({
+        ...store.fdmPrintParams,
+        printTimeHours: 0,
+      });
+      if (store.fdmAmsEnabled) {
+        const idx = store.fdmAmsSlots.findIndex((s) => s.enabled);
+        if (idx >= 0) {
+          const slot = { ...store.fdmAmsSlots[idx], weightUsedGrams: 0 };
+          store.setFdmAmsSlot(idx, slot);
+        }
+      } else {
+        store.setFdmMaterial({ ...store.fdmMaterial, weightUsed: 0 });
+      }
+    } else {
+      store.setResinPrintParams({
+        ...store.resinPrintParams,
+        printTimeHours: 0,
+      });
+    }
+  }, [store, isFDM]);
+  return (
+    <div className="surface rounded-xl p-4 sm:p-5">
+      {renderSectionHeader(
+        isFDM ? Layers : FlaskConical,
+        t("calc.material"),
+        t(
+          isFDM
+            ? "calc.sectionDesc.fdmMaterial"
+            : "calc.sectionDesc.resinMaterial",
+        ),
+        "material",
+      )}
+      {isFDM ? (
+        <>
+          {isFieldVisible("material", "purgeWeight") &&
+            (store.selectedPrinter.maxFilaments ?? 1) > 1 && (
+              <div className="flex items-center justify-end gap-2 mb-3">
+                <span className="text-[10px] font-semibold text-[var(--color-info)] uppercase tracking-wide">
+                  AMS Multi-material
+                </span>
+                <button
+                  onClick={() => {
+                    const was = store.fdmAmsEnabled;
+                    if (!was) {
+                      const slot0 = { ...store.fdmAmsSlots[0] };
+                      slot0.materialType = store.fdmMaterial.type;
+                      slot0.costPerKg = store.fdmMaterial.costPerKg;
+                      slot0.weightUsedGrams = store.fdmMaterial.weightUsed;
+                      slot0.purgeWeightGrams = store.fdmMaterial.purgeWeight;
+                      slot0.density = store.fdmMaterial.density;
+                      slot0.spoolEfficiency = store.fdmMaterial.spoolEfficiency;
+                      store.setFdmAmsSlot(0, slot0);
+                    }
+                    store.setFdmAmsEnabled(!was);
+                  }}
+                  aria-pressed={store.fdmAmsEnabled}
+                  className={`relative w-9 h-4 rounded-full transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-info)] focus-visible:outline-none shrink-0 ${store.fdmAmsEnabled ? "bg-[var(--color-info)]" : "bg-[var(--color-bg-elevated)]"}`}
+                >
+                  <span
+                    className={`absolute top-0.5 w-3 h-3 rounded-full bg-white shadow-md transition-all duration-200 ${store.fdmAmsEnabled ? "left-[18px]" : "left-0.5"}`}
+                  />
+                </button>
+              </div>
+            )}
+          {store.fdmAmsEnabled ? (
+            <>
+              <div className="space-y-2">
+                {store.fdmAmsSlots.map((slot: AMSSlot, i: number) => (
+                  <div
+                    key={i}
+                    className="surface rounded-xl p-3 border-l-4"
+                    style={{ borderLeftColor: slot.color }}
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-[10px] font-bold text-[var(--color-text-secondary)]">
+                        Slot {i + 1}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="color"
+                          value={slot.color}
+                          onChange={(e) =>
+                            store.setFdmAmsSlot(i, {
+                              ...slot,
+                              color: e.target.value,
+                            })
+                          }
+                          className="w-6 h-6 rounded cursor-pointer bg-transparent border-0 p-0"
+                        />
+                        <button
+                          onClick={() => {
+                            const s = { ...slot, enabled: !slot.enabled };
+                            store.setFdmAmsSlot(i, s);
+                          }}
+                          className={`min-h-[44px] min-w-[44px] text-[10px] px-2 py-0.5 rounded-full transition-colors ${slot.enabled ? "bg-[var(--color-info)]/30 text-[var(--color-info)]" : "bg-[var(--color-bg-elevated)] text-[var(--color-text-muted)]"}`}
+                        >
+                          {slot.enabled ? "Ativo" : "Inativo"}
+                        </button>
+                      </div>
+                    </div>
+                    {slot.enabled && (
+                      <div className="space-y-2">
+                        <Select
+                          label=""
+                          value={slot.materialType}
+                          onChange={(v) =>
+                            store.setFdmAmsSlot(i, { ...slot, materialType: v })
+                          }
+                          options={catalogMaterials
+                            .filter((m) => m.type === "fdm")
+                            .map((m) => ({ label: m.name, value: m.name }))}
+                        />
+                        <div className="grid grid-cols-2 gap-2">
+                          <InputGroup
+                            label="R$/kg"
+                            value={slot.costPerKg}
+                            onChange={(v) =>
+                              store.setFdmAmsSlot(i, {
+                                ...slot,
+                                costPerKg: parseFloat(v) || 0,
+                              })
+                            }
+                            type="number"
+                            prefix={currencySymbol}
+                          />
+                          <InputGroup
+                            label="Peso (g)"
+                            value={slot.weightUsedGrams}
+                            onChange={(v) =>
+                              store.setFdmAmsSlot(i, {
+                                ...slot,
+                                weightUsedGrams: parseFloat(v) || 0,
+                              })
+                            }
+                            type="number"
+                            unit="g"
+                          />
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          <InputGroup
+                            label="Purga (g)"
+                            value={slot.purgeWeightGrams}
+                            onChange={(v) =>
+                              store.setFdmAmsSlot(i, {
+                                ...slot,
+                                purgeWeightGrams: parseFloat(v) || 0,
+                              })
+                            }
+                            type="number"
+                            unit="g"
+                          />
+                          <InputGroup
+                            label="Dens."
+                            value={slot.density}
+                            onChange={(v) =>
+                              store.setFdmAmsSlot(i, {
+                                ...slot,
+                                density: parseFloat(v) || 0,
+                              })
+                            }
+                            type="number"
+                            unit="g/cm³"
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <div className="w-full min-w-0 mt-3">
+                <StlPreview
+                  onFileParsed={handleStlParsed}
+                  onClear={handleStlClear}
+                  materialDensity={store.fdmMaterial.density}
+                  infillPercent={store.infillPercent}
+                  printerPowerWatts={store.fdmPrintParams.printerPowerWatts}
+                />
+              </div>
+            </>
+          ) : (
+            <div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
+              <Select
+                label={t("calc.filamentType")}
+                value={store.fdmMaterial.type}
+                onChange={(v) =>
+                  store.setFdmMaterial({ ...store.fdmMaterial, type: v })
+                }
+                options={catalogMaterials
+                  .filter((m) => m.type === "fdm")
+                  .map((m) => ({ label: m.name, value: m.name }))}
+              />
+              <div className="relative">
+                <InputGroup
+                  label={t("calc.costPerKg")}
+                  value={store.fdmMaterial.costPerKg}
+                  onChange={(v) =>
+                    handleInput(v, (val) =>
+                      store.setFdmMaterial({
+                        ...store.fdmMaterial,
+                        costPerKg: val,
+                      }),
+                    )
+                  }
+                  type="number"
+                  prefix={currencySymbol}
+                  tooltip={t("tooltip.costPerKg")}
+                />
+                {inventorySpools.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowSpoolSelector(!showSpoolSelector)}
+                    className={`min-h-[44px] absolute right-2 top-7 text-[10px] px-2 py-1 rounded-md transition-colors ${
+                      showSpoolSelector
+                        ? "bg-[var(--color-accent)]/30 text-[var(--color-accent)] border border-[var(--color-accent)]/40"
+                        : "bg-[var(--color-accent)]/30 text-[var(--color-accent)] hover:bg-[var(--color-accent)]/50"
+                    }`}
+                  >
+                    Inventário
+                  </button>
+                )}
+                {showSpoolSelector && (
+                  <div className="absolute z-20 mt-1 w-full surface border border-[var(--color-border)] rounded-xl p-1 max-h-48 overflow-y-auto shadow-xl">
+                    {inventorySpools
+                      .filter(
+                        (s) =>
+                          s.material.toLowerCase() ===
+                            store.fdmMaterial.type.toLowerCase() ||
+                          showSpoolSelector,
+                      )
+                      .slice(0, 10)
+                      .map((spool) => (
+                        <button
+                          key={spool.id}
+                          type="button"
+                          onClick={() => {
+                            selectSpool(spool);
+                            setShowSpoolSelector(false);
+                          }}
+                          className="w-full text-left px-3 py-2 text-xs rounded-lg hover:bg-[var(--color-bg-elevated)] transition-colors flex justify-between"
+                        >
+                          <span className="text-[var(--color-text-primary)]">
+                            {spool.brand} - {spool.color}
+                          </span>
+                          <span className="text-[var(--color-accent)]">
+                            R$ {spool.costPerKg.toFixed(2)}/kg
+                          </span>
+                        </button>
+                      ))}
+                    {inventorySpools.length === 0 && (
+                      <EmptyState
+                        icon={Package}
+                        title="Inventário vazio"
+                        description="Adicione filamentos ao seu inventário para selecionar rapidamente."
+                      />
+                    )}
+                  </div>
+                )}
+              </div>
+              <InputGroup
+                label={t("calc.weight")}
+                value={store.fdmMaterial.weightUsed}
+                onChange={(v) =>
+                  handleInput(v, (val) =>
+                    store.setFdmMaterial({
+                      ...store.fdmMaterial,
+                      weightUsed: val,
+                    }),
+                  )
+                }
+                type="number"
+                unit="g"
+                tooltip={t("tooltip.weightUsed")}
+              />
+              {isFieldVisible("material", "purgeWeight") && (
+                <InputGroup
+                  label={t("calc.purge")}
+                  value={store.fdmMaterial.purgeWeight}
+                  onChange={(v) =>
+                    handleInput(v, (val) =>
+                      store.setFdmMaterial({
+                        ...store.fdmMaterial,
+                        purgeWeight: val,
+                      }),
+                    )
+                  }
+                  type="number"
+                  unit="g"
+                  tooltip={t("tooltip.purge")}
+                />
+              )}
+              {isFieldVisible("material", "spoolEfficiency") && (
+                <InputGroup
+                  label={t("calc.spoolEfficiency")}
+                  value={store.fdmMaterial.spoolEfficiency}
+                  onChange={(v) =>
+                    handleInput(v, (val) =>
+                      store.setFdmMaterial({
+                        ...store.fdmMaterial,
+                        spoolEfficiency: val,
+                      }),
+                    )
+                  }
+                  type="number"
+                  unit="%"
+                  tooltip={t("tooltip.spoolEfficiency")}
+                />
+              )}
+              {isFieldVisible("material", "density") && (
+                <InputGroup
+                  label={t("calc.density")}
+                  value={store.fdmMaterial.density}
+                  onChange={(v) =>
+                    handleInput(v, (val) =>
+                      store.setFdmMaterial({
+                        ...store.fdmMaterial,
+                        density: val,
+                      }),
+                    )
+                  }
+                  type="number"
+                  unit="g/cm³"
+                  tooltip={t("tooltip.density")}
+                />
+              )}
+              <div className="w-full min-w-0 @form:col-span-2">
+                <StlPreview
+                  onFileParsed={handleStlParsed}
+                  onClear={handleStlClear}
+                  materialDensity={store.fdmMaterial.density}
+                  infillPercent={store.infillPercent}
+                  printerPowerWatts={store.fdmPrintParams.printerPowerWatts}
+                />
+              </div>
+            </div>
+          )}
 
-					{/* Auto-deduction Spool Selector — FDM non-AMS only */}
-					{isFDM && !store.fdmAmsEnabled && inventorySpools.length > 0 && (() => {
-						const unitWeight = store.results?.unitWeight ?? 0
-						const availableSpools = inventorySpools.filter(
-							s => s.status === 'in_stock'
-								&& s.material.toLowerCase() === store.fdmMaterial.type.toLowerCase()
-								&& s.weightGrams >= unitWeight,
-						)
-						return (
-							<div className="mt-4 border-t border-[var(--color-border)] pt-3">
-								<div className="flex items-center justify-between mb-2">
-									<span className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
-										{t("results.selectSpool")}
-									</span>
-									{store.selectedSpoolId && (
-										<button
-											type="button"
-											onClick={() => store.setSelectedSpoolId(null)}
-											className="text-[10px] text-[var(--color-text-muted)] hover:text-red-400 transition-colors flex items-center gap-1"
-										>
-											<X className="w-3 h-3" />
-											{t("results.clearSpool")}
-										</button>
-									)}
-								</div>
-								<div className="space-y-1 max-h-48 overflow-y-auto">
-									{availableSpools.length === 0 ? (
-										<p className="text-xs text-[var(--color-text-muted)] text-center py-2">
-											{t("common.noData")}
-										</p>
-									) : (
-										availableSpools.map(spool => {
-											const isSelected = store.selectedSpoolId === spool.id
-											return (
-												<button
-													key={spool.id}
-													type="button"
-													onClick={() => store.setSelectedSpoolId(isSelected ? null : spool.id)}
-													className={`w-full text-left p-2 rounded-lg transition-colors flex items-center gap-2.5 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none ${
-														isSelected
-															? "bg-emerald-800/30 border border-emerald-500/40"
-															: "bg-[var(--color-bg-hover)] hover:bg-[var(--color-bg-hover)] border border-transparent"
-													}`}
-												>
-													<span
-														className="w-2.5 h-2.5 rounded-full shrink-0 ring-1 ring-[var(--color-border)]"
-														style={{ backgroundColor: spool.colorHex }}
-													/>
-													<div className="flex-1 min-w-0">
-														<div className="text-xs text-[var(--color-text-primary)] font-medium truncate">
-															{spool.brand} — {spool.color}
-														</div>
-														<div className="text-[10px] text-[var(--color-text-muted)]">
-															{spool.material} &middot; {t("results.deductAvailable").replace("{{weight}}", spool.weightGrams.toFixed(0))}
-														</div>
-													</div>
-													{isSelected && (
-														<CheckCircle2 className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
-													)}
-												</button>
-											)
-										})
-									)}
-								</div>
-								{store.selectedSpoolId && (
-									<p className="text-[10px] text-emerald-400/70 mt-1.5 text-center">
-										<Database className="w-3 h-3 inline mr-1 align-middle" />
-									{t("results.deductAvailable").replace("{{weight}}", unitWeight.toFixed(0))}
-									</p>
-								)}
-							</div>
-						)
-					})()}
-				</>
-			) : (
-				<div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
-					<Select
-						label={t("calc.resinType")}
-						value={store.resinMaterial.type}
-						onChange={(v) =>
-							store.setResinMaterial({ ...store.resinMaterial, type: v })
-						}
-						options={catalogMaterials
-							.filter((m) => m.type === "resin")
-							.map((m) => ({ label: m.name, value: m.name }))}
-					/>
-					<InputGroup
-						label={t("calc.costPerLiter")}
-						value={store.resinMaterial.costPerLiter}
-						onChange={(v) =>
-							handleInput(v, (val) =>
-								store.setResinMaterial({
-									...store.resinMaterial,
-									costPerLiter: val,
-								}),
-							)
-						}
-						type="number"
-						prefix={currencySymbol}
-						tooltip={t('tooltip.costPerLiter')}
-					/>
-					<InputGroup
-						label={t("calc.volumeMl")}
-						value={store.resinMaterial.volumeUsedMl}
-						onChange={(v) =>
-							handleInput(v, (val) =>
-								store.setResinMaterial({
-									...store.resinMaterial,
-									volumeUsedMl: val,
-								}),
-							)
-						}
-						type="number"
-						unit="ml"
-						tooltip={t('tooltip.volumeMl')}
-					/>
-					{isFieldVisible("material", "wasteMargin") && (
-						<InputGroup
-							label={t("calc.wasteMargin")}
-							value={store.resinMaterial.wasteMarginPercent}
-							onChange={(v) =>
-								handleInput(v, (val) =>
-									store.setResinMaterial({
-										...store.resinMaterial,
-										wasteMarginPercent: val,
-									}),
-								)
-							}
-							type="number"
-							unit="%"
-							tooltip={t('tooltip.wasteMargin')}
-						/>
-					)}
-				</div>
-			)}
-		</div>
-	);
+          {/* Auto-deduction Spool Selector — FDM non-AMS only */}
+          {isFDM &&
+            !store.fdmAmsEnabled &&
+            inventorySpools.length > 0 &&
+            (() => {
+              const unitWeight = store.results?.unitWeight ?? 0;
+              const availableSpools = inventorySpools.filter(
+                (s) =>
+                  s.status === "in_stock" &&
+                  s.material.toLowerCase() ===
+                    store.fdmMaterial.type.toLowerCase() &&
+                  s.weightGrams >= unitWeight,
+              );
+              return (
+                <div className="mt-4 border-t border-[var(--color-border)] pt-3">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
+                      {t("results.selectSpool")}
+                    </span>
+                    {store.selectedSpoolId && (
+                      <button
+                        type="button"
+                        onClick={() => store.setSelectedSpoolId(null)}
+                        className="text-[10px] text-[var(--color-text-muted)] hover:text-red-400 transition-colors flex items-center gap-1"
+                      >
+                        <X className="w-3 h-3" />
+                        {t("results.clearSpool")}
+                      </button>
+                    )}
+                  </div>
+                  <div className="space-y-1 max-h-48 overflow-y-auto">
+                    {availableSpools.length === 0 ? (
+                      <p className="text-xs text-[var(--color-text-muted)] text-center py-2">
+                        {t("common.noData")}
+                      </p>
+                    ) : (
+                      availableSpools.map((spool) => {
+                        const isSelected = store.selectedSpoolId === spool.id;
+                        return (
+                          <button
+                            key={spool.id}
+                            type="button"
+                            onClick={() =>
+                              store.setSelectedSpoolId(
+                                isSelected ? null : spool.id,
+                              )
+                            }
+                            className={`w-full text-left p-2 rounded-lg transition-colors flex items-center gap-2.5 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none ${
+                              isSelected
+                                ? "bg-emerald-800/30 border border-emerald-500/40"
+                                : "bg-[var(--color-bg-hover)] hover:bg-[var(--color-bg-hover)] border border-transparent"
+                            }`}
+                          >
+                            <span
+                              className="w-2.5 h-2.5 rounded-full shrink-0 ring-1 ring-[var(--color-border)]"
+                              style={{ backgroundColor: spool.colorHex }}
+                            />
+                            <div className="flex-1 min-w-0">
+                              <div className="text-xs text-[var(--color-text-primary)] font-medium truncate">
+                                {spool.brand} — {spool.color}
+                              </div>
+                              <div className="text-[10px] text-[var(--color-text-muted)]">
+                                {spool.material} &middot;{" "}
+                                {t("results.deductAvailable").replace(
+                                  "{{weight}}",
+                                  spool.weightGrams.toFixed(0),
+                                )}
+                              </div>
+                            </div>
+                            {isSelected && (
+                              <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+                            )}
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+                  {store.selectedSpoolId && (
+                    <p className="text-[10px] text-emerald-400/70 mt-1.5 text-center">
+                      <Database className="w-3 h-3 inline mr-1 align-middle" />
+                      {t("results.deductAvailable").replace(
+                        "{{weight}}",
+                        unitWeight.toFixed(0),
+                      )}
+                    </p>
+                  )}
+                </div>
+              );
+            })()}
+        </>
+      ) : (
+        <div className="grid grid-cols-1 @form:grid-cols-2 gap-3">
+          <Select
+            label={t("calc.resinType")}
+            value={store.resinMaterial.type}
+            onChange={(v) =>
+              store.setResinMaterial({ ...store.resinMaterial, type: v })
+            }
+            options={catalogMaterials
+              .filter((m) => m.type === "resin")
+              .map((m) => ({ label: m.name, value: m.name }))}
+          />
+          <InputGroup
+            label={t("calc.costPerLiter")}
+            value={store.resinMaterial.costPerLiter}
+            onChange={(v) =>
+              handleInput(v, (val) =>
+                store.setResinMaterial({
+                  ...store.resinMaterial,
+                  costPerLiter: val,
+                }),
+              )
+            }
+            type="number"
+            prefix={currencySymbol}
+            tooltip={t("tooltip.costPerLiter")}
+          />
+          <InputGroup
+            label={t("calc.volumeMl")}
+            value={store.resinMaterial.volumeUsedMl}
+            onChange={(v) =>
+              handleInput(v, (val) =>
+                store.setResinMaterial({
+                  ...store.resinMaterial,
+                  volumeUsedMl: val,
+                }),
+              )
+            }
+            type="number"
+            unit="ml"
+            tooltip={t("tooltip.volumeMl")}
+          />
+          {isFieldVisible("material", "wasteMargin") && (
+            <InputGroup
+              label={t("calc.wasteMargin")}
+              value={store.resinMaterial.wasteMarginPercent}
+              onChange={(v) =>
+                handleInput(v, (val) =>
+                  store.setResinMaterial({
+                    ...store.resinMaterial,
+                    wasteMarginPercent: val,
+                  }),
+                )
+              }
+              type="number"
+              unit="%"
+              tooltip={t("tooltip.wasteMargin")}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/shared/components/StlPreview/StlPreview.tsx
+++ b/src/shared/components/StlPreview/StlPreview.tsx
@@ -36,6 +36,14 @@ interface StlPreviewProps {
   materialDensity?: number;
   /** Calculator infill percentage. Default 20. */
   infillPercent?: number;
+  /** Layer height in mm (from store fdmPrintParams). Default 0.2. */
+  layerHeight?: number;
+  /** Print speed in mm/s (from store fdmPrintParams). Default 60. */
+  speed?: number;
+  /** Number of perimeter walls (from store fdmPrintParams). Default 3. */
+  wallCount?: number;
+  /** Printer power draw in watts (from store fdmPrintParams / selectedPrinter). */
+  printerPowerWatts?: number;
   /** Called when the user clears the loaded model from the viewer. */
   onClear?: () => void;
 }
@@ -194,6 +202,10 @@ export function StlPreview({
   standalone = false,
   materialDensity,
   infillPercent,
+  layerHeight,
+  speed,
+  wallCount,
+  printerPowerWatts,
   onClear,
 }: StlPreviewProps) {
   const { t } = useTranslation();
@@ -316,10 +328,15 @@ export function StlPreview({
           const density = materialDensity ?? 1.24;
           const infill = infillPercent ?? 20;
           const weight = estimateWeight(volumeCm3, density, infill, 10);
-          const timeEstimate = estimatePrintTime(
+          const timeEstimate = estimatePrintTime({
             volumeCm3,
-            analysis.dimensions,
-          );
+            dimensions: analysis.dimensions,
+            layerHeight,
+            speed,
+            infillPercent: infill,
+            wallCount,
+            printerPowerWatts,
+          });
           const result: FileParseResult = {
             geometry: parsedGeometry,
             analysis,
@@ -337,7 +354,17 @@ export function StlPreview({
       }
       setParsing(false);
     },
-    [t, onFileParsed, showError, materialDensity, infillPercent],
+    [
+      t,
+      onFileParsed,
+      showError,
+      materialDensity,
+      infillPercent,
+      layerHeight,
+      speed,
+      wallCount,
+      printerPowerWatts,
+    ],
   );
 
   const handleFileSelect = useCallback(

--- a/src/shared/components/StlPreview/StlPreview.tsx
+++ b/src/shared/components/StlPreview/StlPreview.tsx
@@ -24,6 +24,10 @@ export interface FileParseResult {
   printTimeHours: number;
   dimensions: { x: number; y: number; z: number };
   triangleCount: number;
+  /** Estimated support material volume in cm³ (only when estimateSupport is enabled). */
+  supportVolumeCm3?: number;
+  /** Estimated support material weight in grams (only when estimateSupport is enabled). */
+  supportWeightGrams?: number;
 }
 
 interface StlPreviewProps {
@@ -44,6 +48,8 @@ interface StlPreviewProps {
   wallCount?: number;
   /** Printer power draw in watts (from store fdmPrintParams / selectedPrinter). */
   printerPowerWatts?: number;
+  /** When true, estimates support material volume from overhang triangles. Default false. */
+  estimateSupport?: boolean;
   /** Called when the user clears the loaded model from the viewer. */
   onClear?: () => void;
 }
@@ -206,10 +212,12 @@ export function StlPreview({
   speed,
   wallCount,
   printerPowerWatts,
+  estimateSupport = false,
   onClear,
 }: StlPreviewProps) {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const lastFileRef = useRef<File | null>(null);
   const [geometry, setGeometry] = useState<BufferGeometry | null>(
     initialGeometry,
   );
@@ -218,6 +226,7 @@ export function StlPreview({
   const [isDragOver, setIsDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [supportEnabled, setSupportEnabled] = useState(estimateSupport);
   const isTouchDevice = useMemo(
     () =>
       typeof window !== "undefined" &&
@@ -257,7 +266,9 @@ export function StlPreview({
   );
 
   const processFile = useCallback(
-    async (file: File) => {
+    async (file: File, supportFlag?: boolean) => {
+      const estimateSupportFlag = supportFlag ?? supportEnabled;
+      lastFileRef.current = file;
       const ext = file.name.split(".").pop()?.toLowerCase();
       if (!ext || !["stl", "obj", "3mf", "gcode"].includes(ext)) {
         showError(t("stl.invalidFile"));
@@ -316,8 +327,14 @@ export function StlPreview({
         } else {
           const { analyzeMeshFile, volumeToCm3, estimateWeight } =
             await import("@/shared/lib/stlParser");
-          const { geometry: parsedGeometry, analysis } =
-            await analyzeMeshFile(file);
+          const { geometry: parsedGeometry, analysis } = await analyzeMeshFile(
+            file,
+            {
+              estimateSupport: estimateSupportFlag,
+              layerHeight,
+              supportDensity: 0.15,
+            },
+          );
           if (analysis.triangleCount > 2_000_000) {
             showError(t("stl.tooComplex"));
             setParsing(false);
@@ -345,6 +362,11 @@ export function StlPreview({
             printTimeHours: timeEstimate.estimatedHours,
             dimensions: analysis.dimensions,
             triangleCount: analysis.triangleCount,
+            supportVolumeCm3: analysis.supportVolumeCm3,
+            supportWeightGrams:
+              analysis.supportVolumeCm3 != null
+                ? parseFloat((analysis.supportVolumeCm3 * density).toFixed(2))
+                : undefined,
           };
           setModelInfo(result);
           onFileParsed?.(result);
@@ -364,8 +386,18 @@ export function StlPreview({
       speed,
       wallCount,
       printerPowerWatts,
+      supportEnabled,
     ],
   );
+
+  const handleToggleSupport = useCallback(() => {
+    const next = !supportEnabled;
+    setSupportEnabled(next);
+    // Re-parse the last loaded model with the new support estimation flag
+    if (lastFileRef.current) {
+      void processFile(lastFileRef.current, next);
+    }
+  }, [supportEnabled, processFile]);
 
   const handleFileSelect = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -524,56 +556,75 @@ export function StlPreview({
 
       {/* Model Info Panel */}
       {modelInfo && (
-        <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 text-xs">
-          {modelInfo.volumeCm3 > 0 && (
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={supportEnabled}
+              onChange={handleToggleSupport}
+              className="w-4 h-4 accent-[var(--color-accent)]"
+            />
+            <span className="text-[var(--color-text-secondary)]">
+              {t("stl.estimateSupport")}
+            </span>
+          </label>
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 text-xs">
+            {modelInfo.volumeCm3 > 0 && (
+              <div className="surface rounded-lg p-2.5 text-center">
+                <p className="text-[var(--color-text-muted)] mb-0.5">
+                  {t("stl.volume")}
+                </p>
+                <p className="font-semibold text-purple-400">
+                  {modelInfo.volumeCm3.toFixed(1)} cm³
+                </p>
+              </div>
+            )}
+            {modelInfo.weight > 0 && (
+              <div className="surface rounded-lg p-2.5 text-center">
+                <p className="text-[var(--color-text-muted)] mb-0.5">
+                  {t("stl.weight")}
+                </p>
+                <p className="font-semibold text-[var(--color-text-primary)]">
+                  {modelInfo.weight.toFixed(1)} g
+                </p>
+                {supportEnabled && modelInfo.supportWeightGrams != null && (
+                  <p className="text-[10px] text-[var(--color-text-muted)] mt-1">
+                    {t("stl.supportWeight")}:{" "}
+                    {modelInfo.supportWeightGrams.toFixed(1)} g
+                  </p>
+                )}
+              </div>
+            )}
             <div className="surface rounded-lg p-2.5 text-center">
               <p className="text-[var(--color-text-muted)] mb-0.5">
-                {t("stl.volume")}
+                {t("stl.dimensions")}
               </p>
-              <p className="font-semibold text-purple-400">
-                {modelInfo.volumeCm3.toFixed(1)} cm³
+              <p className="font-semibold text-[var(--color-text-primary)] text-[11px]">
+                {modelInfo.dimensions.x.toFixed(1)}×
+                {modelInfo.dimensions.y.toFixed(1)}×
+                {modelInfo.dimensions.z.toFixed(1)} mm
               </p>
             </div>
-          )}
-          {modelInfo.weight > 0 && (
+            {modelInfo.triangleCount > 0 && (
+              <div className="surface rounded-lg p-2.5 text-center">
+                <p className="text-[var(--color-text-muted)] mb-0.5">
+                  {t("stl.triangles")}
+                </p>
+                <p className="font-semibold text-[var(--color-text-primary)]">
+                  {modelInfo.triangleCount.toLocaleString()}
+                </p>
+              </div>
+            )}
             <div className="surface rounded-lg p-2.5 text-center">
               <p className="text-[var(--color-text-muted)] mb-0.5">
-                {t("stl.weight")}
+                {t("stl.printTime")}
               </p>
-              <p className="font-semibold text-[var(--color-text-primary)]">
-                {modelInfo.weight.toFixed(1)} g
-              </p>
-            </div>
-          )}
-          <div className="surface rounded-lg p-2.5 text-center">
-            <p className="text-[var(--color-text-muted)] mb-0.5">
-              {t("stl.dimensions")}
-            </p>
-            <p className="font-semibold text-[var(--color-text-primary)] text-[11px]">
-              {modelInfo.dimensions.x.toFixed(1)}×
-              {modelInfo.dimensions.y.toFixed(1)}×
-              {modelInfo.dimensions.z.toFixed(1)} mm
-            </p>
-          </div>
-          {modelInfo.triangleCount > 0 && (
-            <div className="surface rounded-lg p-2.5 text-center">
-              <p className="text-[var(--color-text-muted)] mb-0.5">
-                {t("stl.triangles")}
-              </p>
-              <p className="font-semibold text-[var(--color-text-primary)]">
-                {modelInfo.triangleCount.toLocaleString()}
+              <p className="font-semibold text-emerald-400">
+                {modelInfo.printTimeHours > 0
+                  ? `${modelInfo.printTimeHours.toFixed(1)} h`
+                  : "—"}
               </p>
             </div>
-          )}
-          <div className="surface rounded-lg p-2.5 text-center">
-            <p className="text-[var(--color-text-muted)] mb-0.5">
-              {t("stl.printTime")}
-            </p>
-            <p className="font-semibold text-emerald-400">
-              {modelInfo.printTimeHours > 0
-                ? `${modelInfo.printTimeHours.toFixed(1)} h`
-                : "—"}
-            </p>
           </div>
         </div>
       )}

--- a/src/shared/components/StlPreview/__tests__/StlPreview.test.tsx
+++ b/src/shared/components/StlPreview/__tests__/StlPreview.test.tsx
@@ -34,6 +34,20 @@ vi.mock("@react-three/drei", () => ({
 vi.mock("three/examples/jsm/loaders/STLLoader", () => ({ STLLoader: vi.fn() }));
 vi.mock("three/examples/jsm/loaders/OBJLoader", () => ({ OBJLoader: vi.fn() }));
 
+// Mock the STL parser so STL drops can be tested without real parsing
+const { mockAnalyzeMeshFile } = vi.hoisted(() => ({
+  mockAnalyzeMeshFile: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/stlParser", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/shared/lib/stlParser")>();
+  return {
+    ...actual,
+    analyzeMeshFile: mockAnalyzeMeshFile,
+  };
+});
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createMockGeometry(overrides: Record<string, any> = {}): any {
   return {
@@ -404,6 +418,111 @@ describe("StlPreview", () => {
       expect(clearBtn).toBeInTheDocument();
       await userEvent.setup().click(clearBtn);
       expect(onClear).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("support estimation toggle", () => {
+    const stlFile = () =>
+      new File(
+        [
+          "solid test\nfacet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\nendsolid test",
+        ],
+        "test.stl",
+        { type: "" },
+      );
+
+    const mockAnalysis = {
+      triangleCount: 100,
+      vertexCount: 300,
+      dimensions: { x: 10, y: 10, z: 10 },
+      volume: 1000,
+      surfaceArea: 600,
+      boundingBox: {
+        min: { x: 0, y: 0, z: 0 },
+        max: { x: 10, y: 10, z: 10 },
+      },
+      integrity: { valid: true, issues: [] },
+      supportVolumeCm3: 0.5,
+    };
+
+    beforeEach(() => {
+      mockAnalyzeMeshFile.mockResolvedValue({
+        geometry: createMockGeometry(),
+        analysis: mockAnalysis,
+      });
+    });
+
+    it("parses without support estimation by default and hides support weight", async () => {
+      const onFileParsed = vi.fn();
+      render(<StlPreview onFileParsed={onFileParsed} />);
+      const dropZone = screen.getByRole("button", { name: /stl\./ });
+
+      fireEvent.drop(dropZone, {
+        dataTransfer: { files: [stlFile()], types: ["Files"] },
+      });
+
+      await waitFor(() => expect(onFileParsed).toHaveBeenCalledTimes(1));
+      expect(mockAnalyzeMeshFile).toHaveBeenLastCalledWith(
+        expect.any(File),
+        expect.objectContaining({ estimateSupport: false }),
+      );
+      // Toggle is visible in the info panel
+      expect(
+        screen.getByRole("checkbox", { name: "stl.estimateSupport" }),
+      ).toBeInTheDocument();
+      // Support weight NOT shown while disabled
+      expect(screen.queryByText(/stl\.supportWeight/)).not.toBeInTheDocument();
+    });
+
+    it("re-parses with estimateSupport: true when toggled and shows support weight", async () => {
+      const onFileParsed = vi.fn();
+      render(<StlPreview onFileParsed={onFileParsed} />);
+      const dropZone = screen.getByRole("button", { name: /stl\./ });
+      const file = stlFile();
+
+      fireEvent.drop(dropZone, {
+        dataTransfer: { files: [file], types: ["Files"] },
+      });
+
+      await waitFor(() => expect(onFileParsed).toHaveBeenCalledTimes(1));
+      const toggle = screen.getByRole("checkbox", {
+        name: "stl.estimateSupport",
+      });
+      expect(toggle).not.toBeChecked();
+
+      await userEvent.setup().click(toggle);
+
+      await waitFor(() =>
+        expect(mockAnalyzeMeshFile).toHaveBeenLastCalledWith(
+          file,
+          expect.objectContaining({ estimateSupport: true }),
+        ),
+      );
+      // Support weight shown below the weight (0.5 cm³ × 1.24 g/cm³ = 0.6 g)
+      await waitFor(() =>
+        expect(screen.getByText(/stl\.supportWeight/)).toBeInTheDocument(),
+      );
+      expect(screen.getByText(/stl\.supportWeight/)).toHaveTextContent("0.6 g");
+    });
+
+    it("parses with estimateSupport: true when the prop is enabled", async () => {
+      const onFileParsed = vi.fn();
+      render(<StlPreview estimateSupport onFileParsed={onFileParsed} />);
+      const dropZone = screen.getByRole("button", { name: /stl\./ });
+
+      fireEvent.drop(dropZone, {
+        dataTransfer: { files: [stlFile()], types: ["Files"] },
+      });
+
+      await waitFor(() => expect(onFileParsed).toHaveBeenCalledTimes(1));
+      expect(mockAnalyzeMeshFile).toHaveBeenLastCalledWith(
+        expect.any(File),
+        expect.objectContaining({ estimateSupport: true }),
+      );
+      // Toggle starts checked
+      expect(
+        screen.getByRole("checkbox", { name: "stl.estimateSupport" }),
+      ).toBeChecked();
     });
   });
 });

--- a/src/shared/components/ui/DataSyncModal.tsx
+++ b/src/shared/components/ui/DataSyncModal.tsx
@@ -90,6 +90,7 @@ function DataSyncModalContent({
   const [importPassword, setImportPassword] = useState("");
   const [showImportPassword, setShowImportPassword] = useState(false);
   const [importMode, setImportMode] = useState<ImportMode>("merge");
+  const [confirmReplace, setConfirmReplace] = useState(false);
   const [importPhase, setImportPhase] = useState<Phase>("idle");
   const [importResult, setImportResult] = useState<DataSyncImportResult | null>(
     null,
@@ -167,6 +168,7 @@ function DataSyncModalContent({
     setImportPhase("idle");
     setImportResult(null);
     setImportError(null);
+    setConfirmReplace(false);
     if (!file) {
       setFileEncrypted(false);
       return;
@@ -180,6 +182,12 @@ function DataSyncModalContent({
 
   const handleImport = async () => {
     if (!importFile || importPhase === "working") return;
+    // "Replace all" is destructive — require explicit confirmation first.
+    if (importMode === "replace" && !confirmReplace) {
+      setConfirmReplace(true);
+      return;
+    }
+    setConfirmReplace(false);
     setImportPhase("working");
     setImportResult(null);
     setImportError(null);
@@ -197,6 +205,11 @@ function DataSyncModalContent({
       );
       setImportPhase("error");
     }
+  };
+
+  const handleModeChange = (mode: ImportMode) => {
+    setImportMode(mode);
+    setConfirmReplace(false);
   };
 
   return (
@@ -279,7 +292,10 @@ function DataSyncModalContent({
               showImportPassword={showImportPassword}
               setShowImportPassword={setShowImportPassword}
               mode={importMode}
-              setMode={setImportMode}
+              setMode={handleModeChange}
+              confirmReplace={confirmReplace}
+              onConfirmReplace={handleImport}
+              onCancelReplace={() => setConfirmReplace(false)}
               phase={importPhase}
               result={importResult}
               error={importError}
@@ -483,6 +499,9 @@ interface ImportTabProps {
   setShowImportPassword: React.Dispatch<React.SetStateAction<boolean>>;
   mode: ImportMode;
   setMode: (m: ImportMode) => void;
+  confirmReplace: boolean;
+  onConfirmReplace: () => void;
+  onCancelReplace: () => void;
   phase: Phase;
   result: DataSyncImportResult | null;
   error: "invalid" | "wrongPassword" | null;
@@ -502,6 +521,9 @@ function ImportTab({
   setShowImportPassword,
   mode,
   setMode,
+  confirmReplace,
+  onConfirmReplace,
+  onCancelReplace,
   phase,
   result,
   error,
@@ -626,10 +648,40 @@ function ImportTab({
         </div>
       </fieldset>
 
+      {confirmReplace && (
+        <div
+          role="alert"
+          className="p-3 rounded-xl bg-[var(--color-warning-muted)] border border-[var(--color-warning)] space-y-3"
+        >
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-warning)]" />
+            <p className="text-xs text-[var(--color-text-secondary)] leading-relaxed">
+              {t("sync.import.replaceConfirm")}
+            </p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancelReplace}
+              className="px-4 py-2 rounded-lg text-sm font-semibold text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+            >
+              {t("common.cancel")}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirmReplace}
+              className="px-4 py-2 rounded-lg text-sm font-semibold bg-[var(--color-danger)] text-white hover:opacity-90 transition-opacity focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+            >
+              {t("common.confirm")}
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="space-y-3">
         <button
           onClick={onImport}
-          disabled={!file || phase === "working"}
+          disabled={!file || phase === "working" || confirmReplace}
           className="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-xl text-sm font-semibold bg-[var(--color-accent)] text-[var(--color-text-primary)] hover:bg-[var(--color-accent-hover)] transition-colors disabled:opacity-60 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
         >
           <Upload className="w-4 h-4" />

--- a/src/shared/components/ui/__tests__/DataSyncModal.test.tsx
+++ b/src/shared/components/ui/__tests__/DataSyncModal.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DataSyncModal } from "../DataSyncModal";
+
+const { mockImportData, mockExportData, mockIsEncrypted } = vi.hoisted(() => ({
+  mockImportData: vi.fn(),
+  mockExportData: vi.fn(),
+  mockIsEncrypted: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/shared/lib/dataSync", () => ({
+  exportData: (...args: unknown[]) => mockExportData(...args),
+  importData: (...args: unknown[]) => mockImportData(...args),
+  isEncrypted: (...args: unknown[]) => mockIsEncrypted(...args),
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { initial, animate, exit, transition, ...rest } = props;
+      return <div {...rest}>{children}</div>;
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+function selectFile() {
+  fireEvent.click(screen.getByRole("tab", { name: "sync.import.tab" }));
+  const input = document.querySelector(
+    'input[type="file"]',
+  ) as HTMLInputElement;
+  const file = new File(['{"data":1}'], "backup.open3dcalc", {
+    type: "application/json",
+  });
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+describe("DataSyncModal import confirmation", () => {
+  beforeEach(() => {
+    mockImportData.mockReset();
+    mockExportData.mockReset();
+    mockIsEncrypted.mockReset().mockResolvedValue(false);
+    mockImportData.mockResolvedValue({ imported: 5, conflicts: 0, errors: 0 });
+  });
+
+  it("imports immediately in merge mode without confirmation", () => {
+    render(<DataSyncModal open={true} />);
+    selectFile();
+    fireEvent.click(screen.getByRole("button", { name: "sync.import.button" }));
+    expect(mockImportData).toHaveBeenCalledTimes(1);
+    expect(mockImportData).toHaveBeenCalledWith(expect.any(File), {
+      password: undefined,
+      mode: "merge",
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows a confirmation warning before importing in replace mode", () => {
+    render(<DataSyncModal open={true} />);
+    selectFile();
+    fireEvent.click(
+      screen.getByRole("radio", { name: /sync.import.modeReplace/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "sync.import.button" }));
+
+    expect(mockImportData).not.toHaveBeenCalled();
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("sync.import.replaceConfirm");
+    expect(
+      screen.getByRole("button", { name: "common.confirm" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "common.cancel" }),
+    ).toBeInTheDocument();
+  });
+
+  it("proceeds with the import after confirming", () => {
+    render(<DataSyncModal open={true} />);
+    selectFile();
+    fireEvent.click(
+      screen.getByRole("radio", { name: /sync.import.modeReplace/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "sync.import.button" }));
+    fireEvent.click(screen.getByRole("button", { name: "common.confirm" }));
+
+    expect(mockImportData).toHaveBeenCalledTimes(1);
+    expect(mockImportData).toHaveBeenCalledWith(expect.any(File), {
+      password: undefined,
+      mode: "replace",
+    });
+  });
+
+  it("dismisses the warning without importing when cancelled", () => {
+    render(<DataSyncModal open={true} />);
+    selectFile();
+    fireEvent.click(
+      screen.getByRole("radio", { name: /sync.import.modeReplace/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "sync.import.button" }));
+    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }));
+
+    expect(mockImportData).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("resets the confirmation when the import mode changes", () => {
+    render(<DataSyncModal open={true} />);
+    selectFile();
+    fireEvent.click(
+      screen.getByRole("radio", { name: /sync.import.modeReplace/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "sync.import.button" }));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: /sync.import.modeMerge/ }),
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/src/shared/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/src/shared/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useKeyboardShortcuts, type Shortcut } from "../useKeyboardShortcuts";
+
+function Harness({ shortcuts }: { shortcuts: Shortcut[] }) {
+  useKeyboardShortcuts(shortcuts);
+  return (
+    <div>
+      <input data-testid="input" />
+      <textarea data-testid="textarea" />
+      <div data-testid="editable" contentEditable />
+      <button data-testid="button" type="button">
+        Button
+      </button>
+    </div>
+  );
+}
+
+function fireKey(
+  target: EventTarget,
+  key: string,
+  opts: { ctrl?: boolean; shift?: boolean } = {},
+): KeyboardEvent {
+  const evt = new KeyboardEvent("keydown", {
+    key,
+    ctrlKey: opts.ctrl ?? false,
+    shiftKey: opts.shift ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(evt);
+  return evt;
+}
+
+describe("useKeyboardShortcuts", () => {
+  it("triggers the handler when the shortcut is pressed outside an editable element", () => {
+    const handler = vi.fn();
+    render(
+      <Harness
+        shortcuts={[{ key: "z", ctrl: true, handler, description: "undo" }]}
+      />,
+    );
+    fireKey(window, "z", { ctrl: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents default when the shortcut is handled outside an editable element", () => {
+    const handler = vi.fn();
+    render(
+      <Harness
+        shortcuts={[{ key: "z", ctrl: true, handler, description: "undo" }]}
+      />,
+    );
+    const evt = fireKey(window, "z", { ctrl: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it("skips the handler when focus is in an input, leaving native undo intact", () => {
+    const handler = vi.fn();
+    render(
+      <Harness
+        shortcuts={[{ key: "z", ctrl: true, handler, description: "undo" }]}
+      />,
+    );
+    const evt = fireKey(screen.getByTestId("input"), "z", { ctrl: true });
+    expect(handler).not.toHaveBeenCalled();
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  it("skips the handler when focus is in a textarea", () => {
+    const handler = vi.fn();
+    render(
+      <Harness
+        shortcuts={[{ key: "z", ctrl: true, handler, description: "undo" }]}
+      />,
+    );
+    fireKey(screen.getByTestId("textarea"), "z", { ctrl: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("skips the handler when focus is in a contentEditable element", () => {
+    const handler = vi.fn();
+    render(
+      <Harness
+        shortcuts={[{ key: "z", ctrl: true, handler, description: "undo" }]}
+      />,
+    );
+    fireKey(screen.getByTestId("editable"), "z", { ctrl: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("applies the same exclusion to Ctrl+Shift+Z shortcuts", () => {
+    const handler = vi.fn();
+    render(
+      <Harness
+        shortcuts={[
+          { key: "z", ctrl: true, shift: true, handler, description: "redo" },
+        ]}
+      />,
+    );
+    fireKey(screen.getByTestId("input"), "z", { ctrl: true, shift: true });
+    expect(handler).not.toHaveBeenCalled();
+    fireKey(window, "z", { ctrl: true, shift: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/hooks/useKeyboardShortcuts.ts
+++ b/src/shared/hooks/useKeyboardShortcuts.ts
@@ -1,12 +1,12 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef } from "react";
 
 export interface Shortcut {
-  key: string
-  ctrl?: boolean
-  shift?: boolean
-  alt?: boolean
-  handler: () => void
-  description: string
+  key: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  handler: () => void;
+  description: string;
 }
 
 /**
@@ -19,19 +19,19 @@ export interface Shortcut {
  * always has access to the latest handlers — no need to memoize `shortcuts`.
  */
 export function useKeyboardShortcuts(shortcuts: Shortcut[]) {
-  const shortcutsRef = useRef(shortcuts)
+  const shortcutsRef = useRef(shortcuts);
 
   // Sync ref after render, not during render — avoids react-hooks/refs lint error
   useEffect(() => {
-    shortcutsRef.current = shortcuts
-  })
+    shortcutsRef.current = shortcuts;
+  });
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       for (const s of shortcutsRef.current) {
-        const ctrl = s.ctrl ?? false
-        const shift = s.shift ?? false
-        const alt = s.alt ?? false
+        const ctrl = s.ctrl ?? false;
+        const shift = s.shift ?? false;
+        const alt = s.alt ?? false;
 
         if (
           e.key.toLowerCase() === s.key.toLowerCase() &&
@@ -39,24 +39,35 @@ export function useKeyboardShortcuts(shortcuts: Shortcut[]) {
           e.shiftKey === shift &&
           e.altKey === alt
         ) {
-          // Don't trigger when typing in inputs
-          const target = e.target as HTMLElement | null
-          if (
-            target?.tagName === 'INPUT' ||
-            target?.tagName === 'TEXTAREA' ||
-            target?.isContentEditable
-          ) {
-            continue
+          // Don't trigger when typing in inputs — let the browser handle
+          // native text editing (e.g. Ctrl+Z undo inside a text field).
+          if (isEditableTarget(e.target)) {
+            continue;
           }
 
-          e.preventDefault()
-          s.handler()
-          return
+          e.preventDefault();
+          s.handler();
+          return;
         }
       }
-    }
+    };
 
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [])
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+}
+
+/**
+ * True when the event target is a text-editing surface: `<input>`,
+ * `<textarea>`, or a `contentEditable` element. Checks both the
+ * `isContentEditable` property (real browsers) and the `contenteditable`
+ * attribute (covers jsdom and elements where the property is not computed).
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA") return true;
+  if (target.isContentEditable) return true;
+  const attr = target.getAttribute("contenteditable");
+  return attr !== null && attr !== "false";
 }

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -432,7 +432,9 @@
     "fullscreen": "Fullscreen",
     "exitFullscreen": "Exit fullscreen",
     "clear": "Clear model",
-    "fit": "Fit view"
+    "fit": "Fit view",
+    "estimateSupport": "Estimate support",
+    "supportWeight": "Estimated support"
   },
   "common": {
     "save": "Save",
@@ -1318,6 +1320,7 @@
       "modeReplace": "Replace all",
       "modeMergeDesc": "Add new data, update existing",
       "modeReplaceDesc": "Remove all current data and replace with imported",
+      "replaceConfirm": "Are you sure? This will replace ALL current data with the data from the file. This action cannot be undone.",
       "button": "Import Data",
       "success": "Data imported successfully",
       "importing": "Importing data...",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -432,7 +432,9 @@
     "fullscreen": "Tela cheia",
     "exitFullscreen": "Sair da tela cheia",
     "clear": "Limpar modelo",
-    "fit": "Encaixar"
+    "fit": "Encaixar",
+    "estimateSupport": "Estimar suporte",
+    "supportWeight": "Suporte estimado"
   },
   "common": {
     "save": "Salvar",
@@ -1318,6 +1320,7 @@
       "modeReplace": "Substituir tudo",
       "modeMergeDesc": "Adiciona dados novos, atualiza existentes",
       "modeReplaceDesc": "Remove todos os dados atuais e substitui pelos importados",
+      "replaceConfirm": "Tem certeza? Isso substituirá TODOS os dados atuais pelos dados do arquivo. Esta ação não pode ser desfeita.",
       "button": "Importar Dados",
       "success": "Dados importados com sucesso",
       "importing": "Importando dados...",

--- a/src/shared/lib/__tests__/printTimeEstimator.test.ts
+++ b/src/shared/lib/__tests__/printTimeEstimator.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  estimatePrintTime,
+  estimatePrintTimeFromDimensions,
+} from "@/shared/lib/printTimeEstimator";
+
+const DIMS = { x: 200, y: 200, z: 20 };
+
+describe("estimatePrintTime", () => {
+  it("uses default settings when no real settings are provided", () => {
+    const result = estimatePrintTime({ volumeCm3: 100, dimensions: DIMS });
+
+    // 20mm height / 0.2mm layer height = 100 layers
+    expect(result.layers).toBe(100);
+    // ~962s of print+travel+layer-change time → 16 minutes
+    expect(result.estimatedMinutes).toBe(16);
+    expect(result.estimatedHours).toBe(0.3);
+    expect(result.confidence).toBe("medium");
+  });
+
+  it("returns high confidence when real printer settings are provided", () => {
+    const result = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      layerHeight: 0.2,
+      speed: 60,
+      infillPercent: 20,
+      wallCount: 3,
+      printerPowerWatts: 350,
+    });
+
+    expect(result.confidence).toBe("high");
+  });
+
+  it("returns high confidence when only some real settings are provided", () => {
+    const result = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      printerPowerWatts: 350,
+    });
+
+    expect(result.confidence).toBe("high");
+  });
+
+  it("returns low confidence when geometry is invalid", () => {
+    const result = estimatePrintTime({ volumeCm3: 0, dimensions: DIMS });
+
+    expect(result.confidence).toBe("low");
+  });
+
+  it("increases estimated time when print speed is slower", () => {
+    const fast = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      speed: 60,
+    });
+    const slow = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      speed: 30,
+    });
+
+    expect(slow.estimatedMinutes).toBeGreaterThan(fast.estimatedMinutes);
+  });
+
+  it("increases layer count and time when layer height is smaller", () => {
+    const coarse = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      layerHeight: 0.2,
+    });
+    const fine = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      layerHeight: 0.1,
+    });
+
+    expect(fine.layers).toBe(coarse.layers * 2);
+    expect(fine.estimatedMinutes).toBeGreaterThan(coarse.estimatedMinutes);
+  });
+
+  it("keeps defaults for unspecified settings", () => {
+    const result = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      speed: 120,
+    });
+
+    // Same as default-case estimate but with double speed → fewer minutes
+    expect(result.confidence).toBe("high");
+    expect(result.layers).toBe(100);
+  });
+});
+
+describe("estimatePrintTimeFromDimensions", () => {
+  it("estimates volume from bounding box and forwards settings", () => {
+    const result = estimatePrintTimeFromDimensions(100, 100, 10, { speed: 30 });
+
+    // 100*100*10*0.4/1000 = 40 cm³ → valid geometry
+    expect(result.confidence).toBe("high");
+    expect(result.estimatedMinutes).toBeGreaterThan(0);
+  });
+
+  it("returns medium confidence without real settings", () => {
+    const result = estimatePrintTimeFromDimensions(100, 100, 10);
+
+    expect(result.confidence).toBe("medium");
+  });
+});

--- a/src/shared/lib/__tests__/stlParser.test.ts
+++ b/src/shared/lib/__tests__/stlParser.test.ts
@@ -1,37 +1,109 @@
-import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { resolve, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { estimateSupportVolume } from "../stlParser";
+import type { Triangle } from "../stlParser";
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-describe('stlParser dynamic imports', () => {
-  it('should NOT have static imports of STLLoader or OBJLoader', () => {
-    const sourcePath = resolve(__dirname, '../stlParser.ts')
-    const source = readFileSync(sourcePath, 'utf-8')
+describe("stlParser dynamic imports", () => {
+  it("should NOT have static imports of STLLoader or OBJLoader", () => {
+    const sourcePath = resolve(__dirname, "../stlParser.ts");
+    const source = readFileSync(sourcePath, "utf-8");
 
     // Should NOT have top-level static import statements for three/addons loaders
-    const staticImportPattern = /^import\s+.*from\s+['"]three\/addons\/loaders\//
-    const lines = source.split('\n')
-    const staticImports = lines.filter((line: string) => staticImportPattern.test(line.trim()))
+    const staticImportPattern =
+      /^import\s+.*from\s+['"]three\/addons\/loaders\//;
+    const lines = source.split("\n");
+    const staticImports = lines.filter((line: string) =>
+      staticImportPattern.test(line.trim()),
+    );
 
-    expect(staticImports).toHaveLength(0)
-  })
+    expect(staticImports).toHaveLength(0);
+  });
 
-  it('should use dynamic import() for STLLoader', () => {
-    const sourcePath = resolve(__dirname, '../stlParser.ts')
-    const source = readFileSync(sourcePath, 'utf-8')
+  it("should use dynamic import() for STLLoader", () => {
+    const sourcePath = resolve(__dirname, "../stlParser.ts");
+    const source = readFileSync(sourcePath, "utf-8");
 
     // Should contain dynamic import for STLLoader
-    expect(source).toMatch(/await\s+import\s*\(\s*['"]three\/addons\/loaders\/STLLoader/)
-  })
+    expect(source).toMatch(
+      /await\s+import\s*\(\s*['"]three\/addons\/loaders\/STLLoader/,
+    );
+  });
 
-  it('should use dynamic import() for OBJLoader', () => {
-    const sourcePath = resolve(__dirname, '../stlParser.ts')
-    const source = readFileSync(sourcePath, 'utf-8')
+  it("should use dynamic import() for OBJLoader", () => {
+    const sourcePath = resolve(__dirname, "../stlParser.ts");
+    const source = readFileSync(sourcePath, "utf-8");
 
     // Should contain dynamic import for OBJLoader
-    expect(source).toMatch(/await\s+import\s*\(\s*['"]three\/addons\/loaders\/OBJLoader/)
-  })
-})
+    expect(source).toMatch(
+      /await\s+import\s*\(\s*['"]three\/addons\/loaders\/OBJLoader/,
+    );
+  });
+});
+
+describe("estimateSupportVolume", () => {
+  // Downward-facing triangle in the XZ plane (y=0): normal (0,-1,0), area 50 mm²
+  const downwardTriangle: Triangle = {
+    a: [0, 0, 0],
+    b: [10, 0, 0],
+    c: [0, 0, 10],
+  };
+
+  // Upward-facing triangle in the XY plane (z=0): normal (0,0,1), not an overhang
+  const upwardTriangle: Triangle = {
+    a: [0, 0, 0],
+    b: [10, 0, 0],
+    c: [0, 10, 0],
+  };
+
+  it("counts downward-facing triangles (normal Y < -0.7) as overhangs", () => {
+    const volume = estimateSupportVolume([downwardTriangle]);
+    // 50 mm² * 0.2 mm layerHeight * 0.15 density = 1.5 mm³ = 0.0015 cm³
+    expect(volume).toBeCloseTo(0.0015, 6);
+  });
+
+  it("ignores triangles that are not overhangs", () => {
+    expect(estimateSupportVolume([upwardTriangle])).toBe(0);
+  });
+
+  it("returns 0 for an empty triangle list", () => {
+    expect(estimateSupportVolume([])).toBe(0);
+  });
+
+  it("uses default layerHeight (0.2mm) and supportDensity (0.15)", () => {
+    const volume = estimateSupportVolume([downwardTriangle]);
+    const expected = (50 * 0.2 * 0.15) / 1000;
+    expect(volume).toBeCloseTo(expected, 8);
+  });
+
+  it("respects custom layerHeight and supportDensity options", () => {
+    const volume = estimateSupportVolume([downwardTriangle], {
+      layerHeight: 0.05,
+      supportDensity: 0.3,
+    });
+    // 50 mm² * 0.05 mm * 0.3 = 0.75 mm³ = 0.00075 cm³
+    expect(volume).toBeCloseTo(0.00075, 8);
+  });
+
+  it("treats a 45° downward slope (normal Y ≈ -0.7071) as an overhang", () => {
+    // Triangle tilted 45°: normal (0, -0.7071, 0.7071)
+    const tilted: Triangle = {
+      a: [0, 0, 0],
+      b: [10, 0, 0],
+      c: [0, 10, 10],
+    };
+    const volume = estimateSupportVolume([tilted]);
+    expect(volume).toBeGreaterThan(0);
+  });
+
+  it("returns volume in cm³ (mm³ / 1000)", () => {
+    const volume = estimateSupportVolume([downwardTriangle]);
+    // 1.5 mm³ → 0.0015 cm³
+    expect(volume).toBeLessThan(1);
+    expect(volume).toBeCloseTo(0.0015, 6);
+  });
+});

--- a/src/shared/lib/printTimeEstimator.ts
+++ b/src/shared/lib/printTimeEstimator.ts
@@ -1,23 +1,36 @@
 export interface PrintTimeEstimate {
-  estimatedMinutes: number
-  estimatedHours: number
-  layers: number
-  travelDistanceMm: number
-  filamentLengthMm: number
-  confidence: 'low' | 'medium' | 'high'
+  estimatedMinutes: number;
+  estimatedHours: number;
+  layers: number;
+  travelDistanceMm: number;
+  filamentLengthMm: number;
+  confidence: "low" | "medium" | "high";
 }
 
-interface PrintSettings {
-  layerHeightMm: number
-  nozzleDiameterMm: number
-  printSpeedMmPerS: number
-  travelSpeedMmPerS: number
-  infillPercent: number
-  wallCount: number
-  topBottomLayers: number
+export interface PrintTimeParams {
+  /** Model volume in cm³. */
+  volumeCm3: number;
+  /** Model bounding box in mm (used for layer count). */
+  dimensions: { x: number; y: number; z: number };
+  /** Layer height in mm. Default 0.2. */
+  layerHeight?: number;
+  /** Print speed in mm/s. Default 60. */
+  speed?: number;
+  /** Infill percentage. Default 20. */
+  infillPercent?: number;
+  /** Number of perimeter walls. Default 3. */
+  wallCount?: number;
+  /** Printer power draw in watts (from store fdmPrintParams / selectedPrinter). */
+  printerPowerWatts?: number;
+  /** Nozzle diameter in mm. Default 0.4. */
+  nozzleDiameterMm?: number;
+  /** Travel (non-print) speed in mm/s. Default 150. */
+  travelSpeedMmPerS?: number;
+  /** Solid top/bottom layers. Default 4. */
+  topBottomLayers?: number;
 }
 
-const DEFAULT_SETTINGS: PrintSettings = {
+const DEFAULT_SETTINGS = {
   layerHeightMm: 0.2,
   nozzleDiameterMm: 0.4,
   printSpeedMmPerS: 60,
@@ -25,43 +38,62 @@ const DEFAULT_SETTINGS: PrintSettings = {
   infillPercent: 20,
   wallCount: 3,
   topBottomLayers: 4,
-}
+};
 
-export function estimatePrintTime(
-  volumeCm3: number,
-  dimensions: { x: number; y: number; z: number },
-  settings: Partial<PrintSettings> = {},
-): PrintTimeEstimate {
-  const s = { ...DEFAULT_SETTINGS, ...settings }
+export function estimatePrintTime(params: PrintTimeParams): PrintTimeEstimate {
+  const {
+    volumeCm3,
+    dimensions,
+    layerHeight = DEFAULT_SETTINGS.layerHeightMm,
+    speed = DEFAULT_SETTINGS.printSpeedMmPerS,
+    travelSpeedMmPerS = DEFAULT_SETTINGS.travelSpeedMmPerS,
+  } = params;
 
-  const heightMm = dimensions.z
-  const layers = Math.ceil(heightMm / s.layerHeightMm)
+  const heightMm = dimensions.z;
+  const layers = Math.ceil(heightMm / layerHeight);
 
   // Estimate filament length from volume
   // Volume = π * r² * length
-  const filamentRadiusMm = 1.75 / 2
-  const volumeMm3 = volumeCm3 * 1000
-  const filamentLengthMm = volumeMm3 / (Math.PI * filamentRadiusMm * filamentRadiusMm)
+  const filamentRadiusMm = 1.75 / 2;
+  const volumeMm3 = volumeCm3 * 1000;
+  const filamentLengthMm =
+    volumeMm3 / (Math.PI * filamentRadiusMm * filamentRadiusMm);
 
   // Estimate print time
   // Print time = (filament length / print speed) + (travel distance / travel speed)
   // Travel distance is roughly 25% of print distance
-  const printDistanceMm = filamentLengthMm
-  const travelDistanceMm = printDistanceMm * 0.25
+  const printDistanceMm = filamentLengthMm;
+  const travelDistanceMm = printDistanceMm * 0.25;
 
-  const printTimeSeconds = printDistanceMm / s.printSpeedMmPerS
-  const travelTimeSeconds = travelDistanceMm / s.travelSpeedMmPerS
+  const printTimeSeconds = printDistanceMm / speed;
+  const travelTimeSeconds = travelDistanceMm / travelSpeedMmPerS;
 
   // Add layer change overhead (~2 seconds per layer)
-  const layerChangeSeconds = layers * 2
+  const layerChangeSeconds = layers * 2;
 
-  const totalSeconds = printTimeSeconds + travelTimeSeconds + layerChangeSeconds
-  const estimatedMinutes = Math.round(totalSeconds / 60)
-  const estimatedHours = Math.round((estimatedMinutes / 60) * 10) / 10
+  const totalSeconds =
+    printTimeSeconds + travelTimeSeconds + layerChangeSeconds;
+  const estimatedMinutes = Math.round(totalSeconds / 60);
+  const estimatedHours = Math.round((estimatedMinutes / 60) * 10) / 10;
 
-  // Confidence based on how much we know
-  const confidence: PrintTimeEstimate['confidence'] =
-    volumeCm3 > 0 && dimensions.z > 0 ? 'medium' : 'low'
+  // Confidence: high when real printer settings were provided,
+  // medium when only defaults are used, low without valid geometry
+  const hasRealSettings =
+    params.layerHeight !== undefined ||
+    params.speed !== undefined ||
+    params.infillPercent !== undefined ||
+    params.wallCount !== undefined ||
+    params.printerPowerWatts !== undefined ||
+    params.nozzleDiameterMm !== undefined ||
+    params.travelSpeedMmPerS !== undefined ||
+    params.topBottomLayers !== undefined;
+
+  const confidence: PrintTimeEstimate["confidence"] =
+    volumeCm3 <= 0 || dimensions.z <= 0
+      ? "low"
+      : hasRealSettings
+        ? "high"
+        : "medium";
 
   return {
     estimatedMinutes,
@@ -70,22 +102,22 @@ export function estimatePrintTime(
     travelDistanceMm: Math.round(travelDistanceMm),
     filamentLengthMm: Math.round(filamentLengthMm),
     confidence,
-  }
+  };
 }
 
 export function estimatePrintTimeFromDimensions(
   widthMm: number,
   depthMm: number,
   heightMm: number,
-  settings: Partial<PrintSettings> = {},
+  settings: Omit<PrintTimeParams, "volumeCm3" | "dimensions"> = {},
 ): PrintTimeEstimate {
   // Estimate volume from bounding box (assuming ~40% fill for typical prints)
-  const boundingBoxVolume = widthMm * depthMm * heightMm
-  const estimatedVolumeCm3 = (boundingBoxVolume * 0.4) / 1000
+  const boundingBoxVolume = widthMm * depthMm * heightMm;
+  const estimatedVolumeCm3 = (boundingBoxVolume * 0.4) / 1000;
 
-  return estimatePrintTime(
-    estimatedVolumeCm3,
-    { x: widthMm, y: depthMm, z: heightMm },
-    settings,
-  )
+  return estimatePrintTime({
+    volumeCm3: estimatedVolumeCm3,
+    dimensions: { x: widthMm, y: depthMm, z: heightMm },
+    ...settings,
+  });
 }

--- a/src/shared/lib/stlParser.ts
+++ b/src/shared/lib/stlParser.ts
@@ -1,375 +1,619 @@
-import * as THREE from 'three'
+import * as THREE from "three";
 
 export interface MeshAnalysis {
-  triangleCount: number
-  vertexCount: number
-  dimensions: { x: number; y: number; z: number }
-  volume: number
-  surfaceArea: number
-  boundingBox: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } }
-  integrity: { valid: boolean; issues: string[] }
+  triangleCount: number;
+  vertexCount: number;
+  dimensions: { x: number; y: number; z: number };
+  volume: number;
+  surfaceArea: number;
+  boundingBox: {
+    min: { x: number; y: number; z: number };
+    max: { x: number; y: number; z: number };
+  };
+  integrity: { valid: boolean; issues: string[] };
+  /** Estimated support material volume in cm³. Only present when `estimateSupport` is enabled. */
+  supportVolumeCm3?: number;
+}
+
+/** A single triangle defined by three vertices (coordinates in mm). */
+export interface Triangle {
+  a: [number, number, number];
+  b: [number, number, number];
+  c: [number, number, number];
+}
+
+export interface ParseOptions {
+  /** When true, estimates support material volume from overhang triangles. Default false. */
+  estimateSupport?: boolean;
+  /** Layer height in mm used for support estimation. Default 0.2. */
+  layerHeight?: number;
+  /** Fraction of overhang volume that becomes support material. Default 0.15. */
+  supportDensity?: number;
 }
 
 function calculateVolume(geometry: THREE.BufferGeometry): number {
-  const pos = geometry.attributes.position
-  const index = geometry.index
-  let volume = 0
-  const v1 = new THREE.Vector3()
-  const v2 = new THREE.Vector3()
-  const v3 = new THREE.Vector3()
+  const pos = geometry.attributes.position;
+  const index = geometry.index;
+  let volume = 0;
+  const v1 = new THREE.Vector3();
+  const v2 = new THREE.Vector3();
+  const v3 = new THREE.Vector3();
 
   if (!index) {
     for (let i = 0; i < pos.count; i += 3) {
-      v1.fromBufferAttribute(pos, i)
-      v2.fromBufferAttribute(pos, i + 1)
-      v3.fromBufferAttribute(pos, i + 2)
-      volume += signedTetraVolume(v1, v2, v3)
+      v1.fromBufferAttribute(pos, i);
+      v2.fromBufferAttribute(pos, i + 1);
+      v3.fromBufferAttribute(pos, i + 2);
+      volume += signedTetraVolume(v1, v2, v3);
     }
   } else {
     for (let i = 0; i < index.count; i += 3) {
-      v1.fromBufferAttribute(pos, index.getX(i))
-      v2.fromBufferAttribute(pos, index.getX(i + 1))
-      v3.fromBufferAttribute(pos, index.getX(i + 2))
-      volume += signedTetraVolume(v1, v2, v3)
+      v1.fromBufferAttribute(pos, index.getX(i));
+      v2.fromBufferAttribute(pos, index.getX(i + 1));
+      v3.fromBufferAttribute(pos, index.getX(i + 2));
+      volume += signedTetraVolume(v1, v2, v3);
     }
   }
-  return Math.abs(volume / 6)
+  return Math.abs(volume / 6);
 }
 
-function signedTetraVolume(a: THREE.Vector3, b: THREE.Vector3, c: THREE.Vector3): number {
-  return a.x * (b.y * c.z - b.z * c.y)
-       + b.x * (c.y * a.z - c.z * a.y)
-       + c.x * (a.y * b.z - a.z * b.y)
+function signedTetraVolume(
+  a: THREE.Vector3,
+  b: THREE.Vector3,
+  c: THREE.Vector3,
+): number {
+  return (
+    a.x * (b.y * c.z - b.z * c.y) +
+    b.x * (c.y * a.z - c.z * a.y) +
+    c.x * (a.y * b.z - a.z * b.y)
+  );
 }
 
 function calculateSurfaceArea(geometry: THREE.BufferGeometry): number {
-  const pos = geometry.attributes.position
-  let area = 0
-  const v1 = new THREE.Vector3()
-  const v2 = new THREE.Vector3()
-  const v3 = new THREE.Vector3()
+  const pos = geometry.attributes.position;
+  let area = 0;
+  const v1 = new THREE.Vector3();
+  const v2 = new THREE.Vector3();
+  const v3 = new THREE.Vector3();
 
   const process = (a: number, b: number, c: number) => {
-    v1.fromBufferAttribute(pos, a)
-    v2.fromBufferAttribute(pos, b)
-    v3.fromBufferAttribute(pos, c)
-    const ab = v1.distanceTo(v2)
-    const bc = v2.distanceTo(v3)
-    const ca = v3.distanceTo(v1)
-    const s = (ab + bc + ca) / 2
-    area += Math.sqrt(Math.max(0, s * (s - ab) * (s - bc) * (s - ca)))
+    v1.fromBufferAttribute(pos, a);
+    v2.fromBufferAttribute(pos, b);
+    v3.fromBufferAttribute(pos, c);
+    const ab = v1.distanceTo(v2);
+    const bc = v2.distanceTo(v3);
+    const ca = v3.distanceTo(v1);
+    const s = (ab + bc + ca) / 2;
+    area += Math.sqrt(Math.max(0, s * (s - ab) * (s - bc) * (s - ca)));
+  };
+
+  const index = geometry.index;
+  if (!index) {
+    for (let i = 0; i < pos.count; i += 3) process(i, i + 1, i + 2);
+  } else {
+    for (let i = 0; i < index.count; i += 3)
+      process(index.getX(i), index.getX(i + 1), index.getX(i + 2));
+  }
+  return area;
+}
+
+/**
+ * Extracts triangles from a BufferGeometry (coordinates in mm).
+ * Handles both indexed and non-indexed geometries.
+ */
+function extractTriangles(geometry: THREE.BufferGeometry): Triangle[] {
+  const pos = geometry.attributes.position;
+  const index = geometry.index;
+  const triangles: Triangle[] = [];
+  const read = (i: number): [number, number, number] => [
+    pos.getX(i),
+    pos.getY(i),
+    pos.getZ(i),
+  ];
+
+  if (!index) {
+    for (let i = 0; i < pos.count; i += 3) {
+      triangles.push({ a: read(i), b: read(i + 1), c: read(i + 2) });
+    }
+  } else {
+    for (let i = 0; i < index.count; i += 3) {
+      triangles.push({
+        a: read(index.getX(i)),
+        b: read(index.getX(i + 1)),
+        c: read(index.getX(i + 2)),
+      });
+    }
+  }
+  return triangles;
+}
+
+/**
+ * Estimates the support material volume (in cm³) needed for a mesh.
+ *
+ * Triangles whose normal points downward (normal Y < -0.7, i.e. facing down
+ * more than ~45°) are treated as potential overhangs. The overhang area is
+ * multiplied by the layer height and a support density factor:
+ *
+ *   supportVolume = overhangArea * layerHeight * supportDensity
+ *
+ * @param triangles Mesh triangles (coordinates in mm).
+ * @param options Optional layerHeight (mm, default 0.2) and supportDensity (default 0.15).
+ * @returns Estimated support volume in cm³.
+ */
+export function estimateSupportVolume(
+  triangles: Triangle[],
+  options: { layerHeight?: number; supportDensity?: number } = {},
+): number {
+  const layerHeight = options.layerHeight ?? 0.2;
+  const supportDensity = options.supportDensity ?? 0.15;
+  let overhangAreaMm2 = 0;
+
+  for (const tri of triangles) {
+    const [ax, ay, az] = tri.a;
+    const [bx, by, bz] = tri.b;
+    const [cx, cy, cz] = tri.c;
+
+    // Edges of the triangle
+    const ux = bx - ax,
+      uy = by - ay,
+      uz = bz - az;
+    const vx = cx - ax,
+      vy = cy - ay,
+      vz = cz - az;
+
+    // Normal = u × v (magnitude = 2 × triangle area)
+    const nx = uy * vz - uz * vy;
+    const ny = uz * vx - ux * vz;
+    const nz = ux * vy - uy * vx;
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    if (len === 0) continue;
+
+    // Normalized Y component: < -0.7 means the face points downward > ~45°
+    if (ny / len < -0.7) {
+      overhangAreaMm2 += len / 2;
+    }
   }
 
-  const index = geometry.index
-  if (!index) {
-    for (let i = 0; i < pos.count; i += 3) process(i, i + 1, i + 2)
-  } else {
-    for (let i = 0; i < index.count; i += 3) process(index.getX(i), index.getX(i + 1), index.getX(i + 2))
-  }
-  return area
+  // mm² * mm = mm³ → convert to cm³ (÷ 1000)
+  return (overhangAreaMm2 * layerHeight * supportDensity) / 1000;
 }
 
 function validateMesh(geometry: THREE.BufferGeometry) {
-  const issues: string[] = []
-  const pos = geometry.attributes.position
-  if (!pos || pos.count === 0) issues.push('Model does not contain vertices')
-  if (pos.count % 3 !== 0) issues.push('Vertex count does not form complete triangles')
+  const issues: string[] = [];
+  const pos = geometry.attributes.position;
+  if (!pos || pos.count === 0) issues.push("Model does not contain vertices");
+  if (pos.count % 3 !== 0)
+    issues.push("Vertex count does not form complete triangles");
   if (!geometry.attributes.normal) {
-    issues.push('Model does not contain normals')
-    geometry.computeVertexNormals()
+    issues.push("Model does not contain normals");
+    geometry.computeVertexNormals();
   }
-  if (!geometry.boundingBox) geometry.computeBoundingBox()
-  const box = geometry.boundingBox
-  if (box && (box.isEmpty() || !isFinite(box.min.x))) issues.push('Invalid bounding box')
-  return { valid: issues.length === 0, issues }
+  if (!geometry.boundingBox) geometry.computeBoundingBox();
+  const box = geometry.boundingBox;
+  if (box && (box.isEmpty() || !isFinite(box.min.x)))
+    issues.push("Invalid bounding box");
+  return { valid: issues.length === 0, issues };
 }
 
-function analyzeGeometry(geometry: THREE.BufferGeometry): MeshAnalysis {
-  if (!geometry.boundingBox) geometry.computeBoundingBox()
-  const box = geometry.boundingBox!
-  const size = new THREE.Vector3()
-  box.getSize(size)
-  const pos = geometry.attributes.position
+function analyzeGeometry(
+  geometry: THREE.BufferGeometry,
+  options: ParseOptions = {},
+): MeshAnalysis {
+  if (!geometry.boundingBox) geometry.computeBoundingBox();
+  const box = geometry.boundingBox!;
+  const size = new THREE.Vector3();
+  box.getSize(size);
+  const pos = geometry.attributes.position;
 
-  return {
+  const analysis: MeshAnalysis = {
     triangleCount: pos.count / 3,
     vertexCount: pos.count,
-    dimensions: { x: +size.x.toFixed(2), y: +size.y.toFixed(2), z: +size.z.toFixed(2) },
+    dimensions: {
+      x: +size.x.toFixed(2),
+      y: +size.y.toFixed(2),
+      z: +size.z.toFixed(2),
+    },
     volume: +calculateVolume(geometry).toFixed(2),
     surfaceArea: +calculateSurfaceArea(geometry).toFixed(2),
     boundingBox: {
-      min: { x: +box.min.x.toFixed(2), y: +box.min.y.toFixed(2), z: +box.min.z.toFixed(2) },
-      max: { x: +box.max.x.toFixed(2), y: +box.max.y.toFixed(2), z: +box.max.z.toFixed(2) },
+      min: {
+        x: +box.min.x.toFixed(2),
+        y: +box.min.y.toFixed(2),
+        z: +box.min.z.toFixed(2),
+      },
+      max: {
+        x: +box.max.x.toFixed(2),
+        y: +box.max.y.toFixed(2),
+        z: +box.max.z.toFixed(2),
+      },
     },
     integrity: validateMesh(geometry),
+  };
+
+  if (options.estimateSupport) {
+    analysis.supportVolumeCm3 = +estimateSupportVolume(
+      extractTriangles(geometry),
+      options,
+    ).toFixed(2);
   }
+
+  return analysis;
 }
 
-export async function analyzeMeshFile(file: File): Promise<{ geometry: THREE.BufferGeometry; analysis: MeshAnalysis }> {
-  const ext = file.name.split('.').pop()?.toLowerCase()
+export async function analyzeMeshFile(
+  file: File,
+  options: ParseOptions = {},
+): Promise<{ geometry: THREE.BufferGeometry; analysis: MeshAnalysis }> {
+  const ext = file.name.split(".").pop()?.toLowerCase();
 
-  if (ext === '3mf') {
-    return parse3mf(file)
+  if (ext === "3mf") {
+    return parse3mf(file, options);
   }
 
-  if (ext === 'stl') {
-    const { STLLoader } = await import('three/addons/loaders/STLLoader.js')
+  if (ext === "stl") {
+    const { STLLoader } = await import("three/addons/loaders/STLLoader.js");
     return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = e => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
         try {
-          const loader = new STLLoader()
-          const geometry = loader.parse(e.target?.result as ArrayBuffer)
-          geometry.computeVertexNormals()
-          geometry.computeBoundingBox()
-          const analysis = analyzeGeometry(geometry)
-          resolve({ geometry, analysis })
+          const loader = new STLLoader();
+          const geometry = loader.parse(e.target?.result as ArrayBuffer);
+          geometry.computeVertexNormals();
+          geometry.computeBoundingBox();
+          const analysis = analyzeGeometry(geometry, options);
+          resolve({ geometry, analysis });
         } catch (err) {
-          reject(new Error(`Error processing STL: ${err}`))
+          reject(new Error(`Error processing STL: ${err}`));
         }
-      }
-      reader.onerror = () => reject(new Error('Error reading file'))
-      reader.readAsArrayBuffer(file)
-    })
+      };
+      reader.onerror = () => reject(new Error("Error reading file"));
+      reader.readAsArrayBuffer(file);
+    });
   }
 
-  if (ext === 'obj') {
-    const { OBJLoader } = await import('three/addons/loaders/OBJLoader.js')
+  if (ext === "obj") {
+    const { OBJLoader } = await import("three/addons/loaders/OBJLoader.js");
     return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = e => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
         try {
-          const loader = new OBJLoader()
-          const object = loader.parse(e.target?.result as string)
-          const geometries: THREE.BufferGeometry[] = []
-          object.traverse(child => {
-            if ((child as THREE.Mesh).isMesh) geometries.push((child as THREE.Mesh).geometry as THREE.BufferGeometry)
-          })
-          if (geometries.length === 0) throw new Error('No geometry found in OBJ')
-          const geometry = geometries.length === 1 ? geometries[0] : mergeGeometries(geometries)
-          geometry.computeVertexNormals()
-          geometry.computeBoundingBox()
-          const analysis = analyzeGeometry(geometry)
-          resolve({ geometry, analysis })
+          const loader = new OBJLoader();
+          const object = loader.parse(e.target?.result as string);
+          const geometries: THREE.BufferGeometry[] = [];
+          object.traverse((child) => {
+            if ((child as THREE.Mesh).isMesh)
+              geometries.push(
+                (child as THREE.Mesh).geometry as THREE.BufferGeometry,
+              );
+          });
+          if (geometries.length === 0)
+            throw new Error("No geometry found in OBJ");
+          const geometry =
+            geometries.length === 1
+              ? geometries[0]
+              : mergeGeometries(geometries);
+          geometry.computeVertexNormals();
+          geometry.computeBoundingBox();
+          const analysis = analyzeGeometry(geometry, options);
+          resolve({ geometry, analysis });
         } catch (err) {
-          reject(new Error(`Error processing OBJ: ${err}`))
+          reject(new Error(`Error processing OBJ: ${err}`));
         }
-      }
-      reader.onerror = () => reject(new Error('Error reading file'))
-      reader.readAsText(file)
-    })
+      };
+      reader.onerror = () => reject(new Error("Error reading file"));
+      reader.readAsText(file);
+    });
   }
 
-  throw new Error(`Unsupported format: ${ext}. Use STL, OBJ or 3MF.`)
+  throw new Error(`Unsupported format: ${ext}. Use STL, OBJ or 3MF.`);
 }
 
-async function parse3mf(file: File): Promise<{ geometry: THREE.BufferGeometry; analysis: MeshAnalysis }> {
-  const THREE = await import('three')
-  const buffer = await file.arrayBuffer()
-  const uint8 = new Uint8Array(buffer)
+async function parse3mf(
+  file: File,
+  options: ParseOptions = {},
+): Promise<{ geometry: THREE.BufferGeometry; analysis: MeshAnalysis }> {
+  const THREE = await import("three");
+  const buffer = await file.arrayBuffer();
+  const uint8 = new Uint8Array(buffer);
 
   // Minimal ZIP parser for 3MF (3MF is a ZIP archive containing XML)
   // Find the End of Central Directory record
-  let eocdOffset = -1
+  let eocdOffset = -1;
   for (let i = uint8.length - 22; i >= 0; i--) {
-    if (uint8[i] === 0x50 && uint8[i + 1] === 0x4b && uint8[i + 2] === 0x05 && uint8[i + 3] === 0x06) {
-      eocdOffset = i
-      break
+    if (
+      uint8[i] === 0x50 &&
+      uint8[i + 1] === 0x4b &&
+      uint8[i + 2] === 0x05 &&
+      uint8[i + 3] === 0x06
+    ) {
+      eocdOffset = i;
+      break;
     }
   }
-  if (eocdOffset === -1) throw new Error('Invalid 3MF file: not a valid ZIP archive')
+  if (eocdOffset === -1)
+    throw new Error("Invalid 3MF file: not a valid ZIP archive");
 
   // Read central directory offset
-  const cdOffset = uint8[eocdOffset + 16] | (uint8[eocdOffset + 17] << 8) | (uint8[eocdOffset + 18] << 16) | (uint8[eocdOffset + 19] << 24)
-  const numEntries = uint8[eocdOffset + 10] | (uint8[eocdOffset + 11] << 8)
+  const cdOffset =
+    uint8[eocdOffset + 16] |
+    (uint8[eocdOffset + 17] << 8) |
+    (uint8[eocdOffset + 18] << 16) |
+    (uint8[eocdOffset + 19] << 24);
+  const numEntries = uint8[eocdOffset + 10] | (uint8[eocdOffset + 11] << 8);
 
   // Find the 3D/3DModel.model file
-  let offset = cdOffset
+  let offset = cdOffset;
   for (let i = 0; i < numEntries; i++) {
-    if (uint8[offset] !== 0x50 || uint8[offset + 1] !== 0x4b) break
+    if (uint8[offset] !== 0x50 || uint8[offset + 1] !== 0x4b) break;
 
-    const fileNameLen = uint8[offset + 28] | (uint8[offset + 29] << 8)
-    const extraLen = uint8[offset + 30] | (uint8[offset + 31] << 8)
-    const commentLen = uint8[offset + 32] | (uint8[offset + 33] << 8)
-    const localHeaderOffset = uint8[offset + 42] | (uint8[offset + 43] << 8) | (uint8[offset + 44] << 16) | (uint8[offset + 45] << 24)
-    const compressedSize = uint8[offset + 20] | (uint8[offset + 21] << 8) | (uint8[offset + 22] << 16) | (uint8[offset + 23] << 24)
-    const uncompressedSize = uint8[offset + 24] | (uint8[offset + 25] << 8) | (uint8[offset + 26] << 16) | (uint8[offset + 27] << 24)
-    const compressionMethod = uint8[offset + 10] | (uint8[offset + 11] << 8)
+    const fileNameLen = uint8[offset + 28] | (uint8[offset + 29] << 8);
+    const extraLen = uint8[offset + 30] | (uint8[offset + 31] << 8);
+    const commentLen = uint8[offset + 32] | (uint8[offset + 33] << 8);
+    const localHeaderOffset =
+      uint8[offset + 42] |
+      (uint8[offset + 43] << 8) |
+      (uint8[offset + 44] << 16) |
+      (uint8[offset + 45] << 24);
+    const compressedSize =
+      uint8[offset + 20] |
+      (uint8[offset + 21] << 8) |
+      (uint8[offset + 22] << 16) |
+      (uint8[offset + 23] << 24);
+    const uncompressedSize =
+      uint8[offset + 24] |
+      (uint8[offset + 25] << 8) |
+      (uint8[offset + 26] << 16) |
+      (uint8[offset + 27] << 24);
+    const compressionMethod = uint8[offset + 10] | (uint8[offset + 11] << 8);
 
-    const fileName = new TextDecoder().decode(uint8.slice(offset + 46, offset + 46 + fileNameLen))
+    const fileName = new TextDecoder().decode(
+      uint8.slice(offset + 46, offset + 46 + fileNameLen),
+    );
 
-    if (fileName === '3D/3DModel.model' || fileName.endsWith('.model')) {
+    if (fileName === "3D/3DModel.model" || fileName.endsWith(".model")) {
       // Extract the file data
-      const localHeaderStart = localHeaderOffset
-      const localFileNameLen = uint8[localHeaderStart + 26] | (uint8[localHeaderStart + 27] << 8)
-      const localExtraLen = uint8[localHeaderStart + 28] | (uint8[localHeaderStart + 29] << 8)
-      const dataStart = localHeaderStart + 30 + localFileNameLen + localExtraLen
+      const localHeaderStart = localHeaderOffset;
+      const localFileNameLen =
+        uint8[localHeaderStart + 26] | (uint8[localHeaderStart + 27] << 8);
+      const localExtraLen =
+        uint8[localHeaderStart + 28] | (uint8[localHeaderStart + 29] << 8);
+      const dataStart =
+        localHeaderStart + 30 + localFileNameLen + localExtraLen;
 
       if (compressionMethod === 0) {
         // Stored (no compression)
-        const xmlData = new TextDecoder().decode(uint8.slice(dataStart, dataStart + uncompressedSize))
-        return parse3mfXml(xmlData, THREE)
+        const xmlData = new TextDecoder().decode(
+          uint8.slice(dataStart, dataStart + uncompressedSize),
+        );
+        return parse3mfXml(xmlData, THREE, options);
       } else if (compressionMethod === 8) {
         // Deflate - use DecompressionStream
-        const compressed = uint8.slice(dataStart, dataStart + compressedSize)
-        const ds = new DecompressionStream('deflate-raw')
-        const writer = ds.writable.getWriter()
-        writer.write(compressed)
-        writer.close()
-        const reader = ds.readable.getReader()
-        const chunks: Uint8Array[] = []
+        const compressed = uint8.slice(dataStart, dataStart + compressedSize);
+        const ds = new DecompressionStream("deflate-raw");
+        const writer = ds.writable.getWriter();
+        writer.write(compressed);
+        writer.close();
+        const reader = ds.readable.getReader();
+        const chunks: Uint8Array[] = [];
         while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          chunks.push(value)
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
         }
-        const totalLen = chunks.reduce((sum, c) => sum + c.length, 0)
-        const decompressed = new Uint8Array(totalLen)
-        let pos = 0
+        const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+        const decompressed = new Uint8Array(totalLen);
+        let pos = 0;
         for (const chunk of chunks) {
-          decompressed.set(chunk, pos)
-          pos += chunk.length
+          decompressed.set(chunk, pos);
+          pos += chunk.length;
         }
-        const xmlData = new TextDecoder().decode(decompressed)
-        return parse3mfXml(xmlData, THREE)
+        const xmlData = new TextDecoder().decode(decompressed);
+        return parse3mfXml(xmlData, THREE, options);
       } else {
-        throw new Error(`Unsupported compression method: ${compressionMethod}`)
+        throw new Error(`Unsupported compression method: ${compressionMethod}`);
       }
     }
 
-    offset += 46 + fileNameLen + extraLen + commentLen
+    offset += 46 + fileNameLen + extraLen + commentLen;
   }
 
-  throw new Error('3MF file does not contain a valid 3D model')
+  throw new Error("3MF file does not contain a valid 3D model");
 }
 
-function parse3mfXml(xmlData: string, THREE: typeof import('three')): { geometry: THREE.BufferGeometry; analysis: MeshAnalysis } {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(xmlData, 'text/xml')
+function parse3mfXml(
+  xmlData: string,
+  THREE: typeof import("three"),
+  options: ParseOptions = {},
+): { geometry: THREE.BufferGeometry; analysis: MeshAnalysis } {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlData, "text/xml");
 
-  const error = doc.querySelector('parsererror')
-  if (error) throw new Error('Error parsing 3MF XML')
+  const error = doc.querySelector("parsererror");
+  if (error) throw new Error("Error parsing 3MF XML");
 
-  const objects = doc.querySelectorAll('object')
-  const allPositions: number[] = []
-  const allNormals: number[] = []
+  const objects = doc.querySelectorAll("object");
+  const allPositions: number[] = [];
+  const allNormals: number[] = [];
 
   for (const obj of Array.from(objects)) {
-    const mesh = obj.querySelector('mesh')
-    if (!mesh) continue
+    const mesh = obj.querySelector("mesh");
+    if (!mesh) continue;
 
     // Parse vertices
-    const vertices = mesh.querySelectorAll('vertex')
-    const vertexCoords: [number, number, number][] = []
+    const vertices = mesh.querySelectorAll("vertex");
+    const vertexCoords: [number, number, number][] = [];
     for (const v of Array.from(vertices)) {
-      const x = parseFloat(v.getAttribute('x') || '0')
-      const y = parseFloat(v.getAttribute('y') || '0')
-      const z = parseFloat(v.getAttribute('z') || '0')
-      vertexCoords.push([x, y, z])
+      const x = parseFloat(v.getAttribute("x") || "0");
+      const y = parseFloat(v.getAttribute("y") || "0");
+      const z = parseFloat(v.getAttribute("z") || "0");
+      vertexCoords.push([x, y, z]);
     }
 
     // Parse triangles
-    const triangles = mesh.querySelectorAll('triangle')
+    const triangles = mesh.querySelectorAll("triangle");
     for (const t of Array.from(triangles)) {
-      const v1 = parseInt(t.getAttribute('v1') || '0')
-      const v2 = parseInt(t.getAttribute('v2') || '0')
-      const v3 = parseInt(t.getAttribute('v3') || '0')
+      const v1 = parseInt(t.getAttribute("v1") || "0");
+      const v2 = parseInt(t.getAttribute("v2") || "0");
+      const v3 = parseInt(t.getAttribute("v3") || "0");
 
-      if (v1 < vertexCoords.length && v2 < vertexCoords.length && v3 < vertexCoords.length) {
-        const [x1, y1, z1] = vertexCoords[v1]
-        const [x2, y2, z2] = vertexCoords[v2]
-        const [x3, y3, z3] = vertexCoords[v3]
+      if (
+        v1 < vertexCoords.length &&
+        v2 < vertexCoords.length &&
+        v3 < vertexCoords.length
+      ) {
+        const [x1, y1, z1] = vertexCoords[v1];
+        const [x2, y2, z2] = vertexCoords[v2];
+        const [x3, y3, z3] = vertexCoords[v3];
 
-        allPositions.push(x1, y1, z1, x2, y2, z2, x3, y3, z3)
+        allPositions.push(x1, y1, z1, x2, y2, z2, x3, y3, z3);
 
         // Calculate normal
-        const ax = x2 - x1, ay = y2 - y1, az = z2 - z1
-        const bx = x3 - x1, by = y3 - y1, bz = z3 - z1
-        let nx = ay * bz - az * by
-        let ny = az * bx - ax * bz
-        let nz = ax * by - ay * bx
-        const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1
-        nx /= len; ny /= len; nz /= len
+        const ax = x2 - x1,
+          ay = y2 - y1,
+          az = z2 - z1;
+        const bx = x3 - x1,
+          by = y3 - y1,
+          bz = z3 - z1;
+        let nx = ay * bz - az * by;
+        let ny = az * bx - ax * bz;
+        let nz = ax * by - ay * bx;
+        const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
+        nx /= len;
+        ny /= len;
+        nz /= len;
 
         for (let i = 0; i < 3; i++) {
-          allNormals.push(nx, ny, nz)
+          allNormals.push(nx, ny, nz);
         }
       }
     }
   }
 
-  if (allPositions.length === 0) throw new Error('No triangles found in 3MF file')
+  if (allPositions.length === 0)
+    throw new Error("No triangles found in 3MF file");
 
-  const geometry = new THREE.BufferGeometry()
-  geometry.setAttribute('position', new THREE.Float32BufferAttribute(allPositions, 3))
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute(
+    "position",
+    new THREE.Float32BufferAttribute(allPositions, 3),
+  );
   if (allNormals.length > 0) {
-    geometry.setAttribute('normal', new THREE.Float32BufferAttribute(allNormals, 3))
+    geometry.setAttribute(
+      "normal",
+      new THREE.Float32BufferAttribute(allNormals, 3),
+    );
   }
-  geometry.computeBoundingBox()
+  geometry.computeBoundingBox();
 
-  const volume = calcVolumeFromPositions(allPositions)
-  const box = geometry.boundingBox!
-  const meshSurfaceArea = calculateSurfaceArea(geometry)
+  const volume = calcVolumeFromPositions(allPositions);
+  const box = geometry.boundingBox!;
+  const meshSurfaceArea = calculateSurfaceArea(geometry);
   const analysis: MeshAnalysis = {
     volume,
     triangleCount: allPositions.length / 9,
     vertexCount: allPositions.length / 3,
-    dimensions: { x: box.max.x - box.min.x, y: box.max.y - box.min.y, z: box.max.z - box.min.z },
+    dimensions: {
+      x: box.max.x - box.min.x,
+      y: box.max.y - box.min.y,
+      z: box.max.z - box.min.z,
+    },
     surfaceArea: +meshSurfaceArea.toFixed(2),
-    boundingBox: { min: { x: box.min.x, y: box.min.y, z: box.min.z }, max: { x: box.max.x, y: box.max.y, z: box.max.z } },
+    boundingBox: {
+      min: { x: box.min.x, y: box.min.y, z: box.min.z },
+      max: { x: box.max.x, y: box.max.y, z: box.max.z },
+    },
     integrity: { valid: true, issues: [] },
+  };
+
+  if (options.estimateSupport) {
+    analysis.supportVolumeCm3 = +estimateSupportVolume(
+      extractTriangles(geometry),
+      options,
+    ).toFixed(2);
   }
 
-  return { geometry, analysis }
+  return { geometry, analysis };
 }
 
 function calcVolumeFromPositions(positions: number[]): number {
-  let volume = 0
-  const v1 = new (typeof Float32Array !== 'undefined' ? Float32Array : Array)(3)
-  const v2 = new (typeof Float32Array !== 'undefined' ? Float32Array : Array)(3)
-  const v3 = new (typeof Float32Array !== 'undefined' ? Float32Array : Array)(3)
-  const normal = new (typeof Float32Array !== 'undefined' ? Float32Array : Array)(3)
+  let volume = 0;
+  const v1 = new (typeof Float32Array !== "undefined" ? Float32Array : Array)(
+    3,
+  );
+  const v2 = new (typeof Float32Array !== "undefined" ? Float32Array : Array)(
+    3,
+  );
+  const v3 = new (typeof Float32Array !== "undefined" ? Float32Array : Array)(
+    3,
+  );
+  const normal = new (
+    typeof Float32Array !== "undefined" ? Float32Array : Array
+  )(3);
 
   for (let i = 0; i < positions.length; i += 9) {
-    v1[0] = positions[i]; v1[1] = positions[i + 1]; v1[2] = positions[i + 2]
-    v2[0] = positions[i + 3]; v2[1] = positions[i + 4]; v2[2] = positions[i + 5]
-    v3[0] = positions[i + 6]; v3[1] = positions[i + 7]; v3[2] = positions[i + 8]
+    v1[0] = positions[i];
+    v1[1] = positions[i + 1];
+    v1[2] = positions[i + 2];
+    v2[0] = positions[i + 3];
+    v2[1] = positions[i + 4];
+    v2[2] = positions[i + 5];
+    v3[0] = positions[i + 6];
+    v3[1] = positions[i + 7];
+    v3[2] = positions[i + 8];
 
-    normal[0] = (v2[1] - v1[1]) * (v3[2] - v1[2]) - (v2[2] - v1[2]) * (v3[1] - v1[1])
-    normal[1] = (v2[2] - v1[2]) * (v3[0] - v1[0]) - (v2[0] - v1[0]) * (v3[2] - v1[2])
-    normal[2] = (v2[0] - v1[0]) * (v3[1] - v1[1]) - (v2[1] - v1[1]) * (v3[0] - v1[0])
+    normal[0] =
+      (v2[1] - v1[1]) * (v3[2] - v1[2]) - (v2[2] - v1[2]) * (v3[1] - v1[1]);
+    normal[1] =
+      (v2[2] - v1[2]) * (v3[0] - v1[0]) - (v2[0] - v1[0]) * (v3[2] - v1[2]);
+    normal[2] =
+      (v2[0] - v1[0]) * (v3[1] - v1[1]) - (v2[1] - v1[1]) * (v3[0] - v1[0]);
 
-    volume += (normal[0] * (v1[0] + v2[0] + v3[0]) + normal[1] * (v1[1] + v2[1] + v3[1]) + normal[2] * (v1[2] + v2[2] + v3[2])) / 6
+    volume +=
+      (normal[0] * (v1[0] + v2[0] + v3[0]) +
+        normal[1] * (v1[1] + v2[1] + v3[1]) +
+        normal[2] * (v1[2] + v2[2] + v3[2])) /
+      6;
   }
 
-  return Math.abs(volume)
+  return Math.abs(volume);
 }
 
-function mergeGeometries(geometries: THREE.BufferGeometry[]): THREE.BufferGeometry {
-  const merged = new THREE.BufferGeometry()
-  const positions: number[] = []
-  const normals: number[] = []
+function mergeGeometries(
+  geometries: THREE.BufferGeometry[],
+): THREE.BufferGeometry {
+  const merged = new THREE.BufferGeometry();
+  const positions: number[] = [];
+  const normals: number[] = [];
   for (const g of geometries) {
-    const pos = g.attributes.position
-    const norm = g.attributes.normal
+    const pos = g.attributes.position;
+    const norm = g.attributes.normal;
     for (let i = 0; i < pos.count; i++) {
-      positions.push(pos.getX(i), pos.getY(i), pos.getZ(i))
-      if (norm) normals.push(norm.getX(i), norm.getY(i), norm.getZ(i))
+      positions.push(pos.getX(i), pos.getY(i), pos.getZ(i));
+      if (norm) normals.push(norm.getX(i), norm.getY(i), norm.getZ(i));
     }
   }
-  merged.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3))
-  if (normals.length > 0) merged.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3))
-  return merged
+  merged.setAttribute(
+    "position",
+    new THREE.Float32BufferAttribute(positions, 3),
+  );
+  if (normals.length > 0)
+    merged.setAttribute("normal", new THREE.Float32BufferAttribute(normals, 3));
+  return merged;
 }
 
 export function volumeToCm3(volumeMm3: number): number {
-  return volumeMm3 / 1000
+  return volumeMm3 / 1000;
 }
 
-export function estimateWeight(volumeCm3: number, density: number, infill: number, purge: number): number {
-  const infillRatio = infill / 100
-  const purgeRatio = purge / 100
-  const effectiveVolume = volumeCm3 * (0.2 + 0.8 * infillRatio)
-  const waste = effectiveVolume * purgeRatio
-  return (effectiveVolume + waste) * density
+export function estimateWeight(
+  volumeCm3: number,
+  density: number,
+  infill: number,
+  purge: number,
+): number {
+  const infillRatio = infill / 100;
+  const purgeRatio = purge / 100;
+  const effectiveVolume = volumeCm3 * (0.2 + 0.8 * infillRatio);
+  const waste = effectiveVolume * purgeRatio;
+  return (effectiveVolume + waste) * density;
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,283 +1,304 @@
-export type Language = 'pt-BR' | 'en-US'
+export type Language = "pt-BR" | "en-US";
 
 export type MaterialType =
-  | 'pla' | 'pla_silk' | 'pla_plus' | 'petg' | 'abs' | 'asa'
-  | 'tpu_85a' | 'tpu_95a' | 'nylon_pa6' | 'nylon_pa12' | 'pc'
-  | 'pc_abs' | 'pla_cf' | 'petg_cf' | 'nylon_cf' | 'pla_wood'
-  | 'pla_metal' | 'hips' | 'pva' | 'pp' | 'peek' | 'peek_cf' | 'ultem'
+  | "pla"
+  | "pla_silk"
+  | "pla_plus"
+  | "petg"
+  | "abs"
+  | "asa"
+  | "tpu_85a"
+  | "tpu_95a"
+  | "nylon_pa6"
+  | "nylon_pa12"
+  | "pc"
+  | "pc_abs"
+  | "pla_cf"
+  | "petg_cf"
+  | "nylon_cf"
+  | "pla_wood"
+  | "pla_metal"
+  | "hips"
+  | "pva"
+  | "pp"
+  | "peek"
+  | "peek_cf"
+  | "ultem";
 
 export interface Material {
-  id: string
-  name: string
-  density: number
-  avgPrice: number
-  type: 'fdm' | 'resin'
+  id: string;
+  name: string;
+  density: number;
+  avgPrice: number;
+  type: "fdm" | "resin";
 }
 
 export interface PrinterProfile {
-  id: string
-  name: string
-  brand: string
-  power: number
-  value: number
-  usefulLife: number
-  maintenancePerHour: number
-  image?: string
-  maxFilaments?: number
+  id: string;
+  name: string;
+  brand: string;
+  power: number;
+  value: number;
+  usefulLife: number;
+  maintenancePerHour: number;
+  image?: string;
+  maxFilaments?: number;
 }
 
 export interface AMSSlot {
-  enabled: boolean
-  materialType: string
-  costPerKg: number
-  weightUsedGrams: number
-  purgeWeightGrams: number
-  transitionPurgeGrams: number
-  density: number
-  spoolEfficiency: number
-  color: string
-  spoolId?: string
+  enabled: boolean;
+  materialType: string;
+  costPerKg: number;
+  weightUsedGrams: number;
+  purgeWeightGrams: number;
+  transitionPurgeGrams: number;
+  density: number;
+  spoolEfficiency: number;
+  color: string;
+  spoolId?: string;
 }
 
 export interface Marketplace {
-  id: string
-  name: string
-  feePercent: number
-  feeFixed: number
-  hasFreeShipping: boolean
-  shippingFeePercent?: number
+  id: string;
+  name: string;
+  feePercent: number;
+  feeFixed: number;
+  hasFreeShipping: boolean;
+  shippingFeePercent?: number;
 }
 
 export interface MaterialStateFDM {
-  type: string
-  weightUsed: number
-  purgeWeight: number
-  costPerKg: number
-  density: number
-  spoolEfficiency: number
+  type: string;
+  weightUsed: number;
+  purgeWeight: number;
+  costPerKg: number;
+  density: number;
+  spoolEfficiency: number;
 }
 
 export interface MaterialStateResin {
-  type: string
-  volumeUsedMl: number
-  costPerLiter: number
-  density: number
-  wasteMarginPercent: number
+  type: string;
+  volumeUsedMl: number;
+  costPerLiter: number;
+  density: number;
+  wasteMarginPercent: number;
+  /** Weight in grams, wired from STL parsing (optional, backward compatible). */
+  weightUsed?: number;
 }
 
 export interface PrintParameters {
-  printTimeHours: number
-  printerPowerWatts: number
-  energyCostPerKwh: number
-  failureMode: 'none' | 'percent' | 'fixed'
-  failureValue: number
-  riskMultiplier: number
-  heatUpTimeMinutes: number
-  heatUpPowerPercent: number
+  printTimeHours: number;
+  printerPowerWatts: number;
+  energyCostPerKwh: number;
+  failureMode: "none" | "percent" | "fixed";
+  failureValue: number;
+  riskMultiplier: number;
+  heatUpTimeMinutes: number;
+  heatUpPowerPercent: number;
 }
 
 export interface MachineCosts {
-  enabled: boolean
-  machineCost: number
-  depreciationMonths: number
-  hoursPerMonth: number
-  maintenanceEnabled: boolean
-  maintenanceCost: number
+  enabled: boolean;
+  machineCost: number;
+  depreciationMonths: number;
+  hoursPerMonth: number;
+  maintenanceEnabled: boolean;
+  maintenanceCost: number;
 }
 
 export interface FDMHardware {
-  enabled: boolean
-  nozzleEnabled: boolean
-  nozzleCost: number
-  nozzleLifespanKg: number
-  bedEnabled: boolean
-  bedAdhesionCost: number
+  enabled: boolean;
+  nozzleEnabled: boolean;
+  nozzleCost: number;
+  nozzleLifespanKg: number;
+  bedEnabled: boolean;
+  bedAdhesionCost: number;
 }
 
 export interface FDMFinishing {
-  enabled: boolean
-  suppliesCost: number
+  enabled: boolean;
+  suppliesCost: number;
 }
 
 export interface ResinHardware {
-  enabled: boolean
-  lcdCost: number
-  lcdLifespanHours: number
-  fepCost: number
-  fepLifespanPrints: number
+  enabled: boolean;
+  lcdCost: number;
+  lcdLifespanHours: number;
+  fepCost: number;
+  fepLifespanPrints: number;
 }
 
 export interface PostProcessingResin {
-  washingEnabled: boolean
-  alcoholCostPerLiter: number
-  alcoholVolumeLiters: number
-  curingEnabled: boolean
-  curingTimeMinutes: number
-  curingPowerWatts: number
+  washingEnabled: boolean;
+  alcoholCostPerLiter: number;
+  alcoholVolumeLiters: number;
+  curingEnabled: boolean;
+  curingTimeMinutes: number;
+  curingPowerWatts: number;
 }
 
 export interface LaborCosts {
-  enabled: boolean
-  setupTimeMinutes: number
-  postProcessingTimeMinutes: number
-  hourlyRate: number
+  enabled: boolean;
+  setupTimeMinutes: number;
+  postProcessingTimeMinutes: number;
+  hourlyRate: number;
 }
 
 export interface FixedCosts {
-  enabled: boolean
-  monthlyCost: number
-  monthlyPrintHours: number
+  enabled: boolean;
+  monthlyCost: number;
+  monthlyPrintHours: number;
 }
 
 export interface OperationalCosts {
-  enabled: boolean
-  ppeCostPerPrint: number
-  carbonIntensity: number
+  enabled: boolean;
+  ppeCostPerPrint: number;
+  carbonIntensity: number;
 }
 
 export interface SoftwareCosts {
-  enabled: boolean
-  slicerMonthlyCost: number
-  modelFileCost: number
+  enabled: boolean;
+  slicerMonthlyCost: number;
+  modelFileCost: number;
 }
 
 export interface AdditionalCosts {
-  extrasCost: number
+  extrasCost: number;
 }
 
 export interface VolumeDiscount {
-  minQuantity: number
-  discountPercent: number
+  minQuantity: number;
+  discountPercent: number;
 }
 
 export interface SalesParameters {
-  packagingCost: number
-  shippingCost: number
-  taxPercent: number
-  marketplaceFeePercent: number
-  profitMarginPercent: number
-  volumeDiscounts: VolumeDiscount[]
+  packagingCost: number;
+  shippingCost: number;
+  taxPercent: number;
+  marketplaceFeePercent: number;
+  profitMarginPercent: number;
+  volumeDiscounts: VolumeDiscount[];
 }
 
 export interface CalculationResult {
-  materialCost: number
-  energyCost: number
-  machineCost: number
-  hardwareCost: number
-  consumablesCost: number
-  laborCost: number
-  softwareCost: number
-  failureCost: number
-  extrasCost: number
-  postProcessingCost: number
-  subtotal: number
-  totalCost: number
-  sellPrice: number
-  profit: number
-  marketplaceFee: number
-  taxAmount: number
-  costPerGram: number
-  costPerUnit: number
-  unitWeight: number
-  estimatedPrintTime: number
-  targetMarginPercent: number
-  breakEvenPrice: number
-  actualMargin: number
-  carbonFootprintGrams: number
+  materialCost: number;
+  energyCost: number;
+  machineCost: number;
+  hardwareCost: number;
+  consumablesCost: number;
+  laborCost: number;
+  softwareCost: number;
+  failureCost: number;
+  extrasCost: number;
+  postProcessingCost: number;
+  subtotal: number;
+  totalCost: number;
+  sellPrice: number;
+  profit: number;
+  marketplaceFee: number;
+  taxAmount: number;
+  costPerGram: number;
+  costPerUnit: number;
+  unitWeight: number;
+  estimatedPrintTime: number;
+  targetMarginPercent: number;
+  breakEvenPrice: number;
+  actualMargin: number;
+  carbonFootprintGrams: number;
 }
 
-export { type Customer, type CustomerFormData } from './customer'
-export { type Quote, type QuoteItem, type QuoteFormData } from './quote'
+export { type Customer, type CustomerFormData } from "./customer";
+export { type Quote, type QuoteItem, type QuoteFormData } from "./quote";
 
 export interface HistoryItem {
-  id: string
-  timestamp: number
-  type: 'fdm' | 'resin'
-  summary: string
-  totalCost: number
-  sellPrice: number
-  profit: number
+  id: string;
+  timestamp: number;
+  type: "fdm" | "resin";
+  summary: string;
+  totalCost: number;
+  sellPrice: number;
+  profit: number;
 }
 
 export interface SavedProduct {
-  id: number
-  name: string
-  date: string
-  result: CalculationResult
-  snapshot?: CalculationSnapshot
+  id: number;
+  name: string;
+  date: string;
+  result: CalculationResult;
+  snapshot?: CalculationSnapshot;
 }
 
 export interface HistoryEntry {
-  id: string
-  timestamp: number
-  type: 'fdm' | 'resin'
-  name: string
-  summary: string
-  totalCost: number
-  sellPrice: number
-  profit: number
-  result: CalculationResult
-  snapshot: CalculationSnapshot | null
+  id: string;
+  timestamp: number;
+  type: "fdm" | "resin";
+  name: string;
+  summary: string;
+  totalCost: number;
+  sellPrice: number;
+  profit: number;
+  result: CalculationResult;
+  snapshot: CalculationSnapshot | null;
 }
 
 export interface CalculationInputs {
-  productName: string
-  material: Material
-  weight: number
-  volume: number
-  useVolume: boolean
-  timeMinutes: number
-  printer: PrinterProfile
-  energyRate: number
-  laborRate: number
-  packagingCost: number
-  finishingCost: number
-  failureRate: number
-  markup: number
-  marketplace: Marketplace
-  quantity: number
-  infillPercent: number
-  purgePercent: number
-  shippingCost: number
-  taxRate: number
-  cardFeePercent: number
+  productName: string;
+  material: Material;
+  weight: number;
+  volume: number;
+  useVolume: boolean;
+  timeMinutes: number;
+  printer: PrinterProfile;
+  energyRate: number;
+  laborRate: number;
+  packagingCost: number;
+  finishingCost: number;
+  failureRate: number;
+  markup: number;
+  marketplace: Marketplace;
+  quantity: number;
+  infillPercent: number;
+  purgePercent: number;
+  shippingCost: number;
+  taxRate: number;
+  cardFeePercent: number;
 }
 
 export interface CalculationSnapshot {
-  id: string
-  timestamp: number
-  type: 'fdm' | 'resin'
-  summary: string
-  spoolId?: string
-  fdmAmsEnabled?: boolean
-  fdmAmsSlots?: AMSSlot[]
-  fdmMaterial: MaterialStateFDM
-  fdmPrintParams: PrintParameters
-  fdmMachine: MachineCosts
-  fdmHardware: FDMHardware
-  fdmFinishing: FDMFinishing
-  fdmLabor: LaborCosts
-  fdmExtras: AdditionalCosts
-  fdmSales: SalesParameters
-  fdmOps: OperationalCosts
-  fdmSoft: SoftwareCosts
-  fixedCosts: FixedCosts
-  resinMaterial: MaterialStateResin
-  resinPrintParams: PrintParameters
-  resinPostProcess: PostProcessingResin
-  resinMachine: MachineCosts
-  resinHardware: ResinHardware
-  resinLabor: LaborCosts
-  resinExtras: AdditionalCosts
-  resinSales: SalesParameters
-  resinOps: OperationalCosts
-  resinSoft: SoftwareCosts
-  selectedPrinterId: string
-  selectedMarketplaceId: string
-  productName: string
-  quantity: number
-  infillPercent: number
-  targetMarginMode: boolean
-  enabledSections: Record<string, boolean>
-  results: CalculationResult | null
+  id: string;
+  timestamp: number;
+  type: "fdm" | "resin";
+  summary: string;
+  spoolId?: string;
+  fdmAmsEnabled?: boolean;
+  fdmAmsSlots?: AMSSlot[];
+  fdmMaterial: MaterialStateFDM;
+  fdmPrintParams: PrintParameters;
+  fdmMachine: MachineCosts;
+  fdmHardware: FDMHardware;
+  fdmFinishing: FDMFinishing;
+  fdmLabor: LaborCosts;
+  fdmExtras: AdditionalCosts;
+  fdmSales: SalesParameters;
+  fdmOps: OperationalCosts;
+  fdmSoft: SoftwareCosts;
+  fixedCosts: FixedCosts;
+  resinMaterial: MaterialStateResin;
+  resinPrintParams: PrintParameters;
+  resinPostProcess: PostProcessingResin;
+  resinMachine: MachineCosts;
+  resinHardware: ResinHardware;
+  resinLabor: LaborCosts;
+  resinExtras: AdditionalCosts;
+  resinSales: SalesParameters;
+  resinOps: OperationalCosts;
+  resinSoft: SoftwareCosts;
+  selectedPrinterId: string;
+  selectedMarketplaceId: string;
+  productName: string;
+  quantity: number;
+  infillPercent: number;
+  targetMarginMode: boolean;
+  enabledSections: Record<string, boolean>;
+  results: CalculationResult | null;
 }


### PR DESCRIPTION
## Summary

Melhorias de UI/UX e precisão de cálculo para o Open3DCalc.

## 🚀 O que tem de novo

### STL Upload
- **Estimativa de suporte opcional** — analisa triângulos com overhang (>45°) e estima volume de suporte. Toggle off por default, usuário pode ativar
- **StlPreview na aba Resin** — resin agora tem preview 3D com estimativa de volume/peso (volume × 1.1 waste factor)
- **Print time com config reais** — estimator agora recebe infill% e power do printer ao invés de valores hardcoded

### UI/UX Fixes
- **Confirmação antes de import "Substituir"** — modo replace agora mostra aviso com "Confirmar"/"Cancelar" antes de apagar dados
- **Ctrl+Z não rouba undo dos inputs** — atalho global é ignorado quando foco está em input/textarea/contenteditable

## 📁 Files changed

| File | Description |
|------|-------------|
| `src/shared/lib/stlParser.ts` | Support estimation (overhang detection) |
| `src/shared/lib/printTimeEstimator.ts` | Real printer settings integration |
| `src/shared/components/StlPreview/StlPreview.tsx` | Support toggle + Resin support |
| `src/shared/components/Calculator/sections/MaterialSection.tsx` | Resin StlPreview + wiring |
| `src/shared/components/ui/DataSyncModal.tsx` | Replace confirmation dialog |
| `src/shared/hooks/useKeyboardShortcuts.ts` | Input exclusion from shortcuts |
| `src/shared/types/index.ts` | MaterialStateResin.weightUsed |
| `src/shared/i18n/locales/pt-BR.json` | New translation keys |
| `src/shared/i18n/locales/en-US.json` | New translation keys |

## 🧪 Tests

- 963+ tests passing
- TypeScript strict clean
- Both platform builds OK

---

DO NOT merge without human approval.
