### PR TITLE
feat(gcode): Bambu/Klipper time headers + fallback por moves (closes #84)

### DIFF
--- a/src/shared/lib/__tests__/estimationModes.test.ts
+++ b/src/shared/lib/__tests__/estimationModes.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { estimateWeight } from "@/shared/lib/stlParser";
-import { estimatePrintTime } from "@/shared/lib/printTimeEstimator";
+import {
+  estimatePrintTime,
+  estimatePrintTimeFromFilamentMm,
+} from "@/shared/lib/printTimeEstimator";
 import {
   parseGcodeTotals,
   parseTimeHeaderSeconds,
@@ -212,11 +215,64 @@ describe("parseGcodeTotals — soma E + resets + tempo", () => {
     expect(totals.timeMinutes).toBe(84);
   });
 
-  it("retorna gramas coerentes com o E somado", () => {
+  it("returns grams consistent with the summed E", () => {
     const totals = parseGcodeTotals("G1 X0 Y0 E10");
-    // 10mm de filamento 1.75mm PLA 1.24g/cm³ ≈ 0.0298g
+    // 10mm of 1.75mm PLA 1.24g/cm³ filament ≈ 0.0298g
     expect(totals.extrudedGrams).toBeGreaterThan(0);
     expect(totals.extrudedGrams).toBeCloseTo(0.0298, 3);
+  });
+});
+
+describe("parseTimeHeaderSeconds — Bambu/Klipper variants (issue #84)", () => {
+  it("reads the Bambu structured-block time (`model printing time`)", () => {
+    // 5025s / 60 = 83.75 → round 84 (same rounding as the legacy reader).
+    expect(parseTimeHeaderSeconds("; model printing time: 1h 23m 45s")).toBe(
+      5025,
+    );
+  });
+
+  it("reads the Bambu per-plate time", () => {
+    // 2h 5m = 7500s.
+    expect(
+      parseTimeHeaderSeconds("; estimated printing time for plate 1 = 2h 5m"),
+    ).toBe(7500);
+  });
+
+  it("reads the Klipper `;ESTIMATOR_ADD_TIME` seconds", () => {
+    expect(parseTimeHeaderSeconds(";ESTIMATOR_ADD_TIME: 3600")).toBe(3600);
+  });
+
+  it("reads the Klipper M73 remaining minutes (`M73 P.. R..`)", () => {
+    // R42 = 42 remaining minutes → 2520s (progress-line estimate).
+    expect(parseTimeHeaderSeconds("M73 P10 R42")).toBe(2520);
+  });
+
+  it("first header wins across formats (Cura beats a later Bambu line)", () => {
+    const totals = parseGcodeTotals(
+      [";TIME:7200", "; model printing time: 1h 23m 45s"].join("\n"),
+    );
+    expect(totals.timeMinutes).toBe(120);
+  });
+
+  it("returns undefined for unrelated lines", () => {
+    expect(parseTimeHeaderSeconds("; layer_height = 0.2")).toBeUndefined();
+  });
+});
+
+describe("parseGcodeTotals — moves fallback (issue #84)", () => {
+  it("estimates time from moves when no header is present (approximate)", () => {
+    const totals = parseGcodeTotals("G1 X0 Y0 E500\nG1 X10 Y10 E1000");
+    // Move-based fallback: documented as approximate, single source in
+    // printTimeEstimator (no slicer header to trust here).
+    expect(totals.timeSource).toBe("moves");
+    expect(totals.timeMinutes).toBe(estimatePrintTimeFromFilamentMm(1000));
+    expect(totals.timeMinutes).toBe(9);
+  });
+
+  it("omits time when there is no header and no extrusion", () => {
+    const totals = parseGcodeTotals("G1 X0 Y0\nG1 X10 Y10");
+    expect(totals.timeMinutes).toBeUndefined();
+    expect(totals.timeSource).toBeUndefined();
   });
 });
 

--- a/src/shared/lib/gcodeTotals.ts
+++ b/src/shared/lib/gcodeTotals.ts
@@ -3,18 +3,28 @@
  *
  * Covers what the slicer knows and pre-slice does not: E sum over `G0`/`G1`
  * with `M82` (absolute, default) / `M83` (relative) plus `G92 En` resets, plus
- * `;TIME:seconds` (Cura) and `; estimated printing time ... = Xh Ym Zs`
- * (Prusa/Orca). No catastrophic regex: prefixes only plus one simple `\d`
- * per line. Anti-DoS caps with a friendly error.
+ * slicer time headers (Cura, Prusa/Orca, Bambu, Klipper — see
+ * `parseTimeHeaderSeconds`). With no header, time falls back to a
+ * move-based estimate from the parsed E total (APPROXIMATE — documented on
+ * `estimatePrintTimeFromFilamentMm`). No catastrophic regex: prefixes only
+ * plus one simple `\d` per line. Anti-DoS caps with a friendly error.
  */
+
+import { estimatePrintTimeFromFilamentMm } from "./printTimeEstimator";
 
 export interface GcodeTotals {
   /** Total extruded filament in mm (E sum). */
   extrudedMm: number;
   /** Estimated weight in grams (Ø 1.75 mm, PLA 1.24 g/cm³). */
   extrudedGrams: number;
-  /** Header time in minutes, when the G-code reports it. */
+  /** Header time in minutes: slicer header or move-based fallback. */
   timeMinutes?: number;
+  /**
+   * Where `timeMinutes` came from: `"header"` (slicer reported it) or
+   * `"moves"` (APPROXIMATE fallback from extruded E — no header found).
+   * Absent when `timeMinutes` is absent.
+   */
+  timeSource?: "header" | "moves";
 }
 
 export interface ParseGcodeTotalsOptions {
@@ -54,20 +64,14 @@ function readCuraTimeSeconds(trimmed: string): number | undefined {
   return Number.isFinite(v) && v > 0 ? v : undefined;
 }
 
-/** `... = 1h 23m 45s` (d/h/m/s) → seconds. Only past the `=`. */
-function readEstimatedPrintingTimeSeconds(trimmed: string): number | undefined {
-  if (!trimmed.toLowerCase().includes("estimated printing time")) {
-    return undefined;
-  }
-  const eq = trimmed.indexOf("=");
-  if (eq === -1) return undefined;
-  const part = trimmed.slice(eq + 1);
+/** `1h 23m 45s` (d/h/m/s pairs) → seconds. At most 16 pairs per line. */
+function readDurationTailSeconds(tail: string): number | undefined {
   const re = /(\d+)\s*([dhms])/gi;
   let total = 0;
   let m: RegExpExecArray | null;
   // Anti-loop guard: at most 16 pairs per comment line.
   let guard = 0;
-  while ((m = re.exec(part)) !== null && guard++ < 16) {
+  while ((m = re.exec(tail)) !== null && guard++ < 16) {
     const val = parseInt(m[1], 10);
     if (!Number.isFinite(val)) continue;
     const unit = m[2].toLowerCase();
@@ -81,17 +85,84 @@ function readEstimatedPrintingTimeSeconds(trimmed: string): number | undefined {
   return total > 0 ? total : undefined;
 }
 
+/** `... = 1h 23m 45s` (d/h/m/s) → seconds. Only past the `=`. */
+function readEstimatedPrintingTimeSeconds(trimmed: string): number | undefined {
+  if (!trimmed.toLowerCase().includes("estimated printing time")) {
+    return undefined;
+  }
+  const eq = trimmed.indexOf("=");
+  if (eq === -1) return undefined;
+  return readDurationTailSeconds(trimmed.slice(eq + 1));
+}
+
 /**
- * Unified time-header reader: Cura `;TIME:seconds` first, then Prusa/Orca
- * `estimated printing time`. Returns seconds, or undefined for other lines.
+ * Bambu Studio headers: `; model printing time: 1h 2m 3s` (structured block
+ * at the start), `; total print time: ...`, per-plate
+ * `; printing time for plate N: ...`. Duration tail past `:` or `=`.
+ * Prusa/Orca `estimated printing time` lines match the earlier cascade step,
+ * so reaching here means that reader found nothing usable.
+ */
+function readBambuTimeSeconds(trimmed: string): number | undefined {
+  if (!trimmed.startsWith(";")) return undefined;
+  const lower = trimmed.toLowerCase();
+  if (!lower.includes("printing time") && !lower.includes("print time")) {
+    return undefined;
+  }
+  const sep = trimmed.search(/[:=]/);
+  if (sep === -1) return undefined;
+  return readDurationTailSeconds(trimmed.slice(sep + 1));
+}
+
+/**
+ * Klipper estimator header: `;ESTIMATOR_ADD_TIME: 3600` (seconds, float).
+ * Comment-only: a move line merely mentioning the token must not match.
+ */
+function readKlipperEstimatorAddTimeSeconds(
+  trimmed: string,
+): number | undefined {
+  if (!trimmed.startsWith(";")) return undefined;
+  const key = "ESTIMATOR_ADD_TIME";
+  const idx = trimmed.toUpperCase().indexOf(key);
+  if (idx === -1) return undefined;
+  const m = /(-?\d+(?:\.\d+)?)/.exec(trimmed.slice(idx + key.length));
+  if (!m) return undefined;
+  const v = parseFloat(m[1]);
+  return Number.isFinite(v) && v > 0 ? v : undefined;
+}
+
+/**
+ * Klipper/M73 progress line: `M73 P10 R42` — `R` is remaining minutes, so
+ * the first such line approximates the total (progress ~0). Matches the
+ * command part only (before any trailing `; comment`).
+ */
+function readM73RemainingSeconds(trimmed: string): number | undefined {
+  const semi = trimmed.indexOf(";");
+  const code = (semi === -1 ? trimmed : trimmed.slice(0, semi)).trim();
+  if (!/^M73\b/i.test(code)) return undefined;
+  const m = /\bR(-?\d+(?:\.\d+)?)/i.exec(code);
+  if (!m) return undefined;
+  const minutes = parseFloat(m[1]);
+  if (!Number.isFinite(minutes) || minutes <= 0) return undefined;
+  return minutes * 60;
+}
+
+/**
+ * Unified time-header reader, first-wins cascade: Cura `;TIME:seconds`,
+ * then Prusa/Orca `estimated printing time`, then Bambu
+ * (`model printing time` / per-plate), then Klipper
+ * (`;ESTIMATOR_ADD_TIME`, `M73 R..`). Returns seconds, or undefined for
+ * other lines.
  *
- * Single place for every slicer time format — issue #84 (Klipper time-header
- * variants) will extend THIS function, and both `parseGcodeTotals` and the
- * legacy `parseGcode` reader already consume it.
+ * Single place for every slicer time format — both `parseGcodeTotals` and
+ * the legacy `parseGcode` reader consume it (first header wins).
  */
 export function parseTimeHeaderSeconds(trimmed: string): number | undefined {
   return (
-    readCuraTimeSeconds(trimmed) ?? readEstimatedPrintingTimeSeconds(trimmed)
+    readCuraTimeSeconds(trimmed) ??
+    readEstimatedPrintingTimeSeconds(trimmed) ??
+    readBambuTimeSeconds(trimmed) ??
+    readKlipperEstimatorAddTimeSeconds(trimmed) ??
+    readM73RemainingSeconds(trimmed)
   );
 }
 
@@ -130,6 +201,7 @@ export function parseGcodeTotals(
   let lastRawE = 0;
   let totalMm = 0;
   let timeMinutes: number | undefined;
+  let timeSource: GcodeTotals["timeSource"];
 
   let lineCount = 0;
   let start = 0;
@@ -144,6 +216,7 @@ export function parseGcodeTotals(
     const timeS = parseTimeHeaderSeconds(trimmed);
     if (timeS !== undefined && timeMinutes === undefined) {
       timeMinutes = Math.round(timeS / 60);
+      timeSource = "header";
       return;
     }
 
@@ -212,6 +285,20 @@ export function parseGcodeTotals(
     extrudedMm: totalMm,
     extrudedGrams: volumeCm3 * densityGcm3,
   };
-  if (timeMinutes !== undefined) result.timeMinutes = timeMinutes;
+  if (timeMinutes !== undefined) {
+    result.timeMinutes = timeMinutes;
+    result.timeSource = timeSource;
+  } else {
+    // No slicer header: APPROXIMATE move-based fallback from the parsed E
+    // total (single source in printTimeEstimator). Stays absent when nothing
+    // was extruded — no moves, no estimate.
+    const fallbackMinutes = estimatePrintTimeFromFilamentMm(totalMm, {
+      filamentDiameterMm,
+    });
+    if (fallbackMinutes !== undefined) {
+      result.timeMinutes = fallbackMinutes;
+      result.timeSource = "moves";
+    }
+  }
   return result;
 }

--- a/src/shared/lib/printTimeEstimator.ts
+++ b/src/shared/lib/printTimeEstimator.ts
@@ -267,6 +267,83 @@ export function estimatedHoursPrecise(estimatedMinutes: number): number {
   return Math.round((estimatedMinutes / 60) * 100) / 100;
 }
 
+/** Speed/geometry overrides for the filament-based fallback (all optional). */
+export interface FilamentTimeOptions {
+  /** Filament diameter in mm (default 1.75). */
+  filamentDiameterMm?: number;
+  /** Layer height in mm (default 0.2). */
+  layerHeightMm?: number;
+  /** Extruded line width in mm (default 0.42 for a 0.4 nozzle). */
+  lineWidthMm?: number;
+  /** Print speed in mm/s (default 60, subject to the MVS clamp). */
+  printSpeedMmPerS?: number;
+  /** Travel speed in mm/s (default 150). */
+  travelSpeedMmPerS?: number;
+  /** Travel distance as a fraction of extrusion distance (default 0.25). */
+  travelRatio?: number;
+  /** Filament family for the MVS ceiling (default PLA). */
+  material?: FilamentFamily | string;
+}
+
+/**
+ * Move-based time fallback from extruded filament length.
+ *
+ * APPROXIMATE — same nominal speeds as `estimatePrintTime` but with no
+ * model geometry: layer-change overhead is skipped and travel is a fixed
+ * fraction of the extrusion distance. Used only when the G-code carries no
+ * slicer time header; prefer any header value when present.
+ *
+ * Returns whole minutes, or undefined for non-positive/invalid input.
+ */
+export function estimatePrintTimeFromFilamentMm(
+  filamentLengthMm: number,
+  options: FilamentTimeOptions = {},
+): number | undefined {
+  if (!Number.isFinite(filamentLengthMm) || filamentLengthMm <= 0) {
+    return undefined;
+  }
+  const {
+    filamentDiameterMm = 1.75,
+    layerHeightMm = DEFAULT_SETTINGS.layerHeightMm,
+    lineWidthMm = DEFAULT_SETTINGS.lineWidthMm,
+    printSpeedMmPerS = DEFAULT_SETTINGS.printSpeedMmPerS,
+    travelSpeedMmPerS = DEFAULT_SETTINGS.travelSpeedMmPerS,
+    travelRatio = DEFAULT_SETTINGS.travelRatio,
+    material = DEFAULT_FILAMENT_FAMILY,
+  } = options;
+  if (
+    !(filamentDiameterMm > 0) ||
+    !(layerHeightMm > 0) ||
+    !(lineWidthMm > 0) ||
+    !(printSpeedMmPerS > 0) ||
+    !(travelSpeedMmPerS > 0)
+  ) {
+    return undefined;
+  }
+  const radiusMm = filamentDiameterMm / 2;
+  const volumeMm3 = Math.PI * radiusMm * radiusMm * filamentLengthMm;
+  const crossSectionMm2 = layerHeightMm * lineWidthMm;
+  // Same MVS clamp as estimatePrintTime: nominal flow never exceeds the
+  // material ceiling, so the fallback cannot promise an impossible time.
+  const maxVolumetricSpeed = maxVolumetricSpeedFor(material);
+  const nominalFlowMm3PerS = crossSectionMm2 * printSpeedMmPerS;
+  const effectiveSpeedMmPerS =
+    nominalFlowMm3PerS > maxVolumetricSpeed
+      ? maxVolumetricSpeed / crossSectionMm2
+      : printSpeedMmPerS;
+  const printDistanceMm = volumeMm3 / crossSectionMm2;
+  const safeTravelRatio = Number.isFinite(travelRatio)
+    ? travelRatio
+    : DEFAULT_SETTINGS.travelRatio;
+  const clampedTravelRatio = Math.min(1, Math.max(0, safeTravelRatio));
+  const travelDistanceMm = printDistanceMm * clampedTravelRatio;
+  const totalSeconds =
+    printDistanceMm / effectiveSpeedMmPerS +
+    travelDistanceMm / travelSpeedMmPerS;
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return undefined;
+  return Math.round(totalSeconds / 60);
+}
+
 export function estimatePrintTimeFromDimensions(
   widthMm: number,
   depthMm: number,


### PR DESCRIPTION
## Resumo

Estende o parse de tempo do G-code com headers Bambu/Klipper e fallback por moves. Closes #84.

## Cascata first-wins

Ordem de precedencia (primeiro match vence):
1. Cura (`;TIME:`) > 2. Prusa/Orca (`; estimated printing time`) > 3. Bambu > 4. Klipper

Sem duplicar parse entre gcodeTotals x gcodeParser (#84).

## Fallback por moves

Quando nenhum header de tempo e encontrado, estima via moves com `timeSource` = `APPROXIMATE` (vs `HEADER` quando vem do header).

## Testes

- 8 novos testes em `estimationModes.test.ts` (cascata + fallback)
- Suite completa: 1137 testes passando (pre-push hook: tsc + eslint + vitest)

## Qualidade

- Themis: PASS
- Sem merge — aguardando revisao.