### PR TITLE
fix(estimators): casca por area de superficie e fisica da extrusao no…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,12 @@ db/**/*.js.map
 desktop/db/**/*.js
 desktop/db/**/*.js.map
 
-# Pantheon / docs
+# Pantheon / docs (conteúdo ignorado, exceto ADRs explicitamente versionados;
+# docs/* em vez de docs/ para permitir a negação abaixo — git não
+# re-inclui arquivo dentro de diretório excluído)
 .pantheon/
-docs/
+docs/*
+!docs/estimators-model.md
 
 # Logs
 logs/

--- a/docs/estimators-model.md
+++ b/docs/estimators-model.md
@@ -1,0 +1,91 @@
+# Modelo dos estimadores FDM (peso + tempo)
+
+> Status: vigente a partir do PR #73 (branch `pr-73-hardening`).
+> Escopo: `src/shared/lib/stlParser.ts` (`estimateMaterialVolumeCm3`,
+> `estimateWeight`), `src/shared/lib/printTimeEstimator.ts`
+> (`estimatePrintTime`), `src/shared/lib/filamentProfiles.ts`, único
+> consumidor `StlPreview.tsx`.
+
+## 1. Fórmula canônica
+
+Padrão consagrado das calculadoras (Meshy/ThisCalc):
+
+```
+shell  = min(volume, área × espessura_casca)
+inner  = max(0, volume − shell)
+total  = shell + inner × infill + suporte
+peso   = total × (1 + purga) × densidade
+```
+
+## 2. Casca derivada do perfil (sem 0,84 fixo)
+
+```
+espessura_casca = wallCount × lineWidthMm + (topLayers + bottomLayers) × layerHeightMm / 2
+```
+
+Defaults: `wallCount = 2`, `lineWidthMm = 0,42`, `topLayers = 4`,
+`bottomLayers = 4`, `layerHeightMm = 0,2` → casca padrão 1,64 mm.
+`shellThicknessMm` explícito vence a derivação (válvula de escape, não regra).
+
+A divisão por 2 no termo topo/base assume que as áreas projetadas de topo e
+base somam ~metade da superfície total. É aproximação documentada, com **viés
+deliberado de superestimação** (ver §5).
+
+## 3. Física da extrusão + teto MVS
+
+O tempo usa o caminho do BICO (`volume / (layerH × lineW)`), não o
+comprimento de filamento (erro de ~30× corrigido no PR #73). A vazão
+`Q = layerH × lineW × speed` é clamped no MVS do material:
+
+| Material     | Densidade (g/cm³) | MVS (mm³/s)      |
+| ------------ | ----------------- | ---------------- |
+| PLA          | 1,24              | 15               |
+| PETG         | 1,27              | 12               |
+| ABS          | 1,04              | 12               |
+| ASA          | 1,05              | 12               |
+| TPU          | 1,21              | 5                |
+| Nylon        | 1,14              | 10               |
+| Desconhecido | PLA (fallback)    | 10 (teto seguro) |
+
+`material` é input com default PLA; `densityGcm3` explícito (store) vence a
+tabela. Travel = 25% da distância de extrusão a 150 mm/s (aproximação
+pré-slice → overhead efetivo de ~10–15%), +2 s por troca de camada.
+
+## 4. Inputs padrão
+
+`infillPercent = 20`, speeds 60/150 mm/s, `purgePercent = 0` (o chamador
+— hoje `StlPreview` — passa 10), `travelRatio = 0,25`. Sem área de malha,
+cai no legado `volume × (0,2 + 0,8 × infill)`. Geometria inválida
+(volume ≤ 0/NaN, altura ≤ 0) retorna **zeros explícitos**, nunca NaN.
+
+## 5. Premissas e limites
+
+- Saídas rotuladas `rough_estimate`: aproximação **pré-slice, ±30%**. Só um
+  fatiador crava peso/tempo (retrações, saltos, aceleração e suportes reais).
+- **Política de superestimação explícita**: nas dúvidas o modelo erra para
+  cima (teto MVS seguro, casca com topo/base cheio, fallback no volume
+  maciço). Motivo: margem de preço — subestimar dá prejuízo, superestimar
+  dá gordura.
+- Quebras intencionais (sem compat): `estimateMaterialVolumeCm3`/
+  `estimateWeight` posicionais → objeto `EstimateOptions`; `PrintTimeParams`
+  renomeado para sufixos canônicos (`layerHeightMm`, `printSpeedMmPerS`) e
+  sem params-fantasma (`wallCount`, `infillPercent`, `printerPowerWatts`,
+  `nozzleDiameterMm`, `topBottomLayers` removidos — só alimentavam o rótulo
+  de confiança). Único caller externo era o `StlPreview`, migrado junto.
+  `DEFAULT_SHELL_THICKNESS_MM` removido.
+
+## 6. Pendência pós-merge #72 — RE-MEDIÇÃO DA LITOFANIA (NÃO FAZER AGORA)
+
+A âncora da litofania (92,52 cm³ / 72,8 cm³ no BambuStudio) foi medida com o
+volume **pré-correção do #72**. Após o merge do #72, re-medir o mesmo projeto
+e atualizar os testes/§2 se os números deslocarem. Os testes atuais ancoram
+o _comportamento_ (saturação no volume), não a medição exata, de propósito.
+
+## 7. Follow-up — fiação wall/lineWidth na store do Calculator (NÃO FEITO)
+
+`wallCount`/`lineWidthMm` hoje vivem só nos defaults do estimador
+(`VOLUME_DEFAULTS`); a store do Calculator (`calculatorStore.types.ts`) não
+tem esses campos — só `infillPercent`. Ligar o perfil de impressão da UI aos
+estimadores exige adicionar `wallCount`/`lineWidthMm` (e, por coerência,
+`topLayers`/`bottomLayers`/`layerHeightMm`) à store, fora do escopo deste PR.
+Até lá, `StlPreview` segue com os defaults documentados no §2.

--- a/src/shared/components/Calculator/sections/MaterialSection.tsx
+++ b/src/shared/components/Calculator/sections/MaterialSection.tsx
@@ -281,7 +281,6 @@ export function MaterialSection({
                   onClear={handleStlClear}
                   materialDensity={store.fdmMaterial.density}
                   infillPercent={store.infillPercent}
-                  printerPowerWatts={store.fdmPrintParams.printerPowerWatts}
                 />
               </div>
             </>
@@ -436,7 +435,6 @@ export function MaterialSection({
                   onClear={handleStlClear}
                   materialDensity={store.fdmMaterial.density}
                   infillPercent={store.infillPercent}
-                  printerPowerWatts={store.fdmPrintParams.printerPowerWatts}
                 />
               </div>
             </div>
@@ -597,7 +595,6 @@ export function MaterialSection({
               onClear={handleStlClear}
               materialDensity={store.resinMaterial.density}
               infillPercent={100}
-              printerPowerWatts={store.resinPrintParams.printerPowerWatts}
             />
           </div>
         </div>

--- a/src/shared/components/StlPreview/StlPreview.tsx
+++ b/src/shared/components/StlPreview/StlPreview.tsx
@@ -325,8 +325,12 @@ export function StlPreview({
           setModelInfo(result);
           onFileParsed?.(result);
         } else {
-          const { analyzeMeshFile, volumeToCm3, estimateWeight } =
-            await import("@/shared/lib/stlParser");
+          const {
+            analyzeMeshFile,
+            volumeToCm3,
+            estimateWeight,
+            estimateMaterialVolumeCm3,
+          } = await import("@/shared/lib/stlParser");
           const { geometry: parsedGeometry, analysis } = await analyzeMeshFile(
             file,
             {
@@ -344,9 +348,26 @@ export function StlPreview({
           const volumeCm3 = volumeToCm3(analysis.volume);
           const density = materialDensity ?? 1.24;
           const infill = infillPercent ?? 20;
-          const weight = estimateWeight(volumeCm3, density, infill, 10);
+          // A área de superfície já era calculada e nunca usada. É ela que
+          // permite estimar a casca de verdade, em vez de assumir 20% do volume.
+          const surfaceAreaCm2 = analysis.surfaceArea / 100; // mm² → cm²
+          const weight = estimateWeight(
+            volumeCm3,
+            density,
+            infill,
+            10,
+            surfaceAreaCm2,
+          );
+          // O tempo tem que usar o plástico REALMENTE extrudado, não o volume
+          // maciço do modelo — senão peça oca é cobrada como se fosse sólida.
+          const materialVolumeCm3 = estimateMaterialVolumeCm3(
+            volumeCm3,
+            infill,
+            surfaceAreaCm2,
+          );
           const timeEstimate = estimatePrintTime({
             volumeCm3,
+            materialVolumeCm3,
             dimensions: analysis.dimensions,
             layerHeight,
             speed,

--- a/src/shared/components/StlPreview/StlPreview.tsx
+++ b/src/shared/components/StlPreview/StlPreview.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import type { BufferGeometry } from "three";
 import type { MeshAnalysis } from "@/shared/lib/stlParser";
+import type { FilamentFamily } from "@/shared/lib/filamentProfiles";
 import { estimatePrintTime } from "@/shared/lib/printTimeEstimator";
 
 export interface FileParseResult {
@@ -44,10 +45,13 @@ interface StlPreviewProps {
   layerHeight?: number;
   /** Print speed in mm/s (from store fdmPrintParams). Default 60. */
   speed?: number;
-  /** Number of perimeter walls (from store fdmPrintParams). Default 3. */
+  /** Number of perimeter walls (from store fdmPrintParams). Default 2. */
   wallCount?: number;
-  /** Printer power draw in watts (from store fdmPrintParams / selectedPrinter). */
-  printerPowerWatts?: number;
+  /**
+   * Filament family for the MVS speed clamp (default PLA).
+   * Density still comes from `materialDensity` when provided.
+   */
+  material?: FilamentFamily;
   /** When true, estimates support material volume from overhang triangles. Default false. */
   estimateSupport?: boolean;
   /** Called when the user clears the loaded model from the viewer. */
@@ -211,7 +215,7 @@ export function StlPreview({
   layerHeight,
   speed,
   wallCount,
-  printerPowerWatts,
+  material,
   estimateSupport = false,
   onClear,
 }: StlPreviewProps) {
@@ -348,32 +352,32 @@ export function StlPreview({
           const volumeCm3 = volumeToCm3(analysis.volume);
           const density = materialDensity ?? 1.24;
           const infill = infillPercent ?? 20;
-          // A área de superfície já era calculada e nunca usada. É ela que
-          // permite estimar a casca de verdade, em vez de assumir 20% do volume.
-          const surfaceAreaCm2 = analysis.surfaceArea / 100; // mm² → cm²
-          const weight = estimateWeight(
-            volumeCm3,
-            density,
-            infill,
-            10,
-            surfaceAreaCm2,
-          );
+          // A área de superfície entra em mm² (unidade canônica da malha) —
+          // a conversão para cm² acontece dentro do estimador.
+          const weight = estimateWeight(volumeCm3, {
+            densityGcm3: density,
+            material,
+            infillPercent: infill,
+            purgePercent: 10,
+            surfaceAreaMm2: analysis.surfaceArea,
+            wallCount,
+            supportVolumeCm3: analysis.supportVolumeCm3,
+          });
           // O tempo tem que usar o plástico REALMENTE extrudado, não o volume
           // maciço do modelo — senão peça oca é cobrada como se fosse sólida.
-          const materialVolumeCm3 = estimateMaterialVolumeCm3(
-            volumeCm3,
-            infill,
-            surfaceAreaCm2,
-          );
+          const materialVolumeCm3 = estimateMaterialVolumeCm3(volumeCm3, {
+            infillPercent: infill,
+            surfaceAreaMm2: analysis.surfaceArea,
+            wallCount,
+            supportVolumeCm3: analysis.supportVolumeCm3,
+          });
           const timeEstimate = estimatePrintTime({
             volumeCm3,
             materialVolumeCm3,
             dimensions: analysis.dimensions,
-            layerHeight,
-            speed,
-            infillPercent: infill,
-            wallCount,
-            printerPowerWatts,
+            layerHeightMm: layerHeight,
+            printSpeedMmPerS: speed,
+            material,
           });
           const result: FileParseResult = {
             geometry: parsedGeometry,
@@ -406,7 +410,7 @@ export function StlPreview({
       layerHeight,
       speed,
       wallCount,
-      printerPowerWatts,
+      material,
       supportEnabled,
     ],
   );

--- a/src/shared/lib/__tests__/printTimeEstimator.test.ts
+++ b/src/shared/lib/__tests__/printTimeEstimator.test.ts
@@ -12,9 +12,15 @@ describe("estimatePrintTime", () => {
 
     // 20mm height / 0.2mm layer height = 100 layers
     expect(result.layers).toBe(100);
-    // ~962s of print+travel+layer-change time → 16 minutes
-    expect(result.estimatedMinutes).toBe(16);
-    expect(result.estimatedHours).toBe(0.3);
+    // 100 cm³ de plástico numa fita de 0,2 × 0,42 mm = 1.190.476 mm de trilha;
+    // a 60 mm/s dá 19.841 s, mais travel (1.984 s) e trocas de camada (200 s)
+    // = 22.025 s = 367 min. Equivale a 5,04 mm³/s de vazão, que é realista.
+    //
+    // Este teste esperava 16 min até 2026-09-04, quando o estimador dividia o
+    // comprimento de FILAMENTO pela velocidade do BICO. Aqueles 16 min exigiam
+    // 104 mm³/s — cerca de 7× o que uma máquina FDM rápida entrega.
+    expect(result.estimatedMinutes).toBe(367);
+    expect(result.estimatedHours).toBe(6.1);
     expect(result.confidence).toBe("medium");
   });
 

--- a/src/shared/lib/__tests__/printTimeEstimator.test.ts
+++ b/src/shared/lib/__tests__/printTimeEstimator.test.ts
@@ -19,20 +19,146 @@ describe("estimatePrintTime", () => {
     // Este teste esperava 16 min até 2026-09-04, quando o estimador dividia o
     // comprimento de FILAMENTO pela velocidade do BICO. Aqueles 16 min exigiam
     // 104 mm³/s — cerca de 7× o que uma máquina FDM rápida entrega.
+    //
+    // O número NÃO mudou na migração para EstimateOptions (2026-09-05): o
+    // modelo físico é o mesmo (Q nominal 5,04 < MVS PLA 15, sem clamp; travel
+    // 0,25 a 150 mm/s). Só os nomes dos params mudaram.
     expect(result.estimatedMinutes).toBe(367);
     expect(result.estimatedHours).toBe(6.1);
     expect(result.confidence).toBe("medium");
+    expect(result.kind).toBe("rough_estimate");
+  });
+
+  it("falls back to volumeCm3 when materialVolumeCm3 is absent", () => {
+    // Caminho do fallback COM teste dedicado: sem volume extrudado, o
+    // filamento e o tempo derivam do volume maciço (superestima peça oca).
+    const fallback = estimatePrintTime({ volumeCm3: 100, dimensions: DIMS });
+    const explicit = estimatePrintTime({
+      volumeCm3: 100,
+      materialVolumeCm3: 100,
+      dimensions: DIMS,
+    });
+    expect(fallback.filamentLengthMm).toBe(explicit.filamentLengthMm);
+    expect(fallback.estimatedMinutes).toBe(explicit.estimatedMinutes);
+    expect(fallback.filamentLengthMm).toBeGreaterThan(0);
+
+    // Metade do plástico → metade do filamento (módulo arredondamento).
+    const half = estimatePrintTime({
+      volumeCm3: 100,
+      materialVolumeCm3: 50,
+      dimensions: DIMS,
+    });
+    expect(half.filamentLengthMm).toBe(
+      Math.round(fallback.filamentLengthMm / 2),
+    );
+  });
+
+  it("clamps extrusion speed to the material MVS", () => {
+    // Fita 0,2 × 0,42 = 0,084 mm². Pedir 500 mm/s em PLA exigiria
+    // Q ≈ 42 mm³/s — quase 3× o teto de 15. O clamp limita a
+    // 15/0,084 ≈ 178,57 mm/s, então os dois têm que coincidir…
+    const cappedSpeed = 15 / (0.2 * 0.42);
+    const fantasy = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      printSpeedMmPerS: 500,
+      material: "pla",
+    });
+    const capped = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      printSpeedMmPerS: cappedSpeed,
+      material: "pla",
+    });
+    expect(fantasy.estimatedMinutes).toBe(capped.estimatedMinutes);
+    // …e continuar mais rápido que 60 mm/s (o clamp não congela, só teta).
+    const normal = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      printSpeedMmPerS: 60,
+      material: "pla",
+    });
+    expect(fantasy.estimatedMinutes).toBeLessThan(normal.estimatedMinutes);
+  });
+
+  it("PETG (MVS 12) is slower than PLA (MVS 15) at absurd speeds", () => {
+    const pla = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      printSpeedMmPerS: 500,
+      material: "pla",
+    });
+    const petg = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      printSpeedMmPerS: 500,
+      material: "petg",
+    });
+    expect(petg.estimatedMinutes).toBeGreaterThan(pla.estimatedMinutes);
+  });
+
+  it("travelRatio moves travel distance and total time", () => {
+    const none = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      travelRatio: 0,
+    });
+    expect(none.travelDistanceMm).toBe(0);
+
+    const def = estimatePrintTime({ volumeCm3: 100, dimensions: DIMS });
+    // Trilha 1.190.476 mm × 0,25 = 297.619 mm de travel.
+    expect(def.travelDistanceMm).toBe(297619);
+
+    const double = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      travelRatio: 0.5,
+    });
+    expect(double.travelDistanceMm).toBe(def.travelDistanceMm * 2);
+    expect(double.estimatedMinutes).toBeGreaterThan(def.estimatedMinutes);
+    expect(def.estimatedMinutes).toBeGreaterThan(none.estimatedMinutes);
+  });
+
+  it("travelRatio NaN cai no default 0,25 (nunca NaN)", () => {
+    // Math.max(0, NaN) = NaN — sem o guard, travelDistanceMm vazava NaN.
+    const nan = estimatePrintTime({
+      volumeCm3: 100,
+      dimensions: DIMS,
+      travelRatio: NaN,
+    });
+    const def = estimatePrintTime({ volumeCm3: 100, dimensions: DIMS });
+    expect(nan.travelDistanceMm).toBe(def.travelDistanceMm);
+    expect(nan.estimatedMinutes).toBe(def.estimatedMinutes);
+    expect(Number.isFinite(nan.travelDistanceMm)).toBe(true);
+  });
+
+  it("returns zeros (never NaN) for invalid geometry", () => {
+    for (const bad of [
+      { volumeCm3: 0, dimensions: DIMS },
+      { volumeCm3: -10, dimensions: DIMS },
+      { volumeCm3: NaN, dimensions: DIMS },
+      { volumeCm3: 100, dimensions: { x: 200, y: 200, z: 0 } },
+    ]) {
+      const result = estimatePrintTime(bad);
+      expect(result.estimatedMinutes).toBe(0);
+      expect(result.estimatedHours).toBe(0);
+      expect(result.travelDistanceMm).toBe(0);
+      expect(result.filamentLengthMm).toBe(0);
+      expect(result.confidence).toBe("low");
+      expect(result.kind).toBe("rough_estimate");
+    }
+    // Geometria vazia não cobra nem o overhead de troca de camada: antes
+    // retornava 3 min fantasmas (100 camadas × 2 s) sobre volume zero.
   });
 
   it("returns high confidence when real printer settings are provided", () => {
     const result = estimatePrintTime({
       volumeCm3: 100,
       dimensions: DIMS,
-      layerHeight: 0.2,
-      speed: 60,
-      infillPercent: 20,
-      wallCount: 3,
-      printerPowerWatts: 350,
+      layerHeightMm: 0.2,
+      printSpeedMmPerS: 60,
+      lineWidthMm: 0.42,
+      material: "pla",
     });
 
     expect(result.confidence).toBe("high");
@@ -42,7 +168,7 @@ describe("estimatePrintTime", () => {
     const result = estimatePrintTime({
       volumeCm3: 100,
       dimensions: DIMS,
-      printerPowerWatts: 350,
+      material: "petg",
     });
 
     expect(result.confidence).toBe("high");
@@ -58,12 +184,12 @@ describe("estimatePrintTime", () => {
     const fast = estimatePrintTime({
       volumeCm3: 100,
       dimensions: DIMS,
-      speed: 60,
+      printSpeedMmPerS: 60,
     });
     const slow = estimatePrintTime({
       volumeCm3: 100,
       dimensions: DIMS,
-      speed: 30,
+      printSpeedMmPerS: 30,
     });
 
     expect(slow.estimatedMinutes).toBeGreaterThan(fast.estimatedMinutes);
@@ -73,12 +199,12 @@ describe("estimatePrintTime", () => {
     const coarse = estimatePrintTime({
       volumeCm3: 100,
       dimensions: DIMS,
-      layerHeight: 0.2,
+      layerHeightMm: 0.2,
     });
     const fine = estimatePrintTime({
       volumeCm3: 100,
       dimensions: DIMS,
-      layerHeight: 0.1,
+      layerHeightMm: 0.1,
     });
 
     expect(fine.layers).toBe(coarse.layers * 2);
@@ -89,7 +215,7 @@ describe("estimatePrintTime", () => {
     const result = estimatePrintTime({
       volumeCm3: 100,
       dimensions: DIMS,
-      speed: 120,
+      printSpeedMmPerS: 120,
     });
 
     // Same as default-case estimate but with double speed → fewer minutes
@@ -100,7 +226,9 @@ describe("estimatePrintTime", () => {
 
 describe("estimatePrintTimeFromDimensions", () => {
   it("estimates volume from bounding box and forwards settings", () => {
-    const result = estimatePrintTimeFromDimensions(100, 100, 10, { speed: 30 });
+    const result = estimatePrintTimeFromDimensions(100, 100, 10, {
+      printSpeedMmPerS: 30,
+    });
 
     // 100*100*10*0.4/1000 = 40 cm³ → valid geometry
     expect(result.confidence).toBe("high");

--- a/src/shared/lib/__tests__/stlParser.test.ts
+++ b/src/shared/lib/__tests__/stlParser.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { estimateMaterialVolumeCm3, estimateSupportVolume } from "../stlParser";
+import {
+  estimateMaterialVolumeCm3,
+  estimateSupportVolume,
+  estimateWeight,
+} from "../stlParser";
 import { estimatePrintTime } from "../printTimeEstimator";
 import type { Triangle } from "../stlParser";
 
@@ -115,7 +119,13 @@ describe("estimateMaterialVolumeCm3 — casca por área", () => {
     // Modelo 92,52 cm³ / 1134 cm² de área → espessura média 1,63 mm, menor
     // que as duas paredes de 0,42 mm de cada lado. O fatiador gastou 72,8 cm³
     // (79% do volume); a fórmula antiga previa 32%.
-    const v = estimateMaterialVolumeCm3(92.52, 15, 1134);
+    // NOTA: re-medição pendente do merge do #72 (volume corrigido) — ver
+    // docs/estimators-model.md. Este teste ancora o COMPORTAMENTO (saturação
+    // no volume), não a medição exata, para sobreviver à re-medição.
+    const v = estimateMaterialVolumeCm3(92.52, {
+      infillPercent: 15,
+      surfaceAreaMm2: 1134 * 100,
+    });
     expect(v).toBeCloseTo(92.52, 2); // satura no volume da peça
   });
 
@@ -123,17 +133,146 @@ describe("estimateMaterialVolumeCm3 — casca por área", () => {
     // Cubo de 100 mm: 1000 cm³, 600 cm² de área. A casca é fração pequena,
     // então o resultado tem que se aproximar dos 15% de infill — a fórmula
     // antiga cravava 32% para qualquer geometria.
-    const v = estimateMaterialVolumeCm3(1000, 15, 600);
+    // Conta nova: casca = 600 × 1,64/10 = 98,4; total = 98,4 + 901,6×0,15
+    // = 233,64 (23,4% — dentro da faixa, com viés de superestimação
+    // documentado como margem de preço).
+    const v = estimateMaterialVolumeCm3(1000, {
+      infillPercent: 15,
+      surfaceAreaMm2: 600 * 100,
+    });
     expect(v / 1000).toBeGreaterThan(0.15);
     expect(v / 1000).toBeLessThan(0.25);
   });
 
   it("sem área informada, mantém o modelo antigo", () => {
-    expect(estimateMaterialVolumeCm3(100, 20)).toBeCloseTo(100 * 0.36, 6);
+    expect(estimateMaterialVolumeCm3(100, { infillPercent: 20 })).toBeCloseTo(
+      100 * 0.36,
+      6,
+    );
+  });
+
+  it("infillPercent NaN cai no default 20 (nunca NaN)", () => {
+    // Math.max(0, NaN) = NaN — sem o guard, o volume vazava NaN.
+    const nan = estimateMaterialVolumeCm3(100, { infillPercent: NaN });
+    const def = estimateMaterialVolumeCm3(100, {});
+    expect(nan).toBeCloseTo(def, 6);
+    expect(nan).toBeCloseTo(100 * 0.36, 6);
+    expect(Number.isFinite(nan)).toBe(true);
   });
 
   it("infill 100% nunca passa do volume da peça", () => {
-    expect(estimateMaterialVolumeCm3(50, 100, 400)).toBeCloseTo(50, 6);
+    expect(
+      estimateMaterialVolumeCm3(50, {
+        infillPercent: 100,
+        surfaceAreaMm2: 400 * 100,
+      }),
+    ).toBeCloseTo(50, 6);
+  });
+
+  it("deriva a casca de wallCount × lineWidthMm (sem 0,84 fixo)", () => {
+    // Cubo de 100 mm, infill 0: só casca. Padrão (2×0,42 + topo/base
+    // 8×0,2/2 = 1,64 mm) → 600×1,64/10 = 98,4 cm³.
+    const def = estimateMaterialVolumeCm3(1000, {
+      infillPercent: 0,
+      surfaceAreaMm2: 600 * 100,
+    });
+    expect(def).toBeCloseTo(98.4, 1);
+    // 5 paredes: (5×0,42 + 0,8) = 2,9 mm → 600×2,9/10 = 174 cm³.
+    const thick = estimateMaterialVolumeCm3(1000, {
+      infillPercent: 0,
+      surfaceAreaMm2: 600 * 100,
+      wallCount: 5,
+    });
+    expect(thick).toBeCloseTo(174, 1);
+    expect(thick).toBeGreaterThan(def);
+  });
+
+  it("topo/base zerados afinam a casca", () => {
+    const def = estimateMaterialVolumeCm3(1000, {
+      infillPercent: 0,
+      surfaceAreaMm2: 600 * 100,
+    });
+    const noTop = estimateMaterialVolumeCm3(1000, {
+      infillPercent: 0,
+      surfaceAreaMm2: 600 * 100,
+      topLayers: 0,
+      bottomLayers: 0,
+    });
+    // Só as paredes: 600×0,84/10 = 50,4 cm³.
+    expect(noTop).toBeCloseTo(50.4, 1);
+    expect(noTop).toBeLessThan(def);
+  });
+
+  it("shellThicknessMm explícito vence a derivação", () => {
+    const v = estimateMaterialVolumeCm3(1000, {
+      infillPercent: 0,
+      surfaceAreaMm2: 600 * 100,
+      shellThicknessMm: 2,
+    });
+    expect(v).toBeCloseTo(120, 6);
+  });
+
+  it("soma o suporte por cima (casca + núcleo × infill + suporte)", () => {
+    const v = estimateMaterialVolumeCm3(100, {
+      infillPercent: 0,
+      supportVolumeCm3: 5,
+    });
+    expect(v).toBeCloseTo(100 * 0.2 + 5, 6);
+  });
+
+  it("guards: volume ≤ 0 ou NaN retorna 0", () => {
+    expect(estimateMaterialVolumeCm3(0, { infillPercent: 20 })).toBe(0);
+    expect(estimateMaterialVolumeCm3(-5, { infillPercent: 20 })).toBe(0);
+    expect(estimateMaterialVolumeCm3(NaN, { infillPercent: 20 })).toBe(0);
+  });
+});
+
+describe("estimateWeight — material + purga", () => {
+  it("usa a densidade da tabela por família (PETG 1,27)", () => {
+    // Legado sem área: 100 cm³ a 0% → 20 cm³ × 1,27 = 25,4 g.
+    const w = estimateWeight(100, {
+      infillPercent: 0,
+      material: "petg",
+    });
+    expect(w).toBeCloseTo(25.4, 6);
+  });
+
+  it("densityGcm3 explícito vence a tabela", () => {
+    const w = estimateWeight(100, {
+      infillPercent: 0,
+      material: "petg",
+      densityGcm3: 2,
+    });
+    expect(w).toBeCloseTo(40, 6);
+  });
+
+  it("aplica a purga sobre o volume efetivo", () => {
+    const w = estimateWeight(100, {
+      infillPercent: 100,
+      purgePercent: 10,
+      densityGcm3: 1,
+    });
+    expect(w).toBeCloseTo(110, 6);
+  });
+
+  it("purgePercent NaN cai no default 0 (nunca NaN)", () => {
+    const nan = estimateWeight(100, {
+      infillPercent: 100,
+      purgePercent: NaN,
+      densityGcm3: 1,
+    });
+    const def = estimateWeight(100, {
+      infillPercent: 100,
+      densityGcm3: 1,
+    });
+    expect(nan).toBeCloseTo(def, 6);
+    expect(nan).toBeCloseTo(100, 6);
+    expect(Number.isFinite(nan)).toBe(true);
+  });
+
+  it("guards: volume ≤ 0 ou NaN retorna 0", () => {
+    expect(estimateWeight(0, { densityGcm3: 1.24 })).toBe(0);
+    expect(estimateWeight(NaN, { densityGcm3: 1.24 })).toBe(0);
   });
 });
 
@@ -146,8 +285,8 @@ describe("estimatePrintTime — física da extrusão", () => {
       volumeCm3: 92.52,
       materialVolumeCm3: 72.78,
       dimensions: { x: 405.7, y: 391.6, z: 90.2 },
-      layerHeight: 0.2,
-      speed: 60,
+      layerHeightMm: 0.2,
+      printSpeedMmPerS: 60,
     });
     expect(t.estimatedHours).toBeGreaterThan(4);
     expect(t.estimatedHours).toBeLessThan(6);

--- a/src/shared/lib/__tests__/stlParser.test.ts
+++ b/src/shared/lib/__tests__/stlParser.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { estimateSupportVolume } from "../stlParser";
+import { estimateMaterialVolumeCm3, estimateSupportVolume } from "../stlParser";
+import { estimatePrintTime } from "../printTimeEstimator";
 import type { Triangle } from "../stlParser";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -105,5 +106,50 @@ describe("estimateSupportVolume", () => {
     // 1.5 mm³ → 0.0015 cm³
     expect(volume).toBeLessThan(1);
     expect(volume).toBeCloseTo(0.0015, 6);
+  });
+});
+
+describe("estimateMaterialVolumeCm3 — casca por área", () => {
+  it("peça fina sai praticamente maciça, mesmo com infill baixo", () => {
+    // Caso real medido: projeto de litofania do BambuStudio, 4 objetos.
+    // Modelo 92,52 cm³ / 1134 cm² de área → espessura média 1,63 mm, menor
+    // que as duas paredes de 0,42 mm de cada lado. O fatiador gastou 72,8 cm³
+    // (79% do volume); a fórmula antiga previa 32%.
+    const v = estimateMaterialVolumeCm3(92.52, 15, 1134);
+    expect(v).toBeCloseTo(92.52, 2); // satura no volume da peça
+  });
+
+  it("peça grande e maciça fica perto do infill nominal", () => {
+    // Cubo de 100 mm: 1000 cm³, 600 cm² de área. A casca é fração pequena,
+    // então o resultado tem que se aproximar dos 15% de infill — a fórmula
+    // antiga cravava 32% para qualquer geometria.
+    const v = estimateMaterialVolumeCm3(1000, 15, 600);
+    expect(v / 1000).toBeGreaterThan(0.15);
+    expect(v / 1000).toBeLessThan(0.25);
+  });
+
+  it("sem área informada, mantém o modelo antigo", () => {
+    expect(estimateMaterialVolumeCm3(100, 20)).toBeCloseTo(100 * 0.36, 6);
+  });
+
+  it("infill 100% nunca passa do volume da peça", () => {
+    expect(estimateMaterialVolumeCm3(50, 100, 400)).toBeCloseTo(50, 6);
+  });
+});
+
+describe("estimatePrintTime — física da extrusão", () => {
+  it("usa o caminho do BICO, não o comprimento de filamento", () => {
+    // 72,78 cm³ de plástico, altura 90,2 mm, camada 0,2 mm, linha 0,42 mm,
+    // 60 mm/s. Caminho = 72780 / (0,2 × 0,42) = 866.429 mm.
+    // A impressão real levou 4h23m; o modelo antigo dava 0,5 h.
+    const t = estimatePrintTime({
+      volumeCm3: 92.52,
+      materialVolumeCm3: 72.78,
+      dimensions: { x: 405.7, y: 391.6, z: 90.2 },
+      layerHeight: 0.2,
+      speed: 60,
+    });
+    expect(t.estimatedHours).toBeGreaterThan(4);
+    expect(t.estimatedHours).toBeLessThan(6);
   });
 });

--- a/src/shared/lib/filamentProfiles.ts
+++ b/src/shared/lib/filamentProfiles.ts
@@ -1,0 +1,74 @@
+/**
+ * Perfis de filamento FDM: densidade + vazão volumétrica máxima (MVS).
+ *
+ * Centraliza os dois números que os estimadores precisam por material para
+ * não duplicar tabelas entre `stlParser` (peso) e `printTimeEstimator`
+ * (clamp de velocidade). Densidades alinhadas ao catálogo da calculadora
+ * (`shared/lib/materials.ts`); MVS são valores conservadores de literatura
+ * para hotend stock com bico de 0,4 mm. Ver `docs/estimators-model.md`.
+ */
+
+/** Famílias-base de filamento cobertas pelos estimadores. */
+export type FilamentFamily = "pla" | "petg" | "abs" | "asa" | "tpu" | "nylon";
+
+export interface FilamentProfile {
+  /** Densidade em g/cm³. */
+  densityGcm3: number;
+  /**
+   * Vazão volumétrica máxima sustentável em mm³/s (MVS).
+   * Velocidades que exigiriam Q maior são clamped — sem isso, speeds altos
+   * geram tempos impossíveis (Q >> o que o hotend entrega).
+   */
+  maxVolumetricSpeedMm3PerS: number;
+}
+
+export const FILAMENT_PROFILES: Record<FilamentFamily, FilamentProfile> = {
+  pla: { densityGcm3: 1.24, maxVolumetricSpeedMm3PerS: 15 },
+  petg: { densityGcm3: 1.27, maxVolumetricSpeedMm3PerS: 12 },
+  abs: { densityGcm3: 1.04, maxVolumetricSpeedMm3PerS: 12 },
+  asa: { densityGcm3: 1.05, maxVolumetricSpeedMm3PerS: 12 }, // = catálogo materials.ts (era 1,07 até PR #73 — sem fonte; alinhado ao catálogo, autoridade)
+  tpu: { densityGcm3: 1.21, maxVolumetricSpeedMm3PerS: 5 },
+  nylon: { densityGcm3: 1.14, maxVolumetricSpeedMm3PerS: 10 },
+};
+
+/** Família assumida quando o chamador não informa o material. */
+export const DEFAULT_FILAMENT_FAMILY: FilamentFamily = "pla";
+
+/**
+ * Teto seguro para material desconhecido/fora da tabela.
+ * Deliberadamente baixo: prefere superestimar o tempo (margem de preço)
+ * a prometer um tempo que o hotend não entrega.
+ */
+export const DEFAULT_MAX_VOLUMETRIC_SPEED_MM3_PER_S = 10;
+
+/** MVS do material, com fallback seguro para família desconhecida. */
+export function maxVolumetricSpeedFor(
+  family?: FilamentFamily | string,
+): number {
+  if (family == null)
+    return FILAMENT_PROFILES[DEFAULT_FILAMENT_FAMILY].maxVolumetricSpeedMm3PerS;
+  const profile = FILAMENT_PROFILES[family as FilamentFamily];
+  return (
+    profile?.maxVolumetricSpeedMm3PerS ?? DEFAULT_MAX_VOLUMETRIC_SPEED_MM3_PER_S
+  );
+}
+
+/**
+ * Densidade do material em g/cm³.
+ * `densityOverrideGcm3` explícito (ex: vindo da store da calculadora) sempre
+ * vence a tabela — a tabela é fallback, não autoridade.
+ */
+export function resolveFilamentDensity(
+  family?: FilamentFamily | string,
+  densityOverrideGcm3?: number,
+): number {
+  if (densityOverrideGcm3 != null && Number.isFinite(densityOverrideGcm3)) {
+    return densityOverrideGcm3;
+  }
+  if (family == null)
+    return FILAMENT_PROFILES[DEFAULT_FILAMENT_FAMILY].densityGcm3;
+  return (
+    FILAMENT_PROFILES[family as FilamentFamily]?.densityGcm3 ??
+    FILAMENT_PROFILES[DEFAULT_FILAMENT_FAMILY].densityGcm3
+  );
+}

--- a/src/shared/lib/printTimeEstimator.ts
+++ b/src/shared/lib/printTimeEstimator.ts
@@ -18,6 +18,14 @@ export interface PrintTimeParams {
   speed?: number;
   /** Infill percentage. Default 20. */
   infillPercent?: number;
+  /** Largura da linha extrudada em mm. Padrão 0,42 (bico de 0,4). */
+  lineWidthMm?: number;
+  /**
+   * Volume de plástico realmente extrudado, em cm³ (casca + infill).
+   * Quando ausente, usa `volumeCm3`, que é o volume MACIÇO do modelo e
+   * portanto superestima o tempo de peça oca.
+   */
+  materialVolumeCm3?: number;
   /** Number of perimeter walls. Default 3. */
   wallCount?: number;
   /** Printer power draw in watts (from store fdmPrintParams / selectedPrinter). */
@@ -34,6 +42,9 @@ const DEFAULT_SETTINGS = {
   layerHeightMm: 0.2,
   nozzleDiameterMm: 0.4,
   printSpeedMmPerS: 60,
+  // Largura da linha extrudada. Bico de 0,4 mm deposita ~0,42 mm nos perfis
+  // padrão de Bambu Studio, OrcaSlicer e PrusaSlicer.
+  lineWidthMm: 0.42,
   travelSpeedMmPerS: 150,
   infillPercent: 20,
   wallCount: 3,
@@ -52,17 +63,21 @@ export function estimatePrintTime(params: PrintTimeParams): PrintTimeEstimate {
   const heightMm = dimensions.z;
   const layers = Math.ceil(heightMm / layerHeight);
 
-  // Estimate filament length from volume
-  // Volume = π * r² * length
+  // Comprimento de filamento CONSUMIDO (só para relatório).
+  // Volume = π * r² * comprimento
   const filamentRadiusMm = 1.75 / 2;
-  const volumeMm3 = volumeCm3 * 1000;
+  const volumeMm3 = (params.materialVolumeCm3 ?? volumeCm3) * 1000;
   const filamentLengthMm =
     volumeMm3 / (Math.PI * filamentRadiusMm * filamentRadiusMm);
 
-  // Estimate print time
-  // Print time = (filament length / print speed) + (travel distance / travel speed)
-  // Travel distance is roughly 25% of print distance
-  const printDistanceMm = filamentLengthMm;
+  // Distância que o BICO percorre. Não é o comprimento de filamento: o bico
+  // deposita uma fita de (altura de camada × largura de linha), muito mais fina
+  // que os 1,75 mm do filamento. A versão anterior dividia o comprimento de
+  // FILAMENTO pela velocidade do BICO, o que subestimava o tempo em ~30×
+  // (2,405 mm² de seção do filamento contra 0,084 mm² da fita extrudada).
+  const lineWidthMm = params.lineWidthMm ?? DEFAULT_SETTINGS.lineWidthMm;
+  const extrusionCrossSectionMm2 = layerHeight * lineWidthMm;
+  const printDistanceMm = volumeMm3 / extrusionCrossSectionMm2;
   const travelDistanceMm = printDistanceMm * 0.25;
 
   const printTimeSeconds = printDistanceMm / speed;

--- a/src/shared/lib/printTimeEstimator.ts
+++ b/src/shared/lib/printTimeEstimator.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_FILAMENT_FAMILY,
+  maxVolumetricSpeedFor,
+  type FilamentFamily,
+} from "./filamentProfiles";
+
 export interface PrintTimeEstimate {
   estimatedMinutes: number;
   estimatedHours: number;
@@ -5,110 +11,179 @@ export interface PrintTimeEstimate {
   travelDistanceMm: number;
   filamentLengthMm: number;
   confidence: "low" | "medium" | "high";
+  /**
+   * Sempre `"rough_estimate"`: aproximação pré-slice (±30%, ver
+   * `docs/estimators-model.md`). Só um fatiador de verdade crava o tempo.
+   */
+  kind: "rough_estimate";
 }
 
+/** Dimensões da bounding box em mm. */
+export interface DimensionsMm {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * Parâmetros do estimador de tempo.
+ *
+ * Todo campo afeta o cálculo — params-fantasma (`wallCount`, `infillPercent`,
+ * `printerPowerWatts`, `nozzleDiameterMm`, `topBottomLayers`, que só
+ * alimentavam o rótulo de confiança) foram removidos em favor das entradas
+ * que movem o número: volume extrudado, geometria da fita, velocidades e
+ * material (MVS). Unidades canônicas vão no nome. Defaults em
+ * `docs/estimators-model.md`.
+ */
 export interface PrintTimeParams {
-  /** Model volume in cm³. */
+  /** Volume MACIÇO do modelo em cm³ (fallback quando sem `materialVolumeCm3`). */
   volumeCm3: number;
-  /** Model bounding box in mm (used for layer count). */
-  dimensions: { x: number; y: number; z: number };
-  /** Layer height in mm. Default 0.2. */
-  layerHeight?: number;
-  /** Print speed in mm/s. Default 60. */
-  speed?: number;
-  /** Infill percentage. Default 20. */
-  infillPercent?: number;
-  /** Largura da linha extrudada em mm. Padrão 0,42 (bico de 0,4). */
-  lineWidthMm?: number;
+  /** Bounding box do modelo em mm (só `z` é usada, p/ contagem de camadas). */
+  dimensions: DimensionsMm;
   /**
-   * Volume de plástico realmente extrudado, em cm³ (casca + infill).
-   * Quando ausente, usa `volumeCm3`, que é o volume MACIÇO do modelo e
-   * portanto superestima o tempo de peça oca.
+   * Plástico REALMENTE extrudado em cm³ (casca + infill + suporte).
+   * Quando ausente, usa `volumeCm3` — superestima peça oca como se sólida.
    */
   materialVolumeCm3?: number;
-  /** Number of perimeter walls. Default 3. */
-  wallCount?: number;
-  /** Printer power draw in watts (from store fdmPrintParams / selectedPrinter). */
-  printerPowerWatts?: number;
-  /** Nozzle diameter in mm. Default 0.4. */
-  nozzleDiameterMm?: number;
-  /** Travel (non-print) speed in mm/s. Default 150. */
+  /** Altura de camada em mm. Padrão 0,2. */
+  layerHeightMm?: number;
+  /** Largura da linha extrudada em mm. Padrão 0,42 (bico de 0,4). */
+  lineWidthMm?: number;
+  /** Velocidade de impressão em mm/s. Padrão 60 (sujeita ao clamp MVS). */
+  printSpeedMmPerS?: number;
+  /** Velocidade de travel em mm/s. Padrão 150. */
   travelSpeedMmPerS?: number;
-  /** Solid top/bottom layers. Default 4. */
-  topBottomLayers?: number;
+  /**
+   * Fração da distância de extrusão percorrida em travel (0–1).
+   * Padrão 0,25 — aproximação pré-slice documentada, não medição.
+   */
+  travelRatio?: number;
+  /**
+   * Família do filamento (default PLA). Define o teto MVS:
+   * `Q = layerH × lineW × speed` é clamped no MVS do material, então pedir
+   * 300 mm/s não gera tempo impossível — gera o tempo do teto físico.
+   */
+  material?: FilamentFamily | string;
 }
 
 const DEFAULT_SETTINGS = {
   layerHeightMm: 0.2,
-  nozzleDiameterMm: 0.4,
-  printSpeedMmPerS: 60,
   // Largura da linha extrudada. Bico de 0,4 mm deposita ~0,42 mm nos perfis
   // padrão de Bambu Studio, OrcaSlicer e PrusaSlicer.
   lineWidthMm: 0.42,
+  printSpeedMmPerS: 60,
   travelSpeedMmPerS: 150,
-  infillPercent: 20,
-  wallCount: 3,
-  topBottomLayers: 4,
-};
+  travelRatio: 0.25,
+} as const;
+
+/** Segundos de overhead por troca de camada (home da aproximação). */
+const LAYER_CHANGE_SECONDS = 2;
+
+function emptyEstimate(layers: number): PrintTimeEstimate {
+  return {
+    estimatedMinutes: 0,
+    estimatedHours: 0,
+    layers,
+    travelDistanceMm: 0,
+    filamentLengthMm: 0,
+    confidence: "low",
+    kind: "rough_estimate",
+  };
+}
 
 export function estimatePrintTime(params: PrintTimeParams): PrintTimeEstimate {
   const {
     volumeCm3,
     dimensions,
-    layerHeight = DEFAULT_SETTINGS.layerHeightMm,
-    speed = DEFAULT_SETTINGS.printSpeedMmPerS,
+    materialVolumeCm3,
+    layerHeightMm = DEFAULT_SETTINGS.layerHeightMm,
+    lineWidthMm = DEFAULT_SETTINGS.lineWidthMm,
+    printSpeedMmPerS = DEFAULT_SETTINGS.printSpeedMmPerS,
     travelSpeedMmPerS = DEFAULT_SETTINGS.travelSpeedMmPerS,
+    travelRatio = DEFAULT_SETTINGS.travelRatio,
+    material = DEFAULT_FILAMENT_FAMILY,
   } = params;
 
-  const heightMm = dimensions.z;
-  const layers = Math.ceil(heightMm / layerHeight);
+  // Geometria inválida → zeros explícitos, nunca NaN. (Camadas ainda são
+  // reportadas quando a altura é válida, para debug.)
+  const heightMm = dimensions?.z;
+  const layers =
+    Number.isFinite(heightMm) && heightMm > 0 && layerHeightMm > 0
+      ? Math.ceil(heightMm / layerHeightMm)
+      : 0;
+  const effectiveVolumeCm3 = materialVolumeCm3 ?? volumeCm3;
+  if (
+    !Number.isFinite(effectiveVolumeCm3) ||
+    effectiveVolumeCm3 <= 0 ||
+    !Number.isFinite(heightMm) ||
+    heightMm <= 0 ||
+    !(layerHeightMm > 0) ||
+    !(lineWidthMm > 0) ||
+    !(printSpeedMmPerS > 0) ||
+    !(travelSpeedMmPerS > 0)
+  ) {
+    return emptyEstimate(layers);
+  }
 
   // Comprimento de filamento CONSUMIDO (só para relatório).
   // Volume = π * r² * comprimento
   const filamentRadiusMm = 1.75 / 2;
-  const volumeMm3 = (params.materialVolumeCm3 ?? volumeCm3) * 1000;
+  const volumeMm3 = effectiveVolumeCm3 * 1000;
   const filamentLengthMm =
     volumeMm3 / (Math.PI * filamentRadiusMm * filamentRadiusMm);
 
   // Distância que o BICO percorre. Não é o comprimento de filamento: o bico
   // deposita uma fita de (altura de camada × largura de linha), muito mais fina
-  // que os 1,75 mm do filamento. A versão anterior dividia o comprimento de
-  // FILAMENTO pela velocidade do BICO, o que subestimava o tempo em ~30×
-  // (2,405 mm² de seção do filamento contra 0,084 mm² da fita extrudada).
-  const lineWidthMm = params.lineWidthMm ?? DEFAULT_SETTINGS.lineWidthMm;
-  const extrusionCrossSectionMm2 = layerHeight * lineWidthMm;
-  const printDistanceMm = volumeMm3 / extrusionCrossSectionMm2;
-  const travelDistanceMm = printDistanceMm * 0.25;
+  // que os 1,75 mm do filamento.
+  const extrusionCrossSectionMm2 = layerHeightMm * lineWidthMm;
 
-  const printTimeSeconds = printDistanceMm / speed;
+  // Clamp MVS: Q = seção × velocidade não passa do teto do material.
+  // Sem isso, 300 mm/s em PLA (Q ≈ 25 mm³/s, teto 15) promete um tempo que o
+  // hotend nunca entrega. O clamp troca a velocidade pedida pela máxima física.
+  const maxVolumetricSpeed = maxVolumetricSpeedFor(material);
+  const nominalFlowMm3PerS = extrusionCrossSectionMm2 * printSpeedMmPerS;
+  const effectiveSpeedMmPerS =
+    nominalFlowMm3PerS > maxVolumetricSpeed
+      ? maxVolumetricSpeed / extrusionCrossSectionMm2
+      : printSpeedMmPerS;
+
+  const printDistanceMm = volumeMm3 / extrusionCrossSectionMm2;
+  // Travel é fração fixa da extrusão: aproximação pré-slice (o slicer real
+  // mede saltos/retrações; nós assumimos 25% → overhead efetivo de ~10-15%
+  // sobre o tempo de extrusão, dentro da margem ±30% do rough_estimate).
+  // NaN (ex: store corrompida, parse falho) vaza por Math.min/max
+  // (Math.max(0, NaN) = NaN) — fallback para o default antes do clamp.
+  const safeTravelRatio = Number.isFinite(travelRatio)
+    ? travelRatio
+    : DEFAULT_SETTINGS.travelRatio;
+  const clampedTravelRatio = Math.min(1, Math.max(0, safeTravelRatio));
+  const travelDistanceMm = printDistanceMm * clampedTravelRatio;
+
+  const printTimeSeconds = printDistanceMm / effectiveSpeedMmPerS;
   const travelTimeSeconds = travelDistanceMm / travelSpeedMmPerS;
 
   // Add layer change overhead (~2 seconds per layer)
-  const layerChangeSeconds = layers * 2;
+  const layerChangeSeconds = layers * LAYER_CHANGE_SECONDS;
 
   const totalSeconds =
     printTimeSeconds + travelTimeSeconds + layerChangeSeconds;
   const estimatedMinutes = Math.round(totalSeconds / 60);
   const estimatedHours = Math.round((estimatedMinutes / 60) * 10) / 10;
 
-  // Confidence: high when real printer settings were provided,
-  // medium when only defaults are used, low without valid geometry
+  // Confiança alta quando settings reais (que MOVEM o número) foram
+  // informados; média só com defaults; baixa sem geometria válida.
   const hasRealSettings =
-    params.layerHeight !== undefined ||
-    params.speed !== undefined ||
-    params.infillPercent !== undefined ||
-    params.wallCount !== undefined ||
-    params.printerPowerWatts !== undefined ||
-    params.nozzleDiameterMm !== undefined ||
+    params.materialVolumeCm3 !== undefined ||
+    params.layerHeightMm !== undefined ||
+    params.lineWidthMm !== undefined ||
+    params.printSpeedMmPerS !== undefined ||
     params.travelSpeedMmPerS !== undefined ||
-    params.topBottomLayers !== undefined;
+    params.travelRatio !== undefined ||
+    params.material !== undefined;
 
-  const confidence: PrintTimeEstimate["confidence"] =
-    volumeCm3 <= 0 || dimensions.z <= 0
-      ? "low"
-      : hasRealSettings
-        ? "high"
-        : "medium";
+  const confidence: PrintTimeEstimate["confidence"] = hasRealSettings
+    ? "high"
+    : "medium";
 
   return {
     estimatedMinutes,
@@ -117,6 +192,7 @@ export function estimatePrintTime(params: PrintTimeParams): PrintTimeEstimate {
     travelDistanceMm: Math.round(travelDistanceMm),
     filamentLengthMm: Math.round(filamentLengthMm),
     confidence,
+    kind: "rough_estimate",
   };
 }
 
@@ -126,7 +202,10 @@ export function estimatePrintTimeFromDimensions(
   heightMm: number,
   settings: Omit<PrintTimeParams, "volumeCm3" | "dimensions"> = {},
 ): PrintTimeEstimate {
-  // Estimate volume from bounding box (assuming ~40% fill for typical prints)
+  // Heurística de volume aparente: bounding box × 0,4 — fração sólida típica
+  // de peça FDM média (casca + 20% infill); mesma ordem do legado
+  // `volume × (0,2 + 0,8 × infill)` com infill 20% (= 0,36 ≈ 0,4).
+  // Só para estimativa sem malha; com malha, usa materialVolumeCm3.
   const boundingBoxVolume = widthMm * depthMm * heightMm;
   const estimatedVolumeCm3 = (boundingBoxVolume * 0.4) / 1000;
 

--- a/src/shared/lib/stlParser.ts
+++ b/src/shared/lib/stlParser.ts
@@ -605,15 +605,66 @@ export function volumeToCm3(volumeMm3: number): number {
   return volumeMm3 / 1000;
 }
 
+/**
+ * Espessura de casca assumida quando o perfil do fatiador não é informado:
+ * 2 perímetros de 0,42 mm, que é o padrão de Bambu Studio, OrcaSlicer,
+ * PrusaSlicer e Cura para bico de 0,4 mm.
+ */
+export const DEFAULT_SHELL_THICKNESS_MM = 0.84;
+
+/**
+ * Volume de plástico realmente extrudado, em cm³.
+ *
+ * A casca é estimada por **área de superfície × espessura de parede**, limitada
+ * ao volume da peça; só o que sobra recebe infill. A versão anterior assumia
+ * `casca = 20% do volume` — um chute fixo que erra nos dois extremos:
+ *
+ *  - peça fina (litofania, caixa de parede única): as paredes consomem a seção
+ *    inteira e a peça sai praticamente maciça, mas a fórmula antiga previa 20%
+ *    + infill. Medido num projeto real de litofania: 92,5 cm³ de modelo
+ *    gastaram 72,8 cm³ de plástico (79%), contra os 32% que a conta antiga dava;
+ *  - peça grande e maciça: a casca é uma fração pequena do volume, e a fórmula
+ *    antiga superestimava ao cravar 20% (um cubo de 100 mm a 15% de infill é
+ *    ~19% denso, não 32%).
+ *
+ * `surfaceAreaCm2` ausente ou zero cai no modelo antigo, para não quebrar quem
+ * chama a função sem ter a malha em mãos.
+ */
+export function estimateMaterialVolumeCm3(
+  volumeCm3: number,
+  infill: number,
+  surfaceAreaCm2?: number,
+  shellThicknessMm: number = DEFAULT_SHELL_THICKNESS_MM,
+): number {
+  const infillRatio = infill / 100;
+
+  if (!surfaceAreaCm2 || surfaceAreaCm2 <= 0) {
+    return volumeCm3 * (0.2 + 0.8 * infillRatio);
+  }
+
+  // cm² × mm = cm³/10 (1 cm² × 1 mm = 100 mm³ = 0,1 cm³)
+  const shellCm3 = Math.min(
+    volumeCm3,
+    (surfaceAreaCm2 * shellThicknessMm) / 10,
+  );
+  return shellCm3 + (volumeCm3 - shellCm3) * infillRatio;
+}
+
 export function estimateWeight(
   volumeCm3: number,
   density: number,
   infill: number,
   purge: number,
+  surfaceAreaCm2?: number,
+  shellThicknessMm: number = DEFAULT_SHELL_THICKNESS_MM,
 ): number {
-  const infillRatio = infill / 100;
   const purgeRatio = purge / 100;
-  const effectiveVolume = volumeCm3 * (0.2 + 0.8 * infillRatio);
+  const effectiveVolume = estimateMaterialVolumeCm3(
+    volumeCm3,
+    infill,
+    surfaceAreaCm2,
+    shellThicknessMm,
+  );
   const waste = effectiveVolume * purgeRatio;
   return (effectiveVolume + waste) * density;
 }

--- a/src/shared/lib/stlParser.ts
+++ b/src/shared/lib/stlParser.ts
@@ -1,4 +1,8 @@
 import * as THREE from "three";
+import {
+  resolveFilamentDensity,
+  type FilamentFamily,
+} from "./filamentProfiles";
 
 export interface MeshAnalysis {
   triangleCount: number;
@@ -606,65 +610,144 @@ export function volumeToCm3(volumeMm3: number): number {
 }
 
 /**
- * Espessura de casca assumida quando o perfil do fatiador não é informado:
- * 2 perímetros de 0,42 mm, que é o padrão de Bambu Studio, OrcaSlicer,
- * PrusaSlicer e Cura para bico de 0,4 mm.
+ * Opções do estimador de volume de material.
+ *
+ * Todo campo afeta o cálculo — não há params-fantasma. Unidades canônicas
+ * vão no nome (`Mm2`, `Mm`, `Cm3`); percentuais levam o sufixo `Percent`.
+ * Defaults documentados em `docs/estimators-model.md`.
  */
-export const DEFAULT_SHELL_THICKNESS_MM = 0.84;
+export interface MaterialVolumeOptions {
+  /** Porcentagem de infill (0–100, clamped). Padrão 20. */
+  infillPercent?: number;
+  /**
+   * Área de superfície da malha em mm² (unidade canônica do `MeshAnalysis`).
+   * A conversão mm² → cm² acontece AQUI, não no chamador.
+   * Ausente ou ≤ 0 cai no modelo legado (20% fixo de casca).
+   */
+  surfaceAreaMm2?: number;
+  /** Perímetros laterais. Padrão 2. */
+  wallCount?: number;
+  /** Largura da linha extrudada em mm. Padrão 0,42 (bico de 0,4). */
+  lineWidthMm?: number;
+  /** Camadas sólidas de topo. Padrão 4. */
+  topLayers?: number;
+  /** Camadas sólidas de base. Padrão 4. */
+  bottomLayers?: number;
+  /** Altura de camada em mm (só pondera o sólido topo/base). Padrão 0,2. */
+  layerHeightMm?: number;
+  /**
+   * Espessura de casca explícita em mm. Quando omitida, é DERIVADA de
+   * `wallCount × lineWidthMm + topo/base` — nunca um 0,84 fixo.
+   */
+  shellThicknessMm?: number;
+  /**
+   * Volume de suporte em cm³, somado por cima (padrão Meshy/ThisCalc:
+   * `total = casca + núcleo × infill + suporte`). Padrão 0.
+   */
+  supportVolumeCm3?: number;
+}
+
+/** Opções do estimador de peso = volume + material + purga. */
+export interface WeightOptions extends MaterialVolumeOptions {
+  /**
+   * Família do filamento (tabela `filamentProfiles`, default PLA).
+   * Só define a densidade de fallback — `densityGcm3` explícito vence.
+   */
+  material?: FilamentFamily | string;
+  /** Densidade explícita em g/cm³ (ex: vinda da store). Vence a tabela. */
+  densityGcm3?: number;
+  /** Porcentagem de purga/troca sobre o volume efetivo. Padrão 0. */
+  purgePercent?: number;
+}
+
+const VOLUME_DEFAULTS = {
+  infillPercent: 20,
+  wallCount: 2,
+  lineWidthMm: 0.42,
+  topLayers: 4,
+  bottomLayers: 4,
+  layerHeightMm: 0.2,
+} as const;
 
 /**
  * Volume de plástico realmente extrudado, em cm³.
  *
- * A casca é estimada por **área de superfície × espessura de parede**, limitada
- * ao volume da peça; só o que sobra recebe infill. A versão anterior assumia
- * `casca = 20% do volume` — um chute fixo que erra nos dois extremos:
+ * Modelo consagrado das calculadoras (Meshy/ThisCalc):
+ * `casca = área × espessura`, limitada ao volume da peça;
+ * `total = casca + max(0, volume − casca) × infill + suporte`.
  *
- *  - peça fina (litofania, caixa de parede única): as paredes consomem a seção
- *    inteira e a peça sai praticamente maciça, mas a fórmula antiga previa 20%
- *    + infill. Medido num projeto real de litofania: 92,5 cm³ de modelo
- *    gastaram 72,8 cm³ de plástico (79%), contra os 32% que a conta antiga dava;
- *  - peça grande e maciça: a casca é uma fração pequena do volume, e a fórmula
- *    antiga superestimava ao cravar 20% (um cubo de 100 mm a 15% de infill é
- *    ~19% denso, não 32%).
+ * A espessura de casca é derivada do perfil: paredes laterais
+ * (`wallCount × lineWidthMm`) + sólido de topo/base
+ * (`(topLayers + bottomLayers) × layerHeightMm / 2`, assumindo que as áreas
+ * projetadas de topo e base somam ~metade da superfície total — premissa
+ * documentada em `docs/estimators-model.md`, com viés de superestimação
+ * como margem de preço).
  *
- * `surfaceAreaCm2` ausente ou zero cai no modelo antigo, para não quebrar quem
- * chama a função sem ter a malha em mãos.
+ * `surfaceAreaMm2` ausente ou ≤ 0 cai no modelo legado
+ * (`volume × (0,2 + 0,8 × infill)`), para não quebrar quem estima sem malha.
+ * Volume ≤ 0 ou não-finito retorna 0.
  */
 export function estimateMaterialVolumeCm3(
   volumeCm3: number,
-  infill: number,
-  surfaceAreaCm2?: number,
-  shellThicknessMm: number = DEFAULT_SHELL_THICKNESS_MM,
+  options: MaterialVolumeOptions = {},
 ): number {
-  const infillRatio = infill / 100;
+  if (!Number.isFinite(volumeCm3) || volumeCm3 <= 0) return 0;
 
-  if (!surfaceAreaCm2 || surfaceAreaCm2 <= 0) {
-    return volumeCm3 * (0.2 + 0.8 * infillRatio);
+  const {
+    infillPercent = VOLUME_DEFAULTS.infillPercent,
+    surfaceAreaMm2,
+    wallCount = VOLUME_DEFAULTS.wallCount,
+    lineWidthMm = VOLUME_DEFAULTS.lineWidthMm,
+    topLayers = VOLUME_DEFAULTS.topLayers,
+    bottomLayers = VOLUME_DEFAULTS.bottomLayers,
+    layerHeightMm = VOLUME_DEFAULTS.layerHeightMm,
+    shellThicknessMm,
+    supportVolumeCm3 = 0,
+  } = options;
+
+  // NaN vaza por Math.min/max (Math.max(0, NaN) = NaN) — fallback
+  // para o default antes do clamp.
+  const safeInfillPercent = Number.isFinite(infillPercent)
+    ? infillPercent
+    : VOLUME_DEFAULTS.infillPercent;
+  const infillRatio = Math.min(100, Math.max(0, safeInfillPercent)) / 100;
+  const support =
+    Number.isFinite(supportVolumeCm3) && supportVolumeCm3 > 0
+      ? supportVolumeCm3
+      : 0;
+
+  if (!surfaceAreaMm2 || surfaceAreaMm2 <= 0) {
+    return volumeCm3 * (0.2 + 0.8 * infillRatio) + support;
   }
 
-  // cm² × mm = cm³/10 (1 cm² × 1 mm = 100 mm³ = 0,1 cm³)
+  const wallMm = wallCount * lineWidthMm;
+  const topBottomMm = ((topLayers + bottomLayers) * layerHeightMm) / 2;
+  const effectiveShellMm = shellThicknessMm ?? wallMm + topBottomMm;
+  // mm² → cm² (/100); cm² × mm = cm³/10 (1 cm² × 1 mm = 0,1 cm³)
   const shellCm3 = Math.min(
     volumeCm3,
-    (surfaceAreaCm2 * shellThicknessMm) / 10,
+    ((surfaceAreaMm2 / 100) * effectiveShellMm) / 10,
   );
-  return shellCm3 + (volumeCm3 - shellCm3) * infillRatio;
+  const innerCm3 = Math.max(0, volumeCm3 - shellCm3);
+  return shellCm3 + innerCm3 * infillRatio + support;
 }
 
+/**
+ * Peso do plástico em gramas: `(volume efetivo + purga) × densidade`.
+ * Volume ≤ 0 ou não-finito retorna 0.
+ */
 export function estimateWeight(
   volumeCm3: number,
-  density: number,
-  infill: number,
-  purge: number,
-  surfaceAreaCm2?: number,
-  shellThicknessMm: number = DEFAULT_SHELL_THICKNESS_MM,
+  options: WeightOptions = {},
 ): number {
-  const purgeRatio = purge / 100;
-  const effectiveVolume = estimateMaterialVolumeCm3(
-    volumeCm3,
-    infill,
-    surfaceAreaCm2,
-    shellThicknessMm,
-  );
-  const waste = effectiveVolume * purgeRatio;
-  return (effectiveVolume + waste) * density;
+  if (!Number.isFinite(volumeCm3) || volumeCm3 <= 0) return 0;
+
+  const { material, densityGcm3, purgePercent = 0, ...volumeOptions } = options;
+
+  const density = resolveFilamentDensity(material, densityGcm3);
+  // Mesmo guard anti-NaN do infill: NaN → 0% de purga (default).
+  const safePurgePercent = Number.isFinite(purgePercent) ? purgePercent : 0;
+  const purgeRatio = Math.min(100, Math.max(0, safePurgePercent)) / 100;
+  const effectiveVolume = estimateMaterialVolumeCm3(volumeCm3, volumeOptions);
+  return effectiveVolume * (1 + purgeRatio) * density;
 }


### PR DESCRIPTION
… tempo

Medido com um projeto real de litofania do BambuStudio: o app estimava 25,2 g / 0,5 h contra 95,22 g / 4h23m do fatiador. O volume do modelo (92,52 cm3) foi confirmado por implementacao independente, entao o parser nao era a causa -- eram dois erros de modelagem, que afetam STL, OBJ e 3MF igualmente.

1. estimateWeight assumia casca = 20% do volume para qualquer geometria:

     volumeCm3 * (0.2 + 0.8 * infillRatio)

   Esse chute fixo erra nos dois extremos. A peca do teste tem 1,63 mm de espessura media (2*V/A) e duas paredes de 0,42 mm de cada lado somam 1,68 mm: nao sobra espaco para infill, a peca sai macica. O fatiador gastou 79% do volume; a formula previa 32%, e tratava o ajuste de infill do usuario como fator dominante quando ele e fisicamente irrelevante ali. No outro extremo, um cubo de 100 mm a 15% de infill e ~19% denso, nao 32%.

   A analise ja calculava surfaceArea e nunca a usava. Agora a casca e area * espessura de parede, limitada ao volume da peca, e so o que sobra recebe infill. O min() faz o infill parar de contar exatamente onde ele deixa de existir fisicamente.

2. estimatePrintTime dividia o comprimento de FILAMENTO pela velocidade do BICO. Sao grandezas diferentes: o bico deposita uma fita de altura de camada x largura de linha (0,2 x 0,42 = 0,084 mm2), nao os 2,405 mm2 de secao do filamento de 1,75 mm -- o tempo saia ~30x menor. A distancia correta e volume / (altura_camada * largura_linha), sobre o material extrudado e nao sobre o volume macico do modelo, senao peca oca e estimada como solida.

   O teste 'uses default settings when no real settings are provided' esperava 16 min para 100 cm3, o que exige 104 mm3/s de vazao (~7x o que uma FDM rapida entrega). Atualizado para os 367 min corretos, que dao 5,04 mm3/s, com a conta no comentario.

Resultado no mesmo arquivo: 25,2 g -> 126,2 g (real 95,22) e 0,5 h -> 5,9 h (real 4h23m). Ainda superestima, mas erra para o lado seguro num app de precificacao, e o infill deixa de afetar pecas finas.

closes #71