### PR TITLE
fix(3mf): segue p:path da production extension e corrige volume 3x maior

### DIFF
--- a/src/shared/lib/__tests__/stlParser.3mf.security.test.ts
+++ b/src/shared/lib/__tests__/stlParser.3mf.security.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+// Security hardening tests for the 3MF parser: anti-zip-bomb caps and part
+// path resolution. They run in Node (not jsdom) because they either fail
+// before any DOM parsing happens or only exercise pure helpers.
+import { describe, it, expect } from "vitest";
+import {
+  analyzeMeshFile,
+  resolveModelPath,
+  ZipBombError,
+  MAX_DECOMPRESSED_TOTAL,
+  MAX_EACH_ENTRY,
+  MAX_ENTRIES,
+  MAX_RATIO,
+  MAX_DEPTH,
+} from "../stlParser";
+
+/**
+ * Builds a minimal stored-entry ZIP with control over the declared
+ * uncompressed size and entry count in the central directory, to simulate
+ * lying headers without allocating the claimed bytes.
+ */
+function makeBombZip(opts: {
+  declaredSize?: number;
+  entryCount?: number;
+}): Uint8Array {
+  const enc = new TextEncoder();
+  const name = enc.encode("3D/3dmodel.model");
+  const data = enc.encode("<model/>");
+
+  const local = new Uint8Array(30 + name.length + data.length);
+  const lv = new DataView(local.buffer);
+  lv.setUint32(0, 0x04034b50, true);
+  lv.setUint16(8, 0, true);
+  lv.setUint32(18, data.length, true);
+  lv.setUint32(22, data.length, true);
+  lv.setUint16(26, name.length, true);
+  local.set(name, 30);
+  local.set(data, 30 + name.length);
+
+  const central = new Uint8Array(46 + name.length);
+  const cv = new DataView(central.buffer);
+  cv.setUint32(0, 0x02014b50, true);
+  cv.setUint16(10, 0, true);
+  cv.setUint32(20, data.length, true);
+  cv.setUint32(24, opts.declaredSize ?? data.length, true);
+  cv.setUint16(28, name.length, true);
+  cv.setUint32(42, 0, true);
+  central.set(name, 46);
+
+  const count = opts.entryCount ?? 1;
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, count, true);
+  ev.setUint16(10, count, true);
+  ev.setUint32(12, central.length, true);
+  ev.setUint32(16, local.length, true);
+
+  const out = new Uint8Array(local.length + central.length + eocd.length);
+  out.set(local, 0);
+  out.set(central, local.length);
+  out.set(eocd, local.length + central.length);
+  return out;
+}
+
+describe("3MF hardening", () => {
+  it("exports caps sized between real slicer files (1-20MB) and bombs (GBs)", () => {
+    expect(MAX_DECOMPRESSED_TOTAL).toBe(64 * 1024 * 1024);
+    expect(MAX_EACH_ENTRY).toBe(32 * 1024 * 1024);
+    expect(MAX_RATIO).toBe(100);
+    expect(MAX_ENTRIES).toBe(200);
+    expect(MAX_DEPTH).toBe(8);
+  });
+
+  it("resolveModelPath normalizes p:path forms to a single key", () => {
+    expect(resolveModelPath("/3D/Objects/object_1.model")).toBe(
+      "3D/Objects/object_1.model",
+    );
+    expect(resolveModelPath("3D\\Objects\\object_1.model")).toBe(
+      "3D/Objects/object_1.model",
+    );
+    expect(resolveModelPath("/3D/./Objects/object_1.model")).toBe(
+      "3D/Objects/object_1.model",
+    );
+    expect(resolveModelPath("/3D/Objects/../Objects/object_1.model")).toBe(
+      "3D/Objects/object_1.model",
+    );
+  });
+
+  it("resolveModelPath keeps case (OPC lookup is case-sensitive)", () => {
+    expect(resolveModelPath("/3D/3DMODEL.MODEL")).toBe("3D/3DMODEL.MODEL");
+  });
+
+  it("resolveModelPath rejects .. escaping the package root", () => {
+    expect(() => resolveModelPath("/../evil.model")).toThrow(
+      /escapes package root/,
+    );
+    expect(() => resolveModelPath("/3D/../../evil.model")).toThrow(
+      /escapes package root/,
+    );
+  });
+
+  it("rejects an entry declaring an absurd size with ZipBombError", async () => {
+    const zip = makeBombZip({ declaredSize: 0xffffffff });
+    const file = new File([zip as BlobPart], "bomb.3mf");
+    await expect(analyzeMeshFile(file)).rejects.toThrow(ZipBombError);
+  });
+
+  it("rejects an absurd declared expansion ratio with ZipBombError", async () => {
+    // 8 stored bytes claiming to expand to 8MB: ratio ~1M:1.
+    const zip = makeBombZip({ declaredSize: 8 * 1024 * 1024 });
+    const file = new File([zip as BlobPart], "bomb.3mf");
+    await expect(analyzeMeshFile(file)).rejects.toThrow(/expansion ratio/);
+  });
+
+  it("rejects a central directory declaring too many entries", async () => {
+    const zip = makeBombZip({ entryCount: MAX_ENTRIES + 1 });
+    const file = new File([zip as BlobPart], "bomb.3mf");
+    await expect(analyzeMeshFile(file)).rejects.toThrow(ZipBombError);
+  });
+});

--- a/src/shared/lib/__tests__/stlParser.3mf.security.test.ts
+++ b/src/shared/lib/__tests__/stlParser.3mf.security.test.ts
@@ -64,12 +64,13 @@ function makeBombZip(opts: {
 }
 
 describe("3MF hardening", () => {
-  it("exports caps sized between real slicer files (up to ~76MB/part) and bombs (GBs)", () => {
+  it("exports caps sized between real slicer files (100MB+/part) and bombs (GBs)", () => {
     // Regression anchor: a real 15.6MB 3MF carries a ~76MB part (ratio ~5:1),
-    // so the per-entry cap must sit comfortably above 76MB while MAX_RATIO
-    // (100:1, vs ~10^9 for 42.zip) remains the actual bomb stopper.
-    expect(MAX_DECOMPRESSED_TOTAL).toBe(512 * 1024 * 1024);
-    expect(MAX_EACH_ENTRY).toBe(256 * 1024 * 1024);
+    // and multicolor/lithophane parts exceed 100MB per part, so the caps must
+    // sit comfortably above that while MAX_RATIO (100:1, vs ~10^9 for 42.zip)
+    // remains the actual bomb stopper.
+    expect(MAX_DECOMPRESSED_TOTAL).toBe(1024 * 1024 * 1024);
+    expect(MAX_EACH_ENTRY).toBe(512 * 1024 * 1024);
     expect(MAX_RATIO).toBe(100);
     expect(MAX_ENTRIES).toBe(200);
     expect(MAX_DEPTH).toBe(8);

--- a/src/shared/lib/__tests__/stlParser.3mf.security.test.ts
+++ b/src/shared/lib/__tests__/stlParser.3mf.security.test.ts
@@ -64,9 +64,12 @@ function makeBombZip(opts: {
 }
 
 describe("3MF hardening", () => {
-  it("exports caps sized between real slicer files (1-20MB) and bombs (GBs)", () => {
-    expect(MAX_DECOMPRESSED_TOTAL).toBe(64 * 1024 * 1024);
-    expect(MAX_EACH_ENTRY).toBe(32 * 1024 * 1024);
+  it("exports caps sized between real slicer files (up to ~76MB/part) and bombs (GBs)", () => {
+    // Regression anchor: a real 15.6MB 3MF carries a ~76MB part (ratio ~5:1),
+    // so the per-entry cap must sit comfortably above 76MB while MAX_RATIO
+    // (100:1, vs ~10^9 for 42.zip) remains the actual bomb stopper.
+    expect(MAX_DECOMPRESSED_TOTAL).toBe(512 * 1024 * 1024);
+    expect(MAX_EACH_ENTRY).toBe(256 * 1024 * 1024);
     expect(MAX_RATIO).toBe(100);
     expect(MAX_ENTRIES).toBe(200);
     expect(MAX_DEPTH).toBe(8);

--- a/src/shared/lib/__tests__/stlParser.3mf.test.ts
+++ b/src/shared/lib/__tests__/stlParser.3mf.test.ts
@@ -319,6 +319,50 @@ ${objects}  </resources>
     expect(analysis.volume).toBeCloseTo(1000);
   });
 
+  it("infla entrada deflate grande (> buffer interno) sem deadlock por backpressure", async () => {
+    // Regressão: o padrão sequencial `await write -> await close -> read`
+    // trava em payloads reais (35KB->164KB trava no close(); só payloads
+    // minúsculos cabem no buffer interno do DecompressionStream). A leitura
+    // precisa ser concorrente ao close. Este XML repetitivo infla para
+    // ~1.5MB — muito acima do buffer — e trava para sempre com o padrão
+    // antigo; com o pump concorrente infla em ms.
+    if (typeof globalThis.DecompressionStream === "undefined") {
+      globalThis.DecompressionStream =
+        NodeDecompressionStream as unknown as typeof DecompressionStream;
+    }
+
+    // Conteúdo variado de propósito: precisa inflar para >1MB (bem acima
+    // do buffer interno do DecompressionStream) mas com ratio baixo (~2:1,
+    // como peça real) para não tripar o cap MAX_RATIO=100:1. Um bloco
+    // puramente repetitivo comprimiria 400:1+ e seria (corretamente)
+    // rejeitado como bomba.
+    const padding = Array.from(
+      { length: 120000 },
+      (_, i) => `v${i}x${((i * 2654435761) >>> 0).toString(36)}`,
+    ).join(" "); // ~1.7MB, ratio ~2:1
+    const model = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <!-- ${padding} -->
+  <resources><object id="1" type="model">${CUBE_MESH}</object></resources>
+  <build><item objectid="1"/></build>
+</model>`;
+    const modelBytes = new TextEncoder().encode(model);
+    expect(modelBytes.length).toBeGreaterThan(1024 * 1024);
+    const compressed = new Uint8Array(deflateRawSync(modelBytes));
+    const zip = makeZip({
+      "[Content_Types].xml": '<?xml version="1.0"?><Types/>',
+      "3D/3dmodel.model": {
+        data: compressed,
+        method: 8,
+        declaredSize: modelBytes.length,
+      },
+    });
+
+    const { analysis } = await analyzeMeshFile(file3mf(zip));
+    expect(analysis.triangleCount).toBe(12);
+    expect(analysis.volume).toBeCloseTo(1000);
+  }, 20000);
+
   it("estoura o cap de profundidade com ZipBombError em vez de drop silencioso", async () => {
     // Cadeia mais longa que MAX_DEPTH: precisa falhar alto, nunca perder
     // geometria em silêncio.

--- a/src/shared/lib/__tests__/stlParser.3mf.test.ts
+++ b/src/shared/lib/__tests__/stlParser.3mf.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { analyzeMeshFile } from "../stlParser";
+
+/**
+ * Escreve um ZIP mínimo com entradas STORED (sem compressão).
+ * O parser do 3MF não confere CRC, então o campo vai zerado de propósito —
+ * o que interessa aqui é a topologia do pacote, não a integridade dele.
+ */
+function makeZip(files: Record<string, string>): Uint8Array {
+  const enc = new TextEncoder();
+  const locals: Uint8Array[] = [];
+  const centrals: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = enc.encode(name);
+    const data = enc.encode(content);
+
+    const local = new Uint8Array(30 + nameBytes.length + data.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true); // assinatura do cabeçalho local
+    lv.setUint16(4, 20, true); // versão necessária
+    lv.setUint16(8, 0, true); // método 0 = stored
+    lv.setUint32(18, data.length, true); // tamanho comprimido
+    lv.setUint32(22, data.length, true); // tamanho original
+    lv.setUint16(26, nameBytes.length, true);
+    local.set(nameBytes, 30);
+    local.set(data, 30 + nameBytes.length);
+    locals.push(local);
+
+    const central = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(central.buffer);
+    cv.setUint32(0, 0x02014b50, true); // assinatura do diretório central
+    cv.setUint16(10, 0, true); // método 0 = stored
+    cv.setUint32(20, data.length, true);
+    cv.setUint32(24, data.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, offset, true); // deslocamento do cabeçalho local
+    central.set(nameBytes, 46);
+    centrals.push(central);
+
+    offset += local.length;
+  }
+
+  const cdSize = centrals.reduce((s, c) => s + c.length, 0);
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, centrals.length, true);
+  ev.setUint16(10, centrals.length, true);
+  ev.setUint32(12, cdSize, true);
+  ev.setUint32(16, offset, true);
+
+  const total = offset + cdSize + eocd.length;
+  const out = new Uint8Array(total);
+  let p = 0;
+  for (const b of [...locals, ...centrals, eocd]) {
+    out.set(b, p);
+    p += b.length;
+  }
+  return out;
+}
+
+/** Um cubo 10×10×10 na origem, como <mesh> do 3MF. */
+const CUBE_MESH = `<mesh>
+  <vertices>
+    <vertex x="0" y="0" z="0"/><vertex x="10" y="0" z="0"/>
+    <vertex x="10" y="10" z="0"/><vertex x="0" y="10" z="0"/>
+    <vertex x="0" y="0" z="10"/><vertex x="10" y="0" z="10"/>
+    <vertex x="10" y="10" z="10"/><vertex x="0" y="10" z="10"/>
+  </vertices>
+  <triangles>
+    <triangle v1="0" v2="2" v3="1"/><triangle v1="0" v2="3" v3="2"/>
+    <triangle v1="4" v2="5" v3="6"/><triangle v1="4" v2="6" v3="7"/>
+    <triangle v1="0" v2="1" v3="5"/><triangle v1="0" v2="5" v3="4"/>
+    <triangle v1="1" v2="2" v3="6"/><triangle v1="1" v2="6" v3="5"/>
+    <triangle v1="2" v2="3" v3="7"/><triangle v1="2" v2="7" v3="6"/>
+    <triangle v1="3" v2="0" v3="4"/><triangle v1="3" v2="4" v3="7"/>
+  </triangles>
+</mesh>`;
+
+function file3mf(bytes: Uint8Array, name = "test.3mf"): File {
+  return new File([bytes as BlobPart], name);
+}
+
+describe("3MF parsing", () => {
+  it("lê um 3MF simples, com a malha embutida no modelo raiz", async () => {
+    const zip = makeZip({
+      "[Content_Types].xml": '<?xml version="1.0"?><Types/>',
+      "_rels/.rels": '<?xml version="1.0"?><Relationships/>',
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources><object id="1" type="model">${CUBE_MESH}</object></resources>
+  <build><item objectid="1"/></build>
+</model>`,
+    });
+
+    const { analysis } = await analyzeMeshFile(file3mf(zip));
+    expect(analysis.triangleCount).toBe(12);
+    expect(analysis.dimensions.x).toBeCloseTo(10);
+    expect(analysis.volume).toBeCloseTo(1000);
+  });
+
+  it("segue p:path para malhas em partes externas (production extension)", async () => {
+    // Layout de projeto do OrcaSlicer/BambuStudio: o modelo raiz não tem
+    // malha nenhuma, só um componente apontando para outra parte do ZIP.
+    const zip = makeZip({
+      "[Content_Types].xml": '<?xml version="1.0"?><Types/>',
+      "_rels/.rels": '<?xml version="1.0"?><Relationships/>',
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter"
+ xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
+ xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06">
+  <resources>
+    <object id="1" type="model">
+      <components>
+        <component p:path="/3D/Objects/object_1.model" objectid="2"/>
+      </components>
+    </object>
+  </resources>
+  <build><item objectid="1"/></build>
+</model>`,
+      "3D/Objects/object_1.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources><object id="2" type="model">${CUBE_MESH}</object></resources>
+  <build/>
+</model>`,
+    });
+
+    const { analysis } = await analyzeMeshFile(file3mf(zip));
+    expect(analysis.triangleCount).toBe(12);
+    expect(analysis.volume).toBeCloseTo(1000);
+  });
+
+  it("aplica as matrizes de <item> e <component>", async () => {
+    // Duas cópias do mesmo cubo, uma na origem e outra deslocada 50 mm em X:
+    // sem aplicar a matriz, as duas se empilhariam e a caixa daria 10 mm.
+    const zip = makeZip({
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources><object id="1" type="model">${CUBE_MESH}</object></resources>
+  <build>
+    <item objectid="1"/>
+    <item objectid="1" transform="1 0 0 0 1 0 0 0 1 50 0 0"/>
+  </build>
+</model>`,
+    });
+
+    const { analysis } = await analyzeMeshFile(file3mf(zip));
+    expect(analysis.triangleCount).toBe(24);
+    expect(analysis.dimensions.x).toBeCloseTo(60); // 0..10 e 50..60
+    expect(analysis.dimensions.y).toBeCloseTo(10);
+  });
+
+  it("não trava com componentes que se auto-referenciam", async () => {
+    const zip = makeZip({
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources>
+    <object id="1" type="model">
+      <components><component objectid="1"/></components>
+    </object>
+  </resources>
+  <build><item objectid="1"/></build>
+</model>`,
+    });
+
+    await expect(analyzeMeshFile(file3mf(zip))).rejects.toThrow(
+      /No triangles found/,
+    );
+  });
+});

--- a/src/shared/lib/__tests__/stlParser.3mf.test.ts
+++ b/src/shared/lib/__tests__/stlParser.3mf.test.ts
@@ -1,26 +1,43 @@
 import { describe, it, expect } from "vitest";
-import { analyzeMeshFile } from "../stlParser";
+import { deflateRawSync } from "node:zlib";
+import { DecompressionStream as NodeDecompressionStream } from "node:stream/web";
+import { analyzeMeshFile, MAX_DEPTH, ZipBombError } from "../stlParser";
 
 /**
  * Escreve um ZIP mínimo com entradas STORED (sem compressão).
  * O parser do 3MF não confere CRC, então o campo vai zerado de propósito —
  * o que interessa aqui é a topologia do pacote, não a integridade dele.
  */
-function makeZip(files: Record<string, string>): Uint8Array {
+interface ZipFixture {
+  /** Bytes já prontos (ex.: saída de deflateRawSync para o método 8). */
+  data: Uint8Array;
+  method?: 0 | 8;
+  /**
+   * Tamanho descomprimido declarado no diretório central. Quando omitido,
+   * vale o tamanho real — informar outro valor simula um header mentiroso.
+   */
+  declaredSize?: number;
+}
+
+function makeZip(files: Record<string, string | ZipFixture>): Uint8Array {
   const enc = new TextEncoder();
   const locals: Uint8Array[] = [];
   const centrals: Uint8Array[] = [];
   let offset = 0;
 
-  for (const [name, content] of Object.entries(files)) {
+  for (const [name, spec] of Object.entries(files)) {
     const nameBytes = enc.encode(name);
-    const data = enc.encode(content);
+    const fixture: ZipFixture =
+      typeof spec === "string" ? { data: enc.encode(spec) } : spec;
+    const data = fixture.data;
+    const method = fixture.method ?? 0;
+    const declared = fixture.declaredSize ?? data.length;
 
     const local = new Uint8Array(30 + nameBytes.length + data.length);
     const lv = new DataView(local.buffer);
     lv.setUint32(0, 0x04034b50, true); // assinatura do cabeçalho local
     lv.setUint16(4, 20, true); // versão necessária
-    lv.setUint16(8, 0, true); // método 0 = stored
+    lv.setUint16(8, method, true);
     lv.setUint32(18, data.length, true); // tamanho comprimido
     lv.setUint32(22, data.length, true); // tamanho original
     lv.setUint16(26, nameBytes.length, true);
@@ -31,9 +48,9 @@ function makeZip(files: Record<string, string>): Uint8Array {
     const central = new Uint8Array(46 + nameBytes.length);
     const cv = new DataView(central.buffer);
     cv.setUint32(0, 0x02014b50, true); // assinatura do diretório central
-    cv.setUint16(10, 0, true); // método 0 = stored
+    cv.setUint16(10, method, true);
     cv.setUint32(20, data.length, true);
-    cv.setUint32(24, data.length, true);
+    cv.setUint32(24, declared, true);
     cv.setUint16(28, nameBytes.length, true);
     cv.setUint32(42, offset, true); // deslocamento do cabeçalho local
     central.set(nameBytes, 46);
@@ -167,6 +184,164 @@ describe("3MF parsing", () => {
 
     await expect(analyzeMeshFile(file3mf(zip))).rejects.toThrow(
       /No triangles found/,
+    );
+  });
+
+  it("não trava com componentes que se referenciam mutuamente (ciclo A<->B)", async () => {
+    const zip = makeZip({
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources>
+    <object id="1" type="model">
+      <components><component objectid="2"/></components>
+    </object>
+    <object id="2" type="model">
+      <components><component objectid="1"/></components>
+    </object>
+  </resources>
+  <build><item objectid="1"/></build>
+</model>`,
+    });
+
+    await expect(analyzeMeshFile(file3mf(zip))).rejects.toThrow(
+      /No triangles found/,
+    );
+  });
+
+  it("lê uma entrada deflate (método 8) do ZIP", async () => {
+    // jsdom não tem DecompressionStream; o Node 22 tem. Os bytes deflate crus
+    // vêm de node:zlib (deflateRawSync = raw deflate, o que o ZIP usa).
+    if (typeof globalThis.DecompressionStream === "undefined") {
+      globalThis.DecompressionStream =
+        NodeDecompressionStream as unknown as typeof DecompressionStream;
+    }
+
+    const model = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources><object id="1" type="model">${CUBE_MESH}</object></resources>
+  <build><item objectid="1"/></build>
+</model>`;
+    const modelBytes = new TextEncoder().encode(model);
+    const compressed = new Uint8Array(deflateRawSync(modelBytes));
+    const zip = makeZip({
+      "[Content_Types].xml": '<?xml version="1.0"?><Types/>',
+      "3D/3dmodel.model": {
+        data: compressed,
+        method: 8,
+        declaredSize: modelBytes.length,
+      },
+    });
+
+    const { analysis } = await analyzeMeshFile(file3mf(zip));
+    expect(analysis.triangleCount).toBe(12);
+    expect(analysis.volume).toBeCloseTo(1000);
+  });
+
+  it("rejeita p:path com .. que escapa da raiz do pacote", async () => {
+    const zip = makeZip({
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter"
+ xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
+ xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06">
+  <resources>
+    <object id="1" type="model">
+      <components><component p:path="/3D/../../evil.model" objectid="2"/></components>
+    </object>
+  </resources>
+  <build><item objectid="1"/></build>
+</model>`,
+      "evil.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources><object id="2" type="model">${CUBE_MESH}</object></resources>
+  <build/>
+</model>`,
+    });
+
+    await expect(analyzeMeshFile(file3mf(zip))).rejects.toThrow(
+      /escapes package root/,
+    );
+  });
+
+  it("resolve p:path com casing divergente via fallback case-insensitive", async () => {
+    // ZIP guarda `3D/Objects/Object_1.MODEL`, mas o p:path usa outro casing:
+    // o lookup exato falha e o fallback case-insensitive precisa resolver.
+    const zip = makeZip({
+      "[Content_Types].xml": '<?xml version="1.0"?><Types/>',
+      "_rels/.rels": '<?xml version="1.0"?><Relationships/>',
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter"
+ xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
+ xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06">
+  <resources>
+    <object id="1" type="model">
+      <components>
+        <component p:path="/3d/OBJECTS/object_1.model" objectid="2"/>
+      </components>
+    </object>
+  </resources>
+  <build><item objectid="1"/></build>
+</model>`,
+      "3D/Objects/Object_1.MODEL": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources><object id="2" type="model">${CUBE_MESH}</object></resources>
+  <build/>
+</model>`,
+    });
+
+    const { analysis } = await analyzeMeshFile(file3mf(zip));
+    expect(analysis.triangleCount).toBe(12);
+    expect(analysis.volume).toBeCloseTo(1000);
+  });
+
+  it("preserva geometria com nesting >= 3 (dentro do cap)", async () => {
+    // Cadeia de 4 níveis: item -> 1 -> 2 -> 3 -> malha. Com o cap antigo
+    // (MAX_DEPTH=2) a malha era descartada em silêncio; com o cap atual
+    // ela precisa ser emitida.
+    const chainDepth = 4;
+    let objects = "";
+    for (let i = 1; i <= chainDepth; i++) {
+      objects +=
+        i < chainDepth
+          ? `    <object id="${i}" type="model"><components><component objectid="${i + 1}"/></components></object>\n`
+          : `    <object id="${i}" type="model">${CUBE_MESH}</object>\n`;
+    }
+    const zip = makeZip({
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources>
+${objects}  </resources>
+  <build><item objectid="1"/></build>
+</model>`,
+    });
+
+    const { analysis } = await analyzeMeshFile(file3mf(zip));
+    expect(analysis.triangleCount).toBe(12);
+    expect(analysis.volume).toBeCloseTo(1000);
+  });
+
+  it("estoura o cap de profundidade com ZipBombError em vez de drop silencioso", async () => {
+    // Cadeia mais longa que MAX_DEPTH: precisa falhar alto, nunca perder
+    // geometria em silêncio.
+    const chainLen = MAX_DEPTH + 3;
+    let objects = "";
+    for (let i = 1; i <= chainLen; i++) {
+      objects +=
+        i < chainLen
+          ? `    <object id="${i}" type="model"><components><component objectid="${i + 1}"/></components></object>\n`
+          : `    <object id="${i}" type="model">${CUBE_MESH}</object>\n`;
+    }
+    const zip = makeZip({
+      "3D/3dmodel.model": `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources>
+${objects}  </resources>
+  <build><item objectid="1"/></build>
+</model>`,
+    });
+
+    await expect(analyzeMeshFile(file3mf(zip))).rejects.toThrow(ZipBombError);
+    await expect(analyzeMeshFile(file3mf(zip))).rejects.toThrow(
+      /maximum component depth/,
     );
   });
 });

--- a/src/shared/lib/stlParser.ts
+++ b/src/shared/lib/stlParser.ts
@@ -321,19 +321,21 @@ export async function analyzeMeshFile(
 /** Max total decompressed bytes across all parts of one 3MF package.
 //
 // Sized from a real-world probe: a 15.6 MB 3MF whose largest part inflates to
-// ~76 MB (ratio ~5:1, perfectly legitimate slicer output). 512 MB leaves ~6x
-// headroom above that part while staying orders of magnitude below any real
-// bomb (42.zip expands KBs to GBs/TBs, ratio ~10^9).
+// ~76 MB (ratio ~5:1, perfectly legitimate slicer output). Multicolor and
+// lithophane parts routinely exceed 100 MB per part, so 1 GB keeps ~10x
+// headroom above the probed part while staying orders of magnitude below any
+// real bomb (42.zip expands KBs to GBs/TBs, ratio ~10^9).
 // Kept in check by MAX_RATIO (100:1) and MAX_ENTRIES below, which are what
 // actually stop bombs — not these absolute byte caps. */
-export const MAX_DECOMPRESSED_TOTAL = 512 * 1024 * 1024; // 512 MB
+export const MAX_DECOMPRESSED_TOTAL = 1024 * 1024 * 1024; // 1 GB
 /** Max decompressed bytes of a single ZIP entry.
 //
-// Was 32 MB and false-positived on the legit ~76 MB part above. 256 MB keeps
-// ~3x headroom over it; bombs are still caught by MAX_RATIO (a 42.zip-style
+// Was 32 MB and false-positived on the legit ~76 MB part above. 512 MB keeps
+// ~6x headroom over it (multicolor/lithophane parts pass 100 MB per part);
+// bombs are still caught by MAX_RATIO (a 42.zip-style
 // payload claims ratios ~10^9, far above the 100:1 cap) and by the streaming
 // during-decompression counters, not by this ceiling. */
-export const MAX_EACH_ENTRY = 256 * 1024 * 1024; // 256 MB
+export const MAX_EACH_ENTRY = 512 * 1024 * 1024; // 512 MB
 /** Max allowed expansion ratio (uncompressed / compressed) per entry. */
 export const MAX_RATIO = 100; // 100:1
 /** Max number of entries in the ZIP central directory. */

--- a/src/shared/lib/stlParser.ts
+++ b/src/shared/lib/stlParser.ts
@@ -308,9 +308,43 @@ export async function analyzeMeshFile(
   throw new Error(`Unsupported format: ${ext}. Use STL, OBJ or 3MF.`);
 }
 
+// ---------------------------------------------------------------------------
+// 3MF (OPC/ZIP) hardening limits.
+//
+// A slicer-produced 3MF is typically 1-20 MB. A zip bomb is orders of
+// magnitude bigger once decompressed (GBs out of KBs), so these caps sit far
+// above any legitimate file and far below anything dangerous. There is no
+// canonical number for them — the values below are justified ranges, not
+// standards.
+// ---------------------------------------------------------------------------
+
+/** Max total decompressed bytes across all parts of one 3MF package. */
+export const MAX_DECOMPRESSED_TOTAL = 64 * 1024 * 1024; // 64 MB
+/** Max decompressed bytes of a single ZIP entry. */
+export const MAX_EACH_ENTRY = 32 * 1024 * 1024; // 32 MB
+/** Max allowed expansion ratio (uncompressed / compressed) per entry. */
+export const MAX_RATIO = 100; // 100:1
+/** Max number of entries in the ZIP central directory. */
+export const MAX_ENTRIES = 200;
+/** Max nesting depth of the <components> object graph. */
+export const MAX_DEPTH = 8;
+
+/** Thrown when a 3MF package trips any anti-zip-bomb cap. */
+export class ZipBombError extends Error {
+  constructor(message: string) {
+    super(`3MF zip bomb blocked: ${message}`);
+    this.name = "ZipBombError";
+  }
+}
+
+/** Tracks cumulative decompressed bytes to catch flat bombs while streaming. */
+interface ZipBudget {
+  total: number;
+}
+
 /**
- * Uma entrada do diretório central do ZIP que embala o 3MF.
- * O 3MF é um pacote OPC (um ZIP), então ler o arquivo é ler o ZIP primeiro.
+ * One entry of the ZIP central directory backing the 3MF package.
+ * A 3MF is an OPC package (a ZIP), so reading the file means reading the ZIP first.
  */
 interface ZipEntry {
   name: string;
@@ -321,19 +355,24 @@ interface ZipEntry {
 }
 
 /**
- * Lê o diretório central do ZIP e devolve TODAS as entradas indexadas por nome
- * em minúsculas (nomes de parte OPC são comparados sem diferenciar maiúsculas).
+ * Reads the ZIP central directory and returns ALL entries indexed by
+ * resolved part name.
  *
- * Antes esta varredura parava na PRIMEIRA entrada terminada em ".model" e
- * decodificava só ela. Isso quebra os arquivos da "production extension"
- * (projetos do OrcaSlicer/BambuStudio), em que o modelo raiz não contém malha
- * nenhuma — só <components p:path="/3D/Objects/object_N.model"> — e as malhas
- * de verdade moram em outras partes do mesmo ZIP.
+ * Previously this scan stopped at the FIRST entry ending in ".model" and
+ * decoded only that one. That breaks files using the "production extension"
+ * (OrcaSlicer/BambuStudio projects), where the root model holds no mesh at
+ * all — only <components p:path="/3D/Objects/object_N.model"> — and the real
+ * meshes live in other parts of the same ZIP.
+ *
+ * Also enforces the pre-decompression caps from the central directory's
+ * declared sizes: entry count, per-entry size, total size and expansion
+ * ratio. The streaming (during-decompression) checks in readZipEntryText
+ * catch flat bombs that lie in these headers.
  */
-function readZipCentralDirectory(uint8: Uint8Array): Map<string, ZipEntry> {
-  // O End Of Central Directory fica, por especificação, nos últimos
-  // 22 + 65535 bytes (o comentário do ZIP tem no máximo 64 KiB). Limitar a
-  // busca a essa janela evita varrer um arquivo de centenas de MB byte a byte.
+function buildZipMap(uint8: Uint8Array): Map<string, ZipEntry> {
+  // The End Of Central Directory sits, per spec, within the last
+  // 22 + 65535 bytes (the ZIP comment is at most 64 KiB). Limiting the
+  // search to that window avoids scanning a hundreds-of-MB file byte by byte.
   const scanStart = Math.max(0, uint8.length - 22 - 0xffff);
   let eocdOffset = -1;
   for (let i = uint8.length - 22; i >= scanStart; i--) {
@@ -358,10 +397,18 @@ function readZipCentralDirectory(uint8: Uint8Array): Map<string, ZipEntry> {
     0;
   const numEntries = uint8[eocdOffset + 10] | (uint8[eocdOffset + 11] << 8);
 
+  // Pre-check: entry-count cap before allocating anything per entry.
+  if (numEntries > MAX_ENTRIES) {
+    throw new ZipBombError(
+      `central directory declares ${numEntries} entries (limit ${MAX_ENTRIES})`,
+    );
+  }
+
   const entries = new Map<string, ZipEntry>();
   let offset = cdOffset;
+  let declaredTotal = 0;
   for (let i = 0; i < numEntries; i++) {
-    // 0x02014b50 = assinatura de um cabeçalho do diretório central.
+    // 0x02014b50 = central-directory header signature.
     if (uint8[offset] !== 0x50 || uint8[offset + 1] !== 0x4b) break;
 
     const fileNameLen = uint8[offset + 28] | (uint8[offset + 29] << 8);
@@ -370,28 +417,51 @@ function readZipCentralDirectory(uint8: Uint8Array): Map<string, ZipEntry> {
     const name = new TextDecoder().decode(
       uint8.slice(offset + 46, offset + 46 + fileNameLen),
     );
+    const compressionMethod = uint8[offset + 10] | (uint8[offset + 11] << 8);
+    const compressedSize =
+      (uint8[offset + 20] |
+        (uint8[offset + 21] << 8) |
+        (uint8[offset + 22] << 16) |
+        (uint8[offset + 23] << 24)) >>>
+      0;
+    const uncompressedSize =
+      (uint8[offset + 24] |
+        (uint8[offset + 25] << 8) |
+        (uint8[offset + 26] << 16) |
+        (uint8[offset + 27] << 24)) >>>
+      0;
+    const localHeaderOffset =
+      (uint8[offset + 42] |
+        (uint8[offset + 43] << 8) |
+        (uint8[offset + 44] << 16) |
+        (uint8[offset + 45] << 24)) >>>
+      0;
 
-    entries.set(normalizePartName(name), {
+    // Pre-checks on declared sizes: cheap, and reject honest bombs outright.
+    // Flat bombs that lie here are caught while streaming instead.
+    if (uncompressedSize > MAX_EACH_ENTRY) {
+      throw new ZipBombError(
+        `entry "${name}" declares ${uncompressedSize} bytes (limit ${MAX_EACH_ENTRY})`,
+      );
+    }
+    if (compressedSize > 0 && uncompressedSize / compressedSize > MAX_RATIO) {
+      throw new ZipBombError(
+        `entry "${name}" declares expansion ratio ${(uncompressedSize / compressedSize).toFixed(1)}:1 (limit ${MAX_RATIO}:1)`,
+      );
+    }
+    declaredTotal += uncompressedSize;
+    if (declaredTotal > MAX_DECOMPRESSED_TOTAL) {
+      throw new ZipBombError(
+        `package declares ${declaredTotal} bytes total (limit ${MAX_DECOMPRESSED_TOTAL})`,
+      );
+    }
+
+    entries.set(resolveModelPath(name), {
       name,
-      compressionMethod: uint8[offset + 10] | (uint8[offset + 11] << 8),
-      compressedSize:
-        (uint8[offset + 20] |
-          (uint8[offset + 21] << 8) |
-          (uint8[offset + 22] << 16) |
-          (uint8[offset + 23] << 24)) >>>
-        0,
-      uncompressedSize:
-        (uint8[offset + 24] |
-          (uint8[offset + 25] << 8) |
-          (uint8[offset + 26] << 16) |
-          (uint8[offset + 27] << 24)) >>>
-        0,
-      localHeaderOffset:
-        (uint8[offset + 42] |
-          (uint8[offset + 43] << 8) |
-          (uint8[offset + 44] << 16) |
-          (uint8[offset + 45] << 24)) >>>
-        0,
+      compressionMethod,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
     });
 
     offset += 46 + fileNameLen + extraLen + commentLen;
@@ -401,79 +471,147 @@ function readZipCentralDirectory(uint8: Uint8Array): Map<string, ZipEntry> {
 }
 
 /**
- * Normaliza um nome de parte OPC para servir de chave: sem a barra inicial
- * (o `p:path` do 3MF é absoluto, `/3D/Objects/x.model`, mas o ZIP guarda
- * `3D/Objects/x.model`), com barras invertidas viradas e em minúsculas.
+ * Resolves a 3MF part reference (ZIP entry name, `p:path` attribute) into the
+ * single canonical key used for the ZIP map.
+ *
+ * Handles the forms producers emit: a leading `/` (the 3MF `p:path` is
+ * absolute, `/3D/Objects/x.model`, while the ZIP stores `3D/Objects/x.model`),
+ * backslashes, and `.` / `..` segments resolved lexically.
+ *
+ * Lookup is exact (case-sensitive) first, per the OPC spec; `loadModelPart`
+ * adds a case-insensitive fallback for producers whose ZIP entry casing
+ * diverges from the `p:path` casing. three.js
+ * ignores `p:path` altogether, so supporting it is our differential.
+ * A `..` that would escape the package root is rejected — it is the zip-slip
+ * cousin for part references.
  */
-function normalizePartName(name: string): string {
-  return name.replace(/\\/g, "/").replace(/^\/+/, "").toLowerCase();
+export function resolveModelPath(rawPath: string): string {
+  const trimmed = rawPath.replace(/\\/g, "/").replace(/^\/+/, "");
+  const parts: string[] = [];
+  for (const seg of trimmed.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      if (parts.length === 0) {
+        throw new Error(
+          `Invalid 3MF part path (escapes package root): ${rawPath}`,
+        );
+      }
+      parts.pop();
+      continue;
+    }
+    parts.push(seg);
+  }
+  return parts.join("/");
 }
 
-/** Descomprime uma entrada do ZIP e devolve o texto (as partes do 3MF são XML). */
+/** Decompresses one ZIP entry and returns its text (3MF parts are XML). */
 async function readZipEntryText(
   uint8: Uint8Array,
   entry: ZipEntry,
+  budget: ZipBudget,
 ): Promise<string> {
-  // Os tamanhos vêm do diretório central; o cabeçalho local só é consultado
-  // para saber onde os dados começam, porque os campos de tamanho dele podem
-  // estar zerados quando o escritor usou data descriptor.
+  // Sizes come from the central directory; the local header is only used to
+  // find where the data starts, because its size fields may be zero when the
+  // writer used a data descriptor.
   const lhs = entry.localHeaderOffset;
   const localFileNameLen = uint8[lhs + 26] | (uint8[lhs + 27] << 8);
   const localExtraLen = uint8[lhs + 28] | (uint8[lhs + 29] << 8);
   const dataStart = lhs + 30 + localFileNameLen + localExtraLen;
 
   if (entry.compressionMethod === 0) {
-    // Stored: os bytes já são o conteúdo.
+    // Stored: the bytes already are the content.
+    budget.total += entry.uncompressedSize;
+    if (budget.total > MAX_DECOMPRESSED_TOTAL) {
+      throw new ZipBombError(
+        `package exceeds ${MAX_DECOMPRESSED_TOTAL} decompressed bytes total`,
+      );
+    }
     return new TextDecoder().decode(
       uint8.slice(dataStart, dataStart + entry.uncompressedSize),
     );
   }
 
   if (entry.compressionMethod === 8) {
-    // Deflate cru (sem cabeçalho zlib) — é o que o ZIP usa.
+    // Raw deflate (no zlib header) — what ZIP uses.
+    if (typeof DecompressionStream === "undefined") {
+      throw new Error(
+        "Cannot decompress 3MF entry: DecompressionStream is unavailable " +
+          "(use a modern browser or Node.js 18+)",
+      );
+    }
     const compressed = uint8.slice(dataStart, dataStart + entry.compressedSize);
-    const ds = new DecompressionStream("deflate-raw");
-    const writer = ds.writable.getWriter();
-    writer.write(compressed);
-    writer.close();
-    const reader = ds.readable.getReader();
-    const chunks: Uint8Array[] = [];
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      chunks.push(value);
+    try {
+      const ds = new DecompressionStream("deflate-raw");
+      const writer = ds.writable.getWriter();
+      // Order matters (MDN): write, then close, then read. A corrupt stream
+      // surfaces its error on read, so the whole block stays in try/catch.
+      await writer.write(compressed);
+      await writer.close();
+      const reader = ds.readable.getReader();
+      const chunks: Uint8Array[] = [];
+      let entryTotal = 0;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        entryTotal += value.length;
+        // During-decompression caps: byte counting on the stream catches flat
+        // bombs whose central-directory headers lie about the sizes.
+        if (entryTotal > entry.uncompressedSize) {
+          throw new ZipBombError(
+            `entry "${entry.name}" expanded past its declared ${entry.uncompressedSize} bytes`,
+          );
+        }
+        if (entryTotal > MAX_EACH_ENTRY) {
+          throw new ZipBombError(
+            `entry "${entry.name}" exceeds ${MAX_EACH_ENTRY} decompressed bytes`,
+          );
+        }
+        budget.total += value.length;
+        if (budget.total > MAX_DECOMPRESSED_TOTAL) {
+          throw new ZipBombError(
+            `package exceeds ${MAX_DECOMPRESSED_TOTAL} decompressed bytes total`,
+          );
+        }
+        chunks.push(value);
+      }
+      const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+      const decompressed = new Uint8Array(totalLen);
+      let pos = 0;
+      for (const chunk of chunks) {
+        decompressed.set(chunk, pos);
+        pos += chunk.length;
+      }
+      return new TextDecoder().decode(decompressed);
+    } catch (err) {
+      if (err instanceof ZipBombError) throw err;
+      throw new Error(
+        `Error decompressing 3MF entry "${entry.name}": ${err instanceof Error ? err.message : err}`,
+        { cause: err },
+      );
     }
-    const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
-    const decompressed = new Uint8Array(totalLen);
-    let pos = 0;
-    for (const chunk of chunks) {
-      decompressed.set(chunk, pos);
-      pos += chunk.length;
-    }
-    return new TextDecoder().decode(decompressed);
   }
 
   throw new Error(`Unsupported compression method: ${entry.compressionMethod}`);
 }
 
 /**
- * Escolhe a parte que é o modelo raiz do pacote.
- * Ordem: o caminho convencional `3D/3dmodel.model` e, se ele não existir,
- * a primeira parte `.model` do pacote.
+ * Picks the part that is the package root model.
+ * Order: the conventional `3D/3dmodel.model` path and, if missing, the first
+ * `.model` part in the package.
  */
 function pick3mfRootModel(entries: Map<string, ZipEntry>): string {
-  if (entries.has("3d/3dmodel.model")) return "3d/3dmodel.model";
+  if (entries.has("3D/3dmodel.model")) return "3D/3dmodel.model";
 
   for (const key of entries.keys()) {
-    if (key.endsWith(".model")) return key;
+    if (key.toLowerCase().endsWith(".model")) return key;
   }
   throw new Error("3MF file does not contain a valid 3D model");
 }
 
 /**
- * Matriz do 3MF: 12 números que formam uma 4x3 em convenção de vetor-linha
- * (`m00 m01 m02 m10 m11 m12 m20 m21 m22 m30 m31 m32`), onde a última linha é
- * a translação. A identidade é o valor implícito quando o atributo falta.
+ * A 3MF matrix: 12 numbers forming a 4x3 in row-vector convention
+ * (`m00 m01 m02 m10 m11 m12 m20 m21 m22 m30 m31 m32`), where the last row is
+ * the translation. Identity is the implicit value when the attribute is missing.
  */
 type Mat3mf = number[];
 
@@ -488,8 +626,8 @@ function parse3mfTransform(value: string | null): Mat3mf {
 }
 
 /**
- * Compõe duas transformações: aplica `a` primeiro e `b` depois
- * (p' = p · a · b, seguindo a convenção de vetor-linha do 3MF).
+ * Composes two transforms: applies `a` first and `b` after
+ * (p' = p · a · b, following the 3MF row-vector convention).
  */
 function mul3mf(a: Mat3mf, b: Mat3mf): Mat3mf {
   const out = new Array<number>(12);
@@ -501,7 +639,7 @@ function mul3mf(a: Mat3mf, b: Mat3mf): Mat3mf {
         a[row * 3 + 2] * b[6 + col];
     }
   }
-  // Linha de translação: a translação de `a` passa pela rotação de `b`.
+  // Translation row: the translation of `a` goes through the rotation of `b`.
   for (let col = 0; col < 3; col++) {
     out[9 + col] =
       a[9] * b[col] + a[10] * b[3 + col] + a[11] * b[6 + col] + b[9 + col];
@@ -509,94 +647,165 @@ function mul3mf(a: Mat3mf, b: Mat3mf): Mat3mf {
   return out;
 }
 
+/** Memoized cache of parsed `.model` parts, keyed by resolved part name. */
+type ModelDocCache = Map<string, Document>;
+
+/** Loads and memoizes one `.model` part of the package. */
+async function loadModelPart(
+  uint8: Uint8Array,
+  entries: Map<string, ZipEntry>,
+  cache: ModelDocCache,
+  budget: ZipBudget,
+  path: string,
+): Promise<Document> {
+  const key = resolveModelPath(path);
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  let entryKey = key;
+  let entry = entries.get(key);
+  if (!entry) {
+    // Fallback case-insensitive: exact match first (OPC § — URIs are
+    // case-sensitive), then a case-folded scan for producers whose ZIP entry
+    // casing diverges from the `p:path` casing.
+    const lower = key.toLowerCase();
+    for (const k of entries.keys()) {
+      if (k.toLowerCase() === lower) {
+        entryKey = k;
+        entry = entries.get(k);
+        break;
+      }
+    }
+    const fallbackCached = cache.get(entryKey);
+    if (fallbackCached) {
+      cache.set(key, fallbackCached);
+      return fallbackCached;
+    }
+  }
+  if (!entry) throw new Error(`3MF part not found: ${path}`);
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(
+    await readZipEntryText(uint8, entry, budget),
+    "text/xml",
+  );
+  if (doc.querySelector("parsererror"))
+    throw new Error(`Error parsing 3MF XML in ${path}`);
+  cache.set(entryKey, doc);
+  if (entryKey !== key) cache.set(key, doc);
+  return doc;
+}
+
+/** Shared mutable state threaded through the object-graph walk. */
+interface GraphWalkState {
+  uint8: Uint8Array;
+  entries: Map<string, ZipEntry>;
+  cache: ModelDocCache;
+  budget: ZipBudget;
+  positions: number[];
+  normals: number[];
+}
+
 /**
- * Percorre o grafo de objetos do 3MF a partir dos itens de `<build>` e acumula
- * os triângulos já transformados para as coordenadas finais da bandeja.
+ * Emits one object (and everything it references) already transformed.
+ * `stack` holds the part#id pairs on the current path to stop cycles — a
+ * malformed 3MF could reference itself and hang the browser tab. `depth`
+ * caps nesting per MAX_DEPTH on top of cycle detection, throwing ZipBombError
+ * (never dropping geometry silently) when the cap is exceeded.
+ */
+async function walkObjectGraph(
+  state: GraphWalkState,
+  path: string,
+  objectId: string,
+  transform: Mat3mf,
+  stack: Set<string>,
+  depth: number,
+): Promise<void> {
+  if (depth > MAX_DEPTH)
+    throw new ZipBombError(
+      `maximum component depth exceeded (limit ${MAX_DEPTH})`,
+    );
+  const key = `${resolveModelPath(path)}#${objectId}`;
+  if (stack.has(key)) return;
+
+  const doc = await loadModelPart(
+    state.uint8,
+    state.entries,
+    state.cache,
+    state.budget,
+    path,
+  );
+  const obj = Array.from(doc.querySelectorAll("object")).find(
+    (o) => o.getAttribute("id") === objectId,
+  );
+  if (!obj) return;
+
+  stack.add(key);
+  try {
+    const mesh = obj.querySelector("mesh");
+    if (mesh) {
+      appendMesh(mesh, transform, state.positions, state.normals);
+    }
+
+    for (const component of Array.from(obj.querySelectorAll("component"))) {
+      const childId = component.getAttribute("objectid");
+      if (!childId) continue;
+      // `p:path` points at another part; without it the object is local.
+      const childPath =
+        component.getAttribute("p:path") ||
+        component.getAttribute("path") ||
+        path;
+      const childTransform = mul3mf(
+        parse3mfTransform(component.getAttribute("transform")),
+        transform,
+      );
+      await walkObjectGraph(
+        state,
+        childPath,
+        childId,
+        childTransform,
+        stack,
+        depth + 1,
+      );
+    }
+  } finally {
+    stack.delete(key);
+  }
+}
+
+/**
+ * Walks the 3MF object graph from the `<build>` items and accumulates the
+ * triangles already transformed into final tray coordinates.
  *
- * Trata os três casos que o parser antigo não tratava:
- *  - `<components>`, que montam um objeto a partir de outros objetos;
- *  - `p:path`, que põe o objeto referenciado em OUTRA parte do ZIP
- *    (production extension — é o layout de projeto do OrcaSlicer/BambuStudio);
- *  - as matrizes de `<item>` e `<component>`, sem as quais objetos múltiplos
- *    se empilham todos na origem.
+ * Handles the three cases the old parser missed:
+ *  - `<components>`, which build one object out of other objects;
+ *  - `p:path`, which puts the referenced object in ANOTHER part of the ZIP
+ *    (production extension — the OrcaSlicer/BambuStudio project layout);
+ *  - the `<item>` and `<component>` matrices, without which multiple objects
+ *    all pile up at the origin.
  */
 async function collect3mfTriangles(
   uint8: Uint8Array,
   entries: Map<string, ZipEntry>,
   rootPath: string,
+  budget: ZipBudget,
 ): Promise<{ positions: number[]; normals: number[] }> {
-  const parser = new DOMParser();
-  const docs = new Map<string, Document>();
-
-  /** Carrega e memoiza uma parte `.model` do pacote. */
-  const loadDoc = async (path: string): Promise<Document> => {
-    const key = normalizePartName(path);
-    const cached = docs.get(key);
-    if (cached) return cached;
-
-    const entry = entries.get(key);
-    if (!entry) throw new Error(`3MF part not found: ${path}`);
-
-    const doc = parser.parseFromString(
-      await readZipEntryText(uint8, entry),
-      "text/xml",
-    );
-    if (doc.querySelector("parsererror"))
-      throw new Error(`Error parsing 3MF XML in ${path}`);
-    docs.set(key, doc);
-    return doc;
+  const state: GraphWalkState = {
+    uint8,
+    entries,
+    cache: new Map<string, Document>(),
+    budget,
+    positions: [],
+    normals: [],
   };
 
-  const positions: number[] = [];
-  const normals: number[] = [];
-
-  /**
-   * Emite um objeto (e o que ele referenciar) já transformado.
-   * `stack` guarda os pares parte#id do caminho atual para barrar ciclos —
-   * um 3MF malformado poderia se auto-referenciar e travar a aba do navegador.
-   */
-  const emitObject = async (
-    path: string,
-    objectId: string,
-    transform: Mat3mf,
-    stack: Set<string>,
-  ): Promise<void> => {
-    const key = `${normalizePartName(path)}#${objectId}`;
-    if (stack.has(key) || stack.size > 32) return;
-
-    const doc = await loadDoc(path);
-    const obj = Array.from(doc.querySelectorAll("object")).find(
-      (o) => o.getAttribute("id") === objectId,
-    );
-    if (!obj) return;
-
-    stack.add(key);
-    try {
-      const mesh = obj.querySelector("mesh");
-      if (mesh) {
-        appendMesh(mesh, transform, positions, normals);
-      }
-
-      for (const component of Array.from(obj.querySelectorAll("component"))) {
-        const childId = component.getAttribute("objectid");
-        if (!childId) continue;
-        // `p:path` aponta para outra parte; sem ele, o objeto é local.
-        const childPath =
-          component.getAttribute("p:path") ||
-          component.getAttribute("path") ||
-          path;
-        const childTransform = mul3mf(
-          parse3mfTransform(component.getAttribute("transform")),
-          transform,
-        );
-        await emitObject(childPath, childId, childTransform, stack);
-      }
-    } finally {
-      stack.delete(key);
-    }
-  };
-
-  const rootDoc = await loadDoc(rootPath);
+  const rootDoc = await loadModelPart(
+    uint8,
+    entries,
+    state.cache,
+    budget,
+    rootPath,
+  );
   const items = Array.from(rootDoc.querySelectorAll("build > item"));
 
   if (items.length > 0) {
@@ -605,27 +814,29 @@ async function collect3mfTriangles(
       if (!objectId) continue;
       const itemPath =
         item.getAttribute("p:path") || item.getAttribute("path") || rootPath;
-      await emitObject(
+      await walkObjectGraph(
+        state,
         itemPath,
         objectId,
         parse3mfTransform(item.getAttribute("transform")),
         new Set<string>(),
+        0,
       );
     }
   }
 
-  // Recurso final: pacotes sem `<build>` utilizável (ou cujos itens não
-  // resolveram) ainda rendem geometria se houver malha solta em <resources>.
-  if (positions.length === 0) {
+  // Last resort: packages without a usable <build> (or whose items resolved
+  // to nothing) still yield geometry if a loose mesh sits in <resources>.
+  if (state.positions.length === 0) {
     for (const mesh of Array.from(rootDoc.querySelectorAll("object mesh"))) {
-      appendMesh(mesh, IDENTITY_3MF, positions, normals);
+      appendMesh(mesh, IDENTITY_3MF, state.positions, state.normals);
     }
   }
 
-  return { positions, normals };
+  return { positions: state.positions, normals: state.normals };
 }
 
-/** Converte um `<mesh>` do 3MF em triângulos soltos, aplicando a matriz. */
+/** Converts one 3MF `<mesh>` into loose triangles, applying the matrix. */
 function appendMesh(
   mesh: Element,
   m: Mat3mf,
@@ -633,7 +844,7 @@ function appendMesh(
   normals: number[],
 ): void {
   const vertices = mesh.querySelectorAll("vertex");
-  // Coordenadas já transformadas, em array plano: 3 números por vértice.
+  // Already-transformed coordinates, in a flat array: 3 numbers per vertex.
   const coords = new Float64Array(vertices.length * 3);
   let i = 0;
   for (const v of Array.from(vertices)) {
@@ -664,8 +875,8 @@ function appendMesh(
 
     positions.push(x1, y1, z1, x2, y2, z2, x3, y3, z3);
 
-    // Normal da face, calculada depois da transformação — assim espelhamento
-    // e rotação já vêm embutidos, sem precisar transformar normais à parte.
+    // Face normal, computed after the transform — so mirroring and rotation
+    // come baked in, with no need to transform normals separately.
     const ax = x2 - x1,
       ay = y2 - y1,
       az = z2 - z1;
@@ -690,12 +901,14 @@ async function parse3mf(
   const THREE = await import("three");
   const uint8 = new Uint8Array(await file.arrayBuffer());
 
-  const entries = readZipCentralDirectory(uint8);
+  const entries = buildZipMap(uint8);
   const rootPath = pick3mfRootModel(entries);
+  const budget: ZipBudget = { total: 0 };
   const { positions, normals } = await collect3mfTriangles(
     uint8,
     entries,
     rootPath,
+    budget,
   );
 
   if (positions.length === 0) throw new Error("No triangles found in 3MF file");
@@ -722,10 +935,10 @@ function build3mfGeometry(
   }
   geometry.computeBoundingBox();
 
-  // A análise usa o MESMO caminho de STL e OBJ. Antes o 3MF tinha uma cópia
-  // própria dela, que calculava o volume pelo teorema da divergência dividindo
-  // por 6 em vez de 18 — devolvia o TRIPLO do valor real — e ainda declarava
-  // `integrity: { valid: true }` sem verificar malha nenhuma.
+  // Analysis reuses the SAME path as STL and OBJ. The 3MF used to have its
+  // own copy, which computed volume via the divergence theorem dividing by 6
+  // instead of 18 — returning THREE times the real value — while also
+  // reporting `integrity: { valid: true }` without checking any mesh.
   return { geometry, analysis: analyzeGeometry(geometry, options) };
 }
 

--- a/src/shared/lib/stlParser.ts
+++ b/src/shared/lib/stlParser.ts
@@ -318,10 +318,22 @@ export async function analyzeMeshFile(
 // standards.
 // ---------------------------------------------------------------------------
 
-/** Max total decompressed bytes across all parts of one 3MF package. */
-export const MAX_DECOMPRESSED_TOTAL = 64 * 1024 * 1024; // 64 MB
-/** Max decompressed bytes of a single ZIP entry. */
-export const MAX_EACH_ENTRY = 32 * 1024 * 1024; // 32 MB
+/** Max total decompressed bytes across all parts of one 3MF package.
+//
+// Sized from a real-world probe: a 15.6 MB 3MF whose largest part inflates to
+// ~76 MB (ratio ~5:1, perfectly legitimate slicer output). 512 MB leaves ~6x
+// headroom above that part while staying orders of magnitude below any real
+// bomb (42.zip expands KBs to GBs/TBs, ratio ~10^9).
+// Kept in check by MAX_RATIO (100:1) and MAX_ENTRIES below, which are what
+// actually stop bombs — not these absolute byte caps. */
+export const MAX_DECOMPRESSED_TOTAL = 512 * 1024 * 1024; // 512 MB
+/** Max decompressed bytes of a single ZIP entry.
+//
+// Was 32 MB and false-positived on the legit ~76 MB part above. 256 MB keeps
+// ~3x headroom over it; bombs are still caught by MAX_RATIO (a 42.zip-style
+// payload claims ratios ~10^9, far above the 100:1 cap) and by the streaming
+// during-decompression counters, not by this ceiling. */
+export const MAX_EACH_ENTRY = 256 * 1024 * 1024; // 256 MB
 /** Max allowed expansion ratio (uncompressed / compressed) per entry. */
 export const MAX_RATIO = 100; // 100:1
 /** Max number of entries in the ZIP central directory. */
@@ -543,37 +555,58 @@ async function readZipEntryText(
     try {
       const ds = new DecompressionStream("deflate-raw");
       const writer = ds.writable.getWriter();
-      // Order matters (MDN): write, then close, then read. A corrupt stream
-      // surfaces its error on read, so the whole block stays in try/catch.
-      await writer.write(compressed);
-      await writer.close();
       const reader = ds.readable.getReader();
       const chunks: Uint8Array[] = [];
       let entryTotal = 0;
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        entryTotal += value.length;
-        // During-decompression caps: byte counting on the stream catches flat
-        // bombs whose central-directory headers lie about the sizes.
-        if (entryTotal > entry.uncompressedSize) {
-          throw new ZipBombError(
-            `entry "${entry.name}" expanded past its declared ${entry.uncompressedSize} bytes`,
-          );
+      // Concurrent pump: the read loop must be PENDING before write/close
+      // complete. Awaiting `writer.close()` with nobody draining `readable`
+      // deadlocks by backpressure once the output exceeds the internal queue
+      // (probed: 35 KB compressed -> 164 KB inflated hangs in close(); tiny
+      // test payloads fit the buffer and mask the bug). A corrupt stream
+      // surfaces its error on read, so the whole block stays in try/catch.
+      const pump = (async () => {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          entryTotal += value.length;
+          // During-decompression caps: byte counting on the stream catches flat
+          // bombs whose central-directory headers lie about the sizes.
+          if (entryTotal > entry.uncompressedSize) {
+            throw new ZipBombError(
+              `entry "${entry.name}" expanded past its declared ${entry.uncompressedSize} bytes`,
+            );
+          }
+          if (entryTotal > MAX_EACH_ENTRY) {
+            throw new ZipBombError(
+              `entry "${entry.name}" exceeds ${MAX_EACH_ENTRY} decompressed bytes`,
+            );
+          }
+          budget.total += value.length;
+          if (budget.total > MAX_DECOMPRESSED_TOTAL) {
+            throw new ZipBombError(
+              `package exceeds ${MAX_DECOMPRESSED_TOTAL} decompressed bytes total`,
+            );
+          }
+          chunks.push(value);
         }
-        if (entryTotal > MAX_EACH_ENTRY) {
-          throw new ZipBombError(
-            `entry "${entry.name}" exceeds ${MAX_EACH_ENTRY} decompressed bytes`,
-          );
+      })();
+      try {
+        await writer.write(compressed);
+        await writer.close();
+      } catch (writeErr) {
+        // If the write side fails, unblock the pending read so `pump`
+        // never hangs forever, then let the outer catch wrap the error.
+        try {
+          await reader.cancel();
+        } catch {
+          /* reader already settled — pump carries the real error */
         }
-        budget.total += value.length;
-        if (budget.total > MAX_DECOMPRESSED_TOTAL) {
-          throw new ZipBombError(
-            `package exceeds ${MAX_DECOMPRESSED_TOTAL} decompressed bytes total`,
-          );
-        }
-        chunks.push(value);
+        throw writeErr;
+      } finally {
+        writer.releaseLock();
       }
+      await pump;
+      reader.releaseLock();
       const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
       const decompressed = new Uint8Array(totalLen);
       let pos = 0;

--- a/src/shared/lib/stlParser.ts
+++ b/src/shared/lib/stlParser.ts
@@ -308,18 +308,35 @@ export async function analyzeMeshFile(
   throw new Error(`Unsupported format: ${ext}. Use STL, OBJ or 3MF.`);
 }
 
-async function parse3mf(
-  file: File,
-  options: ParseOptions = {},
-): Promise<{ geometry: THREE.BufferGeometry; analysis: MeshAnalysis }> {
-  const THREE = await import("three");
-  const buffer = await file.arrayBuffer();
-  const uint8 = new Uint8Array(buffer);
+/**
+ * Uma entrada do diretório central do ZIP que embala o 3MF.
+ * O 3MF é um pacote OPC (um ZIP), então ler o arquivo é ler o ZIP primeiro.
+ */
+interface ZipEntry {
+  name: string;
+  compressionMethod: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+}
 
-  // Minimal ZIP parser for 3MF (3MF is a ZIP archive containing XML)
-  // Find the End of Central Directory record
+/**
+ * Lê o diretório central do ZIP e devolve TODAS as entradas indexadas por nome
+ * em minúsculas (nomes de parte OPC são comparados sem diferenciar maiúsculas).
+ *
+ * Antes esta varredura parava na PRIMEIRA entrada terminada em ".model" e
+ * decodificava só ela. Isso quebra os arquivos da "production extension"
+ * (projetos do OrcaSlicer/BambuStudio), em que o modelo raiz não contém malha
+ * nenhuma — só <components p:path="/3D/Objects/object_N.model"> — e as malhas
+ * de verdade moram em outras partes do mesmo ZIP.
+ */
+function readZipCentralDirectory(uint8: Uint8Array): Map<string, ZipEntry> {
+  // O End Of Central Directory fica, por especificação, nos últimos
+  // 22 + 65535 bytes (o comentário do ZIP tem no máximo 64 KiB). Limitar a
+  // busca a essa janela evita varrer um arquivo de centenas de MB byte a byte.
+  const scanStart = Math.max(0, uint8.length - 22 - 0xffff);
   let eocdOffset = -1;
-  for (let i = uint8.length - 22; i >= 0; i--) {
+  for (let i = uint8.length - 22; i >= scanStart; i--) {
     if (
       uint8[i] === 0x50 &&
       uint8[i + 1] === 0x4b &&
@@ -333,165 +350,365 @@ async function parse3mf(
   if (eocdOffset === -1)
     throw new Error("Invalid 3MF file: not a valid ZIP archive");
 
-  // Read central directory offset
   const cdOffset =
-    uint8[eocdOffset + 16] |
-    (uint8[eocdOffset + 17] << 8) |
-    (uint8[eocdOffset + 18] << 16) |
-    (uint8[eocdOffset + 19] << 24);
+    (uint8[eocdOffset + 16] |
+      (uint8[eocdOffset + 17] << 8) |
+      (uint8[eocdOffset + 18] << 16) |
+      (uint8[eocdOffset + 19] << 24)) >>>
+    0;
   const numEntries = uint8[eocdOffset + 10] | (uint8[eocdOffset + 11] << 8);
 
-  // Find the 3D/3DModel.model file
+  const entries = new Map<string, ZipEntry>();
   let offset = cdOffset;
   for (let i = 0; i < numEntries; i++) {
+    // 0x02014b50 = assinatura de um cabeçalho do diretório central.
     if (uint8[offset] !== 0x50 || uint8[offset + 1] !== 0x4b) break;
 
     const fileNameLen = uint8[offset + 28] | (uint8[offset + 29] << 8);
     const extraLen = uint8[offset + 30] | (uint8[offset + 31] << 8);
     const commentLen = uint8[offset + 32] | (uint8[offset + 33] << 8);
-    const localHeaderOffset =
-      uint8[offset + 42] |
-      (uint8[offset + 43] << 8) |
-      (uint8[offset + 44] << 16) |
-      (uint8[offset + 45] << 24);
-    const compressedSize =
-      uint8[offset + 20] |
-      (uint8[offset + 21] << 8) |
-      (uint8[offset + 22] << 16) |
-      (uint8[offset + 23] << 24);
-    const uncompressedSize =
-      uint8[offset + 24] |
-      (uint8[offset + 25] << 8) |
-      (uint8[offset + 26] << 16) |
-      (uint8[offset + 27] << 24);
-    const compressionMethod = uint8[offset + 10] | (uint8[offset + 11] << 8);
-
-    const fileName = new TextDecoder().decode(
+    const name = new TextDecoder().decode(
       uint8.slice(offset + 46, offset + 46 + fileNameLen),
     );
 
-    if (fileName === "3D/3DModel.model" || fileName.endsWith(".model")) {
-      // Extract the file data
-      const localHeaderStart = localHeaderOffset;
-      const localFileNameLen =
-        uint8[localHeaderStart + 26] | (uint8[localHeaderStart + 27] << 8);
-      const localExtraLen =
-        uint8[localHeaderStart + 28] | (uint8[localHeaderStart + 29] << 8);
-      const dataStart =
-        localHeaderStart + 30 + localFileNameLen + localExtraLen;
-
-      if (compressionMethod === 0) {
-        // Stored (no compression)
-        const xmlData = new TextDecoder().decode(
-          uint8.slice(dataStart, dataStart + uncompressedSize),
-        );
-        return parse3mfXml(xmlData, THREE, options);
-      } else if (compressionMethod === 8) {
-        // Deflate - use DecompressionStream
-        const compressed = uint8.slice(dataStart, dataStart + compressedSize);
-        const ds = new DecompressionStream("deflate-raw");
-        const writer = ds.writable.getWriter();
-        writer.write(compressed);
-        writer.close();
-        const reader = ds.readable.getReader();
-        const chunks: Uint8Array[] = [];
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          chunks.push(value);
-        }
-        const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
-        const decompressed = new Uint8Array(totalLen);
-        let pos = 0;
-        for (const chunk of chunks) {
-          decompressed.set(chunk, pos);
-          pos += chunk.length;
-        }
-        const xmlData = new TextDecoder().decode(decompressed);
-        return parse3mfXml(xmlData, THREE, options);
-      } else {
-        throw new Error(`Unsupported compression method: ${compressionMethod}`);
-      }
-    }
+    entries.set(normalizePartName(name), {
+      name,
+      compressionMethod: uint8[offset + 10] | (uint8[offset + 11] << 8),
+      compressedSize:
+        (uint8[offset + 20] |
+          (uint8[offset + 21] << 8) |
+          (uint8[offset + 22] << 16) |
+          (uint8[offset + 23] << 24)) >>>
+        0,
+      uncompressedSize:
+        (uint8[offset + 24] |
+          (uint8[offset + 25] << 8) |
+          (uint8[offset + 26] << 16) |
+          (uint8[offset + 27] << 24)) >>>
+        0,
+      localHeaderOffset:
+        (uint8[offset + 42] |
+          (uint8[offset + 43] << 8) |
+          (uint8[offset + 44] << 16) |
+          (uint8[offset + 45] << 24)) >>>
+        0,
+    });
 
     offset += 46 + fileNameLen + extraLen + commentLen;
   }
 
+  return entries;
+}
+
+/**
+ * Normaliza um nome de parte OPC para servir de chave: sem a barra inicial
+ * (o `p:path` do 3MF é absoluto, `/3D/Objects/x.model`, mas o ZIP guarda
+ * `3D/Objects/x.model`), com barras invertidas viradas e em minúsculas.
+ */
+function normalizePartName(name: string): string {
+  return name.replace(/\\/g, "/").replace(/^\/+/, "").toLowerCase();
+}
+
+/** Descomprime uma entrada do ZIP e devolve o texto (as partes do 3MF são XML). */
+async function readZipEntryText(
+  uint8: Uint8Array,
+  entry: ZipEntry,
+): Promise<string> {
+  // Os tamanhos vêm do diretório central; o cabeçalho local só é consultado
+  // para saber onde os dados começam, porque os campos de tamanho dele podem
+  // estar zerados quando o escritor usou data descriptor.
+  const lhs = entry.localHeaderOffset;
+  const localFileNameLen = uint8[lhs + 26] | (uint8[lhs + 27] << 8);
+  const localExtraLen = uint8[lhs + 28] | (uint8[lhs + 29] << 8);
+  const dataStart = lhs + 30 + localFileNameLen + localExtraLen;
+
+  if (entry.compressionMethod === 0) {
+    // Stored: os bytes já são o conteúdo.
+    return new TextDecoder().decode(
+      uint8.slice(dataStart, dataStart + entry.uncompressedSize),
+    );
+  }
+
+  if (entry.compressionMethod === 8) {
+    // Deflate cru (sem cabeçalho zlib) — é o que o ZIP usa.
+    const compressed = uint8.slice(dataStart, dataStart + entry.compressedSize);
+    const ds = new DecompressionStream("deflate-raw");
+    const writer = ds.writable.getWriter();
+    writer.write(compressed);
+    writer.close();
+    const reader = ds.readable.getReader();
+    const chunks: Uint8Array[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+    const decompressed = new Uint8Array(totalLen);
+    let pos = 0;
+    for (const chunk of chunks) {
+      decompressed.set(chunk, pos);
+      pos += chunk.length;
+    }
+    return new TextDecoder().decode(decompressed);
+  }
+
+  throw new Error(`Unsupported compression method: ${entry.compressionMethod}`);
+}
+
+/**
+ * Escolhe a parte que é o modelo raiz do pacote.
+ * Ordem: o caminho convencional `3D/3dmodel.model` e, se ele não existir,
+ * a primeira parte `.model` do pacote.
+ */
+function pick3mfRootModel(entries: Map<string, ZipEntry>): string {
+  if (entries.has("3d/3dmodel.model")) return "3d/3dmodel.model";
+
+  for (const key of entries.keys()) {
+    if (key.endsWith(".model")) return key;
+  }
   throw new Error("3MF file does not contain a valid 3D model");
 }
 
-function parse3mfXml(
-  xmlData: string,
-  THREE: typeof import("three"),
-  options: ParseOptions = {},
-): { geometry: THREE.BufferGeometry; analysis: MeshAnalysis } {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(xmlData, "text/xml");
+/**
+ * Matriz do 3MF: 12 números que formam uma 4x3 em convenção de vetor-linha
+ * (`m00 m01 m02 m10 m11 m12 m20 m21 m22 m30 m31 m32`), onde a última linha é
+ * a translação. A identidade é o valor implícito quando o atributo falta.
+ */
+type Mat3mf = number[];
 
-  const error = doc.querySelector("parsererror");
-  if (error) throw new Error("Error parsing 3MF XML");
+const IDENTITY_3MF: Mat3mf = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0];
 
-  const objects = doc.querySelectorAll("object");
-  const allPositions: number[] = [];
-  const allNormals: number[] = [];
+function parse3mfTransform(value: string | null): Mat3mf {
+  if (!value) return IDENTITY_3MF;
+  const n = value.trim().split(/\s+/).map(Number);
+  if (n.length !== 12 || n.some((v) => !Number.isFinite(v)))
+    return IDENTITY_3MF;
+  return n;
+}
 
-  for (const obj of Array.from(objects)) {
-    const mesh = obj.querySelector("mesh");
-    if (!mesh) continue;
-
-    // Parse vertices
-    const vertices = mesh.querySelectorAll("vertex");
-    const vertexCoords: [number, number, number][] = [];
-    for (const v of Array.from(vertices)) {
-      const x = parseFloat(v.getAttribute("x") || "0");
-      const y = parseFloat(v.getAttribute("y") || "0");
-      const z = parseFloat(v.getAttribute("z") || "0");
-      vertexCoords.push([x, y, z]);
+/**
+ * Compõe duas transformações: aplica `a` primeiro e `b` depois
+ * (p' = p · a · b, seguindo a convenção de vetor-linha do 3MF).
+ */
+function mul3mf(a: Mat3mf, b: Mat3mf): Mat3mf {
+  const out = new Array<number>(12);
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 3; col++) {
+      out[row * 3 + col] =
+        a[row * 3] * b[col] +
+        a[row * 3 + 1] * b[3 + col] +
+        a[row * 3 + 2] * b[6 + col];
     }
+  }
+  // Linha de translação: a translação de `a` passa pela rotação de `b`.
+  for (let col = 0; col < 3; col++) {
+    out[9 + col] =
+      a[9] * b[col] + a[10] * b[3 + col] + a[11] * b[6 + col] + b[9 + col];
+  }
+  return out;
+}
 
-    // Parse triangles
-    const triangles = mesh.querySelectorAll("triangle");
-    for (const t of Array.from(triangles)) {
-      const v1 = parseInt(t.getAttribute("v1") || "0");
-      const v2 = parseInt(t.getAttribute("v2") || "0");
-      const v3 = parseInt(t.getAttribute("v3") || "0");
+/**
+ * Percorre o grafo de objetos do 3MF a partir dos itens de `<build>` e acumula
+ * os triângulos já transformados para as coordenadas finais da bandeja.
+ *
+ * Trata os três casos que o parser antigo não tratava:
+ *  - `<components>`, que montam um objeto a partir de outros objetos;
+ *  - `p:path`, que põe o objeto referenciado em OUTRA parte do ZIP
+ *    (production extension — é o layout de projeto do OrcaSlicer/BambuStudio);
+ *  - as matrizes de `<item>` e `<component>`, sem as quais objetos múltiplos
+ *    se empilham todos na origem.
+ */
+async function collect3mfTriangles(
+  uint8: Uint8Array,
+  entries: Map<string, ZipEntry>,
+  rootPath: string,
+): Promise<{ positions: number[]; normals: number[] }> {
+  const parser = new DOMParser();
+  const docs = new Map<string, Document>();
 
-      if (
-        v1 < vertexCoords.length &&
-        v2 < vertexCoords.length &&
-        v3 < vertexCoords.length
-      ) {
-        const [x1, y1, z1] = vertexCoords[v1];
-        const [x2, y2, z2] = vertexCoords[v2];
-        const [x3, y3, z3] = vertexCoords[v3];
+  /** Carrega e memoiza uma parte `.model` do pacote. */
+  const loadDoc = async (path: string): Promise<Document> => {
+    const key = normalizePartName(path);
+    const cached = docs.get(key);
+    if (cached) return cached;
 
-        allPositions.push(x1, y1, z1, x2, y2, z2, x3, y3, z3);
+    const entry = entries.get(key);
+    if (!entry) throw new Error(`3MF part not found: ${path}`);
 
-        // Calculate normal
-        const ax = x2 - x1,
-          ay = y2 - y1,
-          az = z2 - z1;
-        const bx = x3 - x1,
-          by = y3 - y1,
-          bz = z3 - z1;
-        let nx = ay * bz - az * by;
-        let ny = az * bx - ax * bz;
-        let nz = ax * by - ay * bx;
-        const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
-        nx /= len;
-        ny /= len;
-        nz /= len;
+    const doc = parser.parseFromString(
+      await readZipEntryText(uint8, entry),
+      "text/xml",
+    );
+    if (doc.querySelector("parsererror"))
+      throw new Error(`Error parsing 3MF XML in ${path}`);
+    docs.set(key, doc);
+    return doc;
+  };
 
-        for (let i = 0; i < 3; i++) {
-          allNormals.push(nx, ny, nz);
-        }
+  const positions: number[] = [];
+  const normals: number[] = [];
+
+  /**
+   * Emite um objeto (e o que ele referenciar) já transformado.
+   * `stack` guarda os pares parte#id do caminho atual para barrar ciclos —
+   * um 3MF malformado poderia se auto-referenciar e travar a aba do navegador.
+   */
+  const emitObject = async (
+    path: string,
+    objectId: string,
+    transform: Mat3mf,
+    stack: Set<string>,
+  ): Promise<void> => {
+    const key = `${normalizePartName(path)}#${objectId}`;
+    if (stack.has(key) || stack.size > 32) return;
+
+    const doc = await loadDoc(path);
+    const obj = Array.from(doc.querySelectorAll("object")).find(
+      (o) => o.getAttribute("id") === objectId,
+    );
+    if (!obj) return;
+
+    stack.add(key);
+    try {
+      const mesh = obj.querySelector("mesh");
+      if (mesh) {
+        appendMesh(mesh, transform, positions, normals);
       }
+
+      for (const component of Array.from(obj.querySelectorAll("component"))) {
+        const childId = component.getAttribute("objectid");
+        if (!childId) continue;
+        // `p:path` aponta para outra parte; sem ele, o objeto é local.
+        const childPath =
+          component.getAttribute("p:path") ||
+          component.getAttribute("path") ||
+          path;
+        const childTransform = mul3mf(
+          parse3mfTransform(component.getAttribute("transform")),
+          transform,
+        );
+        await emitObject(childPath, childId, childTransform, stack);
+      }
+    } finally {
+      stack.delete(key);
+    }
+  };
+
+  const rootDoc = await loadDoc(rootPath);
+  const items = Array.from(rootDoc.querySelectorAll("build > item"));
+
+  if (items.length > 0) {
+    for (const item of items) {
+      const objectId = item.getAttribute("objectid");
+      if (!objectId) continue;
+      const itemPath =
+        item.getAttribute("p:path") || item.getAttribute("path") || rootPath;
+      await emitObject(
+        itemPath,
+        objectId,
+        parse3mfTransform(item.getAttribute("transform")),
+        new Set<string>(),
+      );
     }
   }
 
-  if (allPositions.length === 0)
-    throw new Error("No triangles found in 3MF file");
+  // Recurso final: pacotes sem `<build>` utilizável (ou cujos itens não
+  // resolveram) ainda rendem geometria se houver malha solta em <resources>.
+  if (positions.length === 0) {
+    for (const mesh of Array.from(rootDoc.querySelectorAll("object mesh"))) {
+      appendMesh(mesh, IDENTITY_3MF, positions, normals);
+    }
+  }
 
+  return { positions, normals };
+}
+
+/** Converte um `<mesh>` do 3MF em triângulos soltos, aplicando a matriz. */
+function appendMesh(
+  mesh: Element,
+  m: Mat3mf,
+  positions: number[],
+  normals: number[],
+): void {
+  const vertices = mesh.querySelectorAll("vertex");
+  // Coordenadas já transformadas, em array plano: 3 números por vértice.
+  const coords = new Float64Array(vertices.length * 3);
+  let i = 0;
+  for (const v of Array.from(vertices)) {
+    const x = parseFloat(v.getAttribute("x") || "0");
+    const y = parseFloat(v.getAttribute("y") || "0");
+    const z = parseFloat(v.getAttribute("z") || "0");
+    coords[i++] = x * m[0] + y * m[3] + z * m[6] + m[9];
+    coords[i++] = x * m[1] + y * m[4] + z * m[7] + m[10];
+    coords[i++] = x * m[2] + y * m[5] + z * m[8] + m[11];
+  }
+
+  const vertexCount = vertices.length;
+  for (const t of Array.from(mesh.querySelectorAll("triangle"))) {
+    const v1 = parseInt(t.getAttribute("v1") || "0");
+    const v2 = parseInt(t.getAttribute("v2") || "0");
+    const v3 = parseInt(t.getAttribute("v3") || "0");
+    if (v1 >= vertexCount || v2 >= vertexCount || v3 >= vertexCount) continue;
+
+    const x1 = coords[v1 * 3],
+      y1 = coords[v1 * 3 + 1],
+      z1 = coords[v1 * 3 + 2];
+    const x2 = coords[v2 * 3],
+      y2 = coords[v2 * 3 + 1],
+      z2 = coords[v2 * 3 + 2];
+    const x3 = coords[v3 * 3],
+      y3 = coords[v3 * 3 + 1],
+      z3 = coords[v3 * 3 + 2];
+
+    positions.push(x1, y1, z1, x2, y2, z2, x3, y3, z3);
+
+    // Normal da face, calculada depois da transformação — assim espelhamento
+    // e rotação já vêm embutidos, sem precisar transformar normais à parte.
+    const ax = x2 - x1,
+      ay = y2 - y1,
+      az = z2 - z1;
+    const bx = x3 - x1,
+      by = y3 - y1,
+      bz = z3 - z1;
+    let nx = ay * bz - az * by;
+    let ny = az * bx - ax * bz;
+    let nz = ax * by - ay * bx;
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
+    nx /= len;
+    ny /= len;
+    nz /= len;
+    for (let k = 0; k < 3; k++) normals.push(nx, ny, nz);
+  }
+}
+
+async function parse3mf(
+  file: File,
+  options: ParseOptions = {},
+): Promise<{ geometry: THREE.BufferGeometry; analysis: MeshAnalysis }> {
+  const THREE = await import("three");
+  const uint8 = new Uint8Array(await file.arrayBuffer());
+
+  const entries = readZipCentralDirectory(uint8);
+  const rootPath = pick3mfRootModel(entries);
+  const { positions, normals } = await collect3mfTriangles(
+    uint8,
+    entries,
+    rootPath,
+  );
+
+  if (positions.length === 0) throw new Error("No triangles found in 3MF file");
+
+  return build3mfGeometry(positions, normals, THREE, options);
+}
+
+function build3mfGeometry(
+  allPositions: number[],
+  allNormals: number[],
+  THREE: typeof import("three"),
+  options: ParseOptions = {},
+): { geometry: THREE.BufferGeometry; analysis: MeshAnalysis } {
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute(
     "position",
@@ -505,77 +722,11 @@ function parse3mfXml(
   }
   geometry.computeBoundingBox();
 
-  const volume = calcVolumeFromPositions(allPositions);
-  const box = geometry.boundingBox!;
-  const meshSurfaceArea = calculateSurfaceArea(geometry);
-  const analysis: MeshAnalysis = {
-    volume,
-    triangleCount: allPositions.length / 9,
-    vertexCount: allPositions.length / 3,
-    dimensions: {
-      x: box.max.x - box.min.x,
-      y: box.max.y - box.min.y,
-      z: box.max.z - box.min.z,
-    },
-    surfaceArea: +meshSurfaceArea.toFixed(2),
-    boundingBox: {
-      min: { x: box.min.x, y: box.min.y, z: box.min.z },
-      max: { x: box.max.x, y: box.max.y, z: box.max.z },
-    },
-    integrity: { valid: true, issues: [] },
-  };
-
-  if (options.estimateSupport) {
-    analysis.supportVolumeCm3 = +estimateSupportVolume(
-      extractTriangles(geometry),
-      options,
-    ).toFixed(2);
-  }
-
-  return { geometry, analysis };
-}
-
-function calcVolumeFromPositions(positions: number[]): number {
-  let volume = 0;
-  const v1 = new (typeof Float32Array !== "undefined" ? Float32Array : Array)(
-    3,
-  );
-  const v2 = new (typeof Float32Array !== "undefined" ? Float32Array : Array)(
-    3,
-  );
-  const v3 = new (typeof Float32Array !== "undefined" ? Float32Array : Array)(
-    3,
-  );
-  const normal = new (
-    typeof Float32Array !== "undefined" ? Float32Array : Array
-  )(3);
-
-  for (let i = 0; i < positions.length; i += 9) {
-    v1[0] = positions[i];
-    v1[1] = positions[i + 1];
-    v1[2] = positions[i + 2];
-    v2[0] = positions[i + 3];
-    v2[1] = positions[i + 4];
-    v2[2] = positions[i + 5];
-    v3[0] = positions[i + 6];
-    v3[1] = positions[i + 7];
-    v3[2] = positions[i + 8];
-
-    normal[0] =
-      (v2[1] - v1[1]) * (v3[2] - v1[2]) - (v2[2] - v1[2]) * (v3[1] - v1[1]);
-    normal[1] =
-      (v2[2] - v1[2]) * (v3[0] - v1[0]) - (v2[0] - v1[0]) * (v3[2] - v1[2]);
-    normal[2] =
-      (v2[0] - v1[0]) * (v3[1] - v1[1]) - (v2[1] - v1[1]) * (v3[0] - v1[0]);
-
-    volume +=
-      (normal[0] * (v1[0] + v2[0] + v3[0]) +
-        normal[1] * (v1[1] + v2[1] + v3[1]) +
-        normal[2] * (v1[2] + v2[2] + v3[2])) /
-      6;
-  }
-
-  return Math.abs(volume);
+  // A análise usa o MESMO caminho de STL e OBJ. Antes o 3MF tinha uma cópia
+  // própria dela, que calculava o volume pelo teorema da divergência dividindo
+  // por 6 em vez de 18 — devolvia o TRIPLO do valor real — e ainda declarava
+  // `integrity: { valid: true }` sem verificar malha nenhuma.
+  return { geometry, analysis: analyzeGeometry(geometry, options) };
 }
 
 function mergeGeometries(


### PR DESCRIPTION
Projetos .3mf do OrcaSlicer/BambuStudio nao abriam: o parser lia apenas a primeira parte .model do ZIP e procurava <mesh> dentro dela. Esses arquivos usam a production extension, em que 3D/3dmodel.model nao tem malha nenhuma e so referencia outras partes do pacote via <components p:path=...>, entao o parser achava 0 triangulos e falhava.

Tres problemas corrigidos no caminho do 3MF:

1. p:path nao era seguido. Agora o diretorio central do ZIP inteiro e indexado e o grafo e percorrido a partir de <build><item>, resolvendo <components> e partes externas, com protecao contra ciclos (um 3MF malformado podia travar a aba do navegador).

2. As matrizes de <item> e <component> eram ignoradas, entao objetos multiplos ficavam empilhados na origem e as dimensoes saiam erradas. Agora sao compostas e aplicadas (4x3, convencao de vetor-linha).

3. calcVolumeFromPositions() dividia por 6 onde o teorema da divergencia pede 18, e todo volume de 3MF saia 3x maior -- um cubo de 10 mm era reportado como 3000 mm3. O projeto ja tinha a conta certa em calculateVolume()/signedTetraVolume(), usada por STL e OBJ; a duplicata foi removida e o 3MF passou a usar analyzeGeometry(), que tambem roda o validateMesh() que o caminho do 3MF pulava (declarava integrity valida sem verificar).

Testado contra cube_gears.3mf, facecolors.3mf e multipletextures.3mf (three.js), Production/detachedmodel.3mf (lib3mf, que passou de 48 para os 1296 triangulos reais) e um projeto real do BambuStudio, alem de pacotes sinteticos com production extension, matrizes e componentes ciclicos.

closes #69