### PR TITLE
fix(build): pin electron 43 (node-abi sem ABI do 44)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open3dcalc",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open3dcalc",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.20",
@@ -49,7 +49,7 @@
         "concurrently": "^10.0.5",
         "cross-env": "^10.1.0",
         "drizzle-kit": "^0.31.10",
-        "electron": "^44.1.1",
+        "electron": "43.4.1",
         "electron-builder": "^26.15.3",
         "eslint": "^10.9.0",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -8949,9 +8949,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "44.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-44.1.1.tgz",
-      "integrity": "sha512-N2WCq2sbOkqQgvXJYx2lS6UiO8bF+Yr67trDnS6JKa2WxTCRQsAjGl57SUtdW9h6r5PlduBFjIhxhgd3dzv1hg==",
+      "version": "43.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.1.tgz",
+      "integrity": "sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "concurrently": "^10.0.5",
     "cross-env": "^10.1.0",
     "drizzle-kit": "^0.31.10",
-    "electron": "^44.1.1",
+    "electron": "43.4.1",
     "electron-builder": "^26.15.3",
     "eslint": "^10.9.0",
     "eslint-plugin-react-hooks": "^7.1.1",


### PR DESCRIPTION
Reverte bump #62 (44.1.1 -> 43.4.1 pin exato).

**Motivo:** node-abi@4.31.0 (via @electron/rebuild@4.2.0) nao conhece ABI do Electron 44 — `Could not detect abi for version 44.1.1` — quebra postinstall/rebuild do better-sqlite3 e o build electron.

**Mudanca:**
- `package.json`: `electron: ^44.1.1 -> 43.4.1` (pin exato)
- `package-lock.json`: regenerado via `npm install --package-lock-only` (43.4.1)

**Validacao:**
- `npm ls electron` -> electron@43.4.1 OK
- `npm run build:electron` (tsc + verify-electron-imports) -> ✅
- `npm run typecheck:electron` -> ✅

Sem merge, sem tag — aguardando review.