### PR TITLE
fix(ci): release PR body quoting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,4 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "chore(release): $VERSION" \
-            --body "Automated release preparation for $VERSION. Merge this PR "\
-              "after CI passes; then create the immutable tag $VERSION on the "\
-              "merged commit to publish."
+            --body "Automated release preparation for $VERSION. Merge this PR after CI passes; then create the immutable tag $VERSION on the merged commit to publish."


### PR DESCRIPTION
Desbloqueia release v1.10.1 — corrige quoting do --body no step de release PR (SHA a3ba529).

Join das 3 linhas com backslash-continuation em uma única string quoted, evitando que o YAML/shell quebre o argumento do gh.