### PR TITLE
fix(changelog): canonical dates, i18n locale, and release backfill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
 
       - name: Sync in-app changelog
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: node scripts/sync-changelog.mjs --write
 
       - name: Validate changed release files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- **gcode:** no longer ignores gcode without a TIME header and supports the Prusa/Orca format (closes #32) — removes the silent `if(printTimeMinutes>0)` gate in `StlPreview.tsx:242`, `d/h/m/s` parser (`1h 23m 45s`/`2d 5h`/`45m 30s`) in `gcodeParser.ts`, `geometry: BufferGeometry | null`, `setGeometry(null)` on the GCODE branch, drop zone stays visible (`!modelInfo?.geometry`), 🗑️ `stl.clear` button for GCODE, 13 new tests (7 parser + 6 StlPreview), 893/893 passing, lint/typecheck clean, Themis PASS_WITH_NOTES resolved
+
 ## v1.11.0
 
 [compare changes](https://github.com/ils15/open3dcalc/compare/v1.10.0...v1.11.0)
@@ -8,22 +14,22 @@
 
 - **sync:** Add text label to DataSyncButton for better visibility ([a6da01d](https://github.com/ils15/open3dcalc/commit/a6da01d))
 - UI/UX improvements — STL support estimation, Resin preview, safety fixes ([#57](https://github.com/ils15/open3dcalc/pull/57))
-- **calc:** Exibe lucro por hora (profit/hr) FDM+Resina ([#77](https://github.com/ils15/open3dcalc/pull/77))
-- **products:** Cadastro produtos + vendido + CSV + sync ([#78](https://github.com/ils15/open3dcalc/pull/78))
-- **estimators:** Modos simple/advanced + G-code opcional ([#83](https://github.com/ils15/open3dcalc/pull/83))
-- **gcode:** Bambu/Klipper time headers + fallback por moves via `timeSource` HEADER/APPROXIMATE, cascata first-wins Cura > Prusa/Orca > Bambu > Klipper ([#86](https://github.com/ils15/open3dcalc/pull/86), closes [#84](https://github.com/ils15/open3dcalc/issues/84))
-- **calc:** Preço de venda editável (override display-local BRL) + ponte calculadora→produto com toast/evento e i18n pt-BR/en-US ([#87](https://github.com/ils15/open3dcalc/pull/87), closes [#85](https://github.com/ils15/open3dcalc/issues/85))
+- **calc:** Show profit/hr for FDM + Resin ([#77](https://github.com/ils15/open3dcalc/pull/77))
+- **products:** Product registration + sold + CSV + sync ([#78](https://github.com/ils15/open3dcalc/pull/78))
+- **estimators:** Simple/advanced modes + optional G-code ([#83](https://github.com/ils15/open3dcalc/pull/83))
+- **gcode:** Bambu/Klipper time headers + fallback by moves via `timeSource` HEADER/APPROXIMATE, first-wins cascade Cura > Prusa/Orca > Bambu > Klipper ([#86](https://github.com/ils15/open3dcalc/pull/86), closes [#84](https://github.com/ils15/open3dcalc/issues/84))
+- **calc:** Editable sale price (display-local BRL override) + calculator→product bridge with toast/event and pt-BR/en-US i18n ([#87](https://github.com/ils15/open3dcalc/pull/87), closes [#85](https://github.com/ils15/open3dcalc/issues/85))
 
 ### 🩹 Fixes
 
 - **ci:** Remove v1.10.0 exclusion and sync changelog ([7794266](https://github.com/ils15/open3dcalc/commit/7794266))
 - **dashboard:** Replace React.lazy with static recharts imports to fix #7463 crash ([#7463](https://github.com/ils15/open3dcalc/issues/7463))
-- **3mf:** Segue p:path da production extension e corrige volume 3x maior ([#72](https://github.com/ils15/open3dcalc/pull/72))
-- **estimators:** Casca por area de superficie e fisica da extrusao no… ([#73](https://github.com/ils15/open3dcalc/pull/73))
-- **release:** Windows exe + auto-update resiliente ([#76](https://github.com/ils15/open3dcalc/pull/76))
+- **3mf:** Follow p:path from the production extension and fix 3x larger volume ([#72](https://github.com/ils15/open3dcalc/pull/72))
+- **estimators:** Surface-area shell and extrusion physics in… ([#73](https://github.com/ils15/open3dcalc/pull/73))
+- **release:** Windows exe + resilient auto-update ([#76](https://github.com/ils15/open3dcalc/pull/76))
 - **release:** Join --body into single quoted string in release PR step ([#79](https://github.com/ils15/open3dcalc/pull/79))
-- **estimators:** Espessura de casca e média ponderada, não soma ([#82](https://github.com/ils15/open3dcalc/pull/82))
-- **gcode:** Dedup parsers, cap único 50MB single-source, helpers tempo/temperatura unificados, validação centralizada, arredondamento 1 casa, doc+tooltip i18n (`gcodeEPathsNote` pt-BR) ([#88](https://github.com/ils15/open3dcalc/pull/88))
+- **estimators:** Shell thickness and weighted average, not the sum ([#82](https://github.com/ils15/open3dcalc/pull/82))
+- **gcode:** Dedup parsers, single-source 50MB cap, unified time/temperature helpers, centralized validation, 1-decimal rounding, i18n doc+tooltip (`gcodeEPathsNote` pt-BR) ([#88](https://github.com/ils15/open3dcalc/pull/88))
 
 ### 📦 Dependencies
 
@@ -92,22 +98,16 @@
 - **layout:** Responsive calculator columns for complete mode ([#30](https://github.com/ils15/open3dcalc/pull/30))
 - **changelog:** Localize version cards and polish header controls ([#33](https://github.com/ils15/open3dcalc/pull/33))
 - **layout:** Results sidebar only with space, portal dropdowns, ultrawide shell ([#34](https://github.com/ils15/open3dcalc/pull/34))
-- **gcode:** Não ignora gcode sem TIME header e suporta Prusa/Orca ([#32](https://github.com/ils15/open3dcalc/pull/32), [#51](https://github.com/ils15/open3dcalc/pull/51))
+- **gcode:** Do not ignore gcode without a TIME header and support Prusa/Orca ([#32](https://github.com/ils15/open3dcalc/pull/32), [#51](https://github.com/ils15/open3dcalc/pull/51))
 
 ### 🏡 Chore
 
-- **ci:** Pre-commit — gitleaks + guardião .env + AI Bifrost ([9afa29b](https://github.com/ils15/open3dcalc/commit/9afa29b))
+- **ci:** Pre-commit — gitleaks + .env guardian + AI Bifrost ([9afa29b](https://github.com/ils15/open3dcalc/commit/9afa29b))
 - **ci:** Security phase 2 — deepwork CI/CD, pre-commit and scan ([fe56338](https://github.com/ils15/open3dcalc/commit/fe56338))
 
 ### ❤️ Contributors
 
 - Ils15 ([@ils15](https://github.com/ils15))
-
-## Unreleased
-
-### 🐛 Bug Fixes
-
-- **gcode:** não ignora gcode sem TIME header e suporta formato Prusa/Orca (closes #32) — remove gate silencioso `if(printTimeMinutes>0)` em `StlPreview.tsx:242`, parser `d/h/m/s` (`1h 23m 45s`/`2d 5h`/`45m 30s`) em `gcodeParser.ts`, `geometry: BufferGeometry | null`, `setGeometry(null)` no branch GCODE, drop zone permanece visível (`!modelInfo?.geometry`), botão 🗑️ `stl.clear` para GCODE, 13 testes novos (7 parser + 6 StlPreview), 893/893 passing, lint/typecheck clean, Themis PASS_WITH_NOTES resolvido
 
 ## v1.9.2
 
@@ -117,7 +117,7 @@
 
 - **ci:** Add AI code review workflow via Bifrost LLM Gateway ([8287e51](https://github.com/ils15/open3dcalc/commit/8287e51))
 - **ci:** Switch AI review to alibaba/open-code-review, fix release artifacts ([#11](https://github.com/ils15/open3dcalc/pull/11))
-- CI/CD otimizado — self-hosted runner, husky-only, AI commit review, i18n ([#12](https://github.com/ils15/open3dcalc/pull/12))
+- Optimized CI/CD — self-hosted runner, husky-only, AI commit review, i18n ([#12](https://github.com/ils15/open3dcalc/pull/12))
 - Auto-deduct filament + date filters (Issue #16) ([#17](https://github.com/ils15/open3dcalc/pull/17), [#16](https://github.com/ils15/open3dcalc/issues/16))
 - Phase 2+3 — STL & Dashboard optimization (dead code removal, calc integration) ([#20](https://github.com/ils15/open3dcalc/pull/20))
 
@@ -127,7 +127,7 @@
 - Safety Sprint — security & quality hardening ([#19](https://github.com/ils15/open3dcalc/pull/19))
 - **release:** Remove [skip ci] from release commit ([#21](https://github.com/ils15/open3dcalc/pull/21))
 - **release:** Push tag only, use release branch + PR for version bump ([#22](https://github.com/ils15/open3dcalc/pull/22))
-- **release:** Padronizar pipeline protegido e idempotente ([#23](https://github.com/ils15/open3dcalc/pull/23))
+- **release:** Standardize protected and idempotent pipeline ([#23](https://github.com/ils15/open3dcalc/pull/23))
 
 ### 🏡 Chore
 
@@ -194,26 +194,28 @@
 
 [compare changes](https://github.com/ils15/open3dcalc/compare/v1.8.0...v1.8.1)
 
+_Hotfix release; no user-facing changes._
+
 ## v1.8.0 — Bifrost UI Redesign (2026-06-29)
 
 ### 🎨 UI/UX
 
-- Redesign Bifrost: superfícies planas, sem glassmorphism
-- Tema claro/escuro no web
-- Badges retangulares (6px), border-radius reduzido (14px)
-- Sistema de CSS variables unificado
+- Bifrost redesign: flat surfaces, no glassmorphism
+- Light/dark theme on web
+- Rectangular badges (6px), reduced border-radius (14px)
+- Unified CSS variables system
 
-### 🔧 Técnico
+### 🔧 Technical
 
-- Codebase unificada em monorepo (`src/shared/` + `src/platform/`)
-- Git migrado para raiz (história preservada)
-- `web/` e `desktop/` mantidos para referência histórica
+- Unified codebase in a monorepo (`src/shared/` + `src/platform/`)
+- Git migrated to root (history preserved)
+- `web/` and `desktop/` kept for historical reference
 
-### ✅ Testes
+### ✅ Tests
 
-- 417 testes, 36/36 arquivos passando
-- Cobertura >80%
+- 417 tests, 36/36 files passing
+- Coverage >80%
 
 ---
 
-Para histórico completo anterior à v1.8.0, veja as [releases no GitHub](https://github.com/ils15/open3dcalc/releases).
+For the complete history before v1.8.0, see the [GitHub releases](https://github.com/ils15/open3dcalc/releases).

--- a/scripts/__tests__/sync-changelog.test.ts
+++ b/scripts/__tests__/sync-changelog.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildVersions,
   cleanItem,
+  fetchReleaseDate,
   findVersionsArraySpan,
   formatReport,
   main,
@@ -291,22 +292,24 @@ describe("sync-changelog CLI", () => {
     ].join("\n");
     const next = [{ version: "2.0.0", date: "", sections: [] }];
     const updated = replaceVersionsArray(raw, next);
-    expect(updated).toBe([
-      "{",
-      '  "changelog": {',
-      '    "header": "x",',
-      '    "versions": [',
-      "      {",
-      '        "version": "2.0.0",',
-      '        "date": "",',
-      '        "sections": []',
-      "      }",
-      "    ],",
-      '    "viewAllOnGitHub": "y"',
-      "  },",
-      '\t"legacy": "\tindented with a literal tab"',
-      "}",
-    ].join("\n"));
+    expect(updated).toBe(
+      [
+        "{",
+        '  "changelog": {',
+        '    "header": "x",',
+        '    "versions": [',
+        "      {",
+        '        "version": "2.0.0",',
+        '        "date": "",',
+        '        "sections": []',
+        "      }",
+        "    ],",
+        '    "viewAllOnGitHub": "y"',
+        "  },",
+        '\t"legacy": "\tindented with a literal tab"',
+        "}",
+      ].join("\n"),
+    );
     const span = findVersionsArraySpan(raw);
     expect(span).not.toBeNull();
     expect(raw.slice(span.start, span.start + 1)).toBe("[");
@@ -334,6 +337,88 @@ describe("sync-changelog CLI", () => {
       withTab.slice(0, beforeSpan.start),
     );
     expect(after.slice(versionsSpan.end)).toBe(withTab.slice(beforeSpan.end));
+  });
+});
+
+describe("sync-changelog GitHub dates", () => {
+  /** GitHub API stub: releases, tags, commits, PRs and the release/tag date. */
+  const githubApi = (publishedAt: string | null) => (url: string) => {
+    if (url.includes("/releases/tags/"))
+      return publishedAt
+        ? Response.json({ tag_name: "v1.9.2", published_at: publishedAt })
+        : new Response("missing", { status: 404 });
+    if (url.includes("/releases?"))
+      return Response.json([
+        { tag_name: "v1.9.2", target_commitish: "sha-192", assets: [] },
+      ]);
+    if (url.includes("/tags?"))
+      return Response.json([{ name: "v1.9.2", commit: { sha: "sha-192" } }]);
+    if (url.includes("/commits?"))
+      return Response.json([
+        { sha: "sha-192", commit: { message: "feat: ship" } },
+      ]);
+    return Response.json([]);
+  };
+
+  it("fills a version date from the GitHub release published_at (--from-github)", async () => {
+    const root = await tempRoot();
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string) => {
+      calls.push(url);
+      return githubApi("2026-08-21T15:42:00Z")(url);
+    }) as typeof fetch;
+    try {
+      await main(["--from-github", "v1.9.2", "--write"], { root });
+      const written = JSON.parse(
+        await readFile(
+          resolve(root, "src/shared/i18n/locales/pt-BR.json"),
+          "utf8",
+        ),
+      );
+      const entry = written.changelog.versions.find(
+        (candidate: { version: string }) => candidate.version === "1.9.2",
+      );
+      expect(entry.date).toBe("2026-08-21");
+      expect(calls.some((call) => call.includes("/releases/tags/v1.9.2"))).toBe(
+        true,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("falls back to the tag commit date when the release API fails", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes("/releases/tags/"))
+        return new Response("missing", { status: 404 });
+      if (url.includes("/commits/v1.9.2"))
+        return Response.json({
+          commit: { committer: { date: "2026-08-20T09:00:00Z" } },
+        });
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+    try {
+      await expect(
+        fetchReleaseDate("ils15/open3dcalc", "v1.9.2"),
+      ).resolves.toBe("2026-08-20");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns an empty date instead of guessing when both sources fail", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("boom", { status: 500 })) as typeof fetch;
+    try {
+      await expect(
+        fetchReleaseDate("ils15/open3dcalc", "v1.9.2"),
+      ).resolves.toBe("");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/scripts/__tests__/sync-changelog.test.ts
+++ b/scripts/__tests__/sync-changelog.test.ts
@@ -187,6 +187,96 @@ describe("sync-changelog generation", () => {
   });
 });
 
+describe("sync-changelog translation durability", () => {
+  const localePath = (root: string, name: string) =>
+    resolve(root, "src/shared/i18n/locales", `${name}.json`);
+  const readLocale = async (root: string, name: string) =>
+    JSON.parse(await readFile(localePath(root, name), "utf8"));
+  const writeLocale = async (root: string, name: string, data: unknown) =>
+    writeFile(localePath(root, name), `${JSON.stringify(data, null, 2)}\n`);
+
+  it("preserves translated pt-BR items and appends only new items in English", async () => {
+    const root = await tempRoot();
+    // Seed pt-BR with a human translation in a section that matches the source.
+    const pt = await readLocale(root, "pt-BR");
+    pt.changelog.versions[0].sections = [
+      {
+        title: "🚀 Novidades",
+        items: ["**ui:** Adicionar modo escuro (abc123)"],
+      },
+    ];
+    await writeLocale(root, "pt-BR", pt);
+    // Seed en-US with stale text to prove the canonical locale still updates.
+    const en = await readLocale(root, "en-US");
+    en.changelog.versions[0].sections[0].items = ["**ui:** stale"];
+    await writeLocale(root, "en-US", en);
+
+    await main(["--write"], { root });
+
+    const ptAfter = await readLocale(root, "pt-BR");
+    const enAfter = await readLocale(root, "en-US");
+    const ptV120 = ptAfter.changelog.versions.find(
+      (entry: { version: string }) => entry.version === "1.2.0",
+    );
+    const enV120 = enAfter.changelog.versions.find(
+      (entry: { version: string }) => entry.version === "1.2.0",
+    );
+    // Existing translation survives by (version, section, item position)…
+    expect(ptV120.sections[0].items[0]).toBe(
+      "**ui:** Adicionar modo escuro (abc123)",
+    );
+    // …the genuinely new item enters in English for later translation.
+    expect(ptV120.sections[0].items[1]).toBe(
+      "**ci:** Ship release automation (#12)",
+    );
+    // en-US is the canonical locale: stale text is replaced by the source.
+    expect(enV120.sections[0].items).toEqual([
+      "**ui:** Add dark mode (abc123)",
+      "**ci:** Ship release automation (#12)",
+    ]);
+    // Version count and order are preserved.
+    expect(
+      ptAfter.changelog.versions.map(
+        (entry: { version: string }) => entry.version,
+      ),
+    ).toEqual(["1.2.0", "1.1.1", "1.1.0", "1.0.0"]);
+    // A locale-only version is still preserved untouched.
+    expect(
+      ptAfter.changelog.versions.find(
+        (entry: { version: string }) => entry.version === "1.0.0",
+      ),
+    ).toEqual(
+      pt.changelog.versions.find(
+        (entry: { version: string }) => entry.version === "1.0.0",
+      ),
+    );
+    // The preserved state is considered in sync.
+    await expect(main(["--check"], { root })).resolves.toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("keeps a translated item stable across repeated --write runs", async () => {
+    const root = await tempRoot();
+    const pt = await readLocale(root, "pt-BR");
+    pt.changelog.versions[0].sections = [
+      {
+        title: "🚀 Novidades",
+        items: ["**ui:** Adicionar modo escuro (abc123)"],
+      },
+    ];
+    await writeLocale(root, "pt-BR", pt);
+
+    await main(["--write"], { root });
+    const first = await readFile(localePath(root, "pt-BR"), "utf8");
+    const report = await main(["--write"], { root });
+    const second = await readFile(localePath(root, "pt-BR"), "utf8");
+
+    expect(second).toBe(first);
+    expect(report.wrote).toBe(false);
+  });
+});
+
 describe("sync-changelog CLI", () => {
   it("parses flags and rejects conflicting or unknown ones", () => {
     expect(parseArgs([])).toEqual({
@@ -421,7 +511,9 @@ describe("sync-changelog GitHub dates", () => {
       expect(entry.date).toBe("2026-08-24");
       expect(calls.some((call) => call.includes("/commits/v1.9.2"))).toBe(true);
       // The fallback source is never consulted once the commit date resolves.
-      expect(calls.some((call) => call.includes("/releases/tags/"))).toBe(false);
+      expect(calls.some((call) => call.includes("/releases/tags/"))).toBe(
+        false,
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -501,7 +593,9 @@ describe("sync-changelog GitHub dates", () => {
       await expect(
         resolveReleaseDate("ils15/open3dcalc", "banana"),
       ).resolves.toBe("");
-      await expect(resolveReleaseDate("ils15/open3dcalc", "")).resolves.toBe("");
+      await expect(resolveReleaseDate("ils15/open3dcalc", "")).resolves.toBe(
+        "",
+      );
       expect(calls).toBe(0);
     } finally {
       globalThis.fetch = originalFetch;
@@ -517,12 +611,12 @@ describe("sync-changelog GitHub dates", () => {
       return Response.json({});
     }) as typeof fetch;
     try {
-      await expect(
-        resolveReleaseDate("not a repo", "v1.9.2"),
-      ).resolves.toBe("");
-      await expect(
-        resolveReleaseDate("../etc/passwd", "v1.9.2"),
-      ).resolves.toBe("");
+      await expect(resolveReleaseDate("not a repo", "v1.9.2")).resolves.toBe(
+        "",
+      );
+      await expect(resolveReleaseDate("../etc/passwd", "v1.9.2")).resolves.toBe(
+        "",
+      );
       expect(calls).toBe(0);
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining("invalid repository"),
@@ -538,7 +632,9 @@ describe("sync-changelog GitHub dates", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     process.env.GH_TOKEN = "super-secret-token";
     globalThis.fetch = (async (url: string) =>
-      githubApi({ commitStatus: 403, releaseStatus: 403 })(url)) as typeof fetch;
+      githubApi({ commitStatus: 403, releaseStatus: 403 })(
+        url,
+      )) as typeof fetch;
     try {
       await expect(
         resolveReleaseDate("ils15/open3dcalc", "v1.9.2"),

--- a/scripts/__tests__/sync-changelog.test.ts
+++ b/scripts/__tests__/sync-changelog.test.ts
@@ -1,20 +1,31 @@
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildVersions,
   cleanItem,
-  fetchReleaseDate,
   findVersionsArraySpan,
   formatReport,
   main,
   parseArgs,
   parseChangelog,
   replaceVersionsArray,
+  resolveReleaseDate,
   sectionTitleFor,
   semverDesc,
 } from "../sync-changelog.mjs";
+
+// The offline date-fill path is gated on GH_TOKEN; keep it out of the way so
+// the deterministic suite never reaches for the network.
+const ORIGINAL_GH_TOKEN = process.env.GH_TOKEN;
+beforeEach(() => {
+  delete process.env.GH_TOKEN;
+});
+afterEach(() => {
+  if (ORIGINAL_GH_TOKEN === undefined) delete process.env.GH_TOKEN;
+  else process.env.GH_TOKEN = ORIGINAL_GH_TOKEN;
+});
 
 const FIXTURES = resolve("scripts/__fixtures__/changelog");
 const fixtureChangelog = () =>
@@ -341,32 +352,60 @@ describe("sync-changelog CLI", () => {
 });
 
 describe("sync-changelog GitHub dates", () => {
-  /** GitHub API stub: releases, tags, commits, PRs and the release/tag date. */
-  const githubApi = (publishedAt: string | null) => (url: string) => {
-    if (url.includes("/releases/tags/"))
-      return publishedAt
-        ? Response.json({ tag_name: "v1.9.2", published_at: publishedAt })
-        : new Response("missing", { status: 404 });
-    if (url.includes("/releases?"))
-      return Response.json([
-        { tag_name: "v1.9.2", target_commitish: "sha-192", assets: [] },
-      ]);
-    if (url.includes("/tags?"))
-      return Response.json([{ name: "v1.9.2", commit: { sha: "sha-192" } }]);
-    if (url.includes("/commits?"))
-      return Response.json([
-        { sha: "sha-192", commit: { message: "feat: ship" } },
-      ]);
-    return Response.json([]);
+  /**
+   * GitHub API stub. `commit`/`publishedAt` drive the two date sources:
+   * the tag commit (primary) and the release `published_at` (fallback).
+   */
+  const githubApi = ({
+    commit = { commit: { committer: { date: "2026-08-20T09:00:00Z" } } },
+    publishedAt = "2026-08-21T15:42:00Z",
+    commitStatus = 200,
+    releaseStatus = 200,
+  }: {
+    commit?: unknown;
+    publishedAt?: string | null;
+    commitStatus?: number;
+    releaseStatus?: number;
+  } = {}) => {
+    const respond = (status: number, body: unknown) =>
+      status === 200
+        ? Response.json(body)
+        : new Response("missing", { status });
+    return (url: string) => {
+      if (url.includes("/commits/v")) return respond(commitStatus, commit);
+      if (url.includes("/releases/tags/"))
+        return respond(releaseStatus, {
+          tag_name: "v1.9.2",
+          published_at: publishedAt,
+        });
+      if (url.includes("/releases"))
+        return Response.json([
+          { tag_name: "v1.9.2", target_commitish: "sha-192", assets: [] },
+        ]);
+      if (url.includes("/tags"))
+        return Response.json([{ name: "v1.9.2", commit: { sha: "sha-192" } }]);
+      if (url.includes("/commits/") && url.includes("/pulls"))
+        return Response.json([]);
+      if (url.includes("/commits"))
+        return Response.json([
+          { sha: "sha-192", commit: { message: "feat: ship" } },
+        ]);
+      if (url.includes("/compare/")) return Response.json({ commits: [] });
+      if (url.includes("/pulls")) return Response.json([]);
+      return Response.json([]);
+    };
   };
 
-  it("fills a version date from the GitHub release published_at (--from-github)", async () => {
+  it("prefers the immutable tag-commit date over published_at (--from-github)", async () => {
     const root = await tempRoot();
     const originalFetch = globalThis.fetch;
     const calls: string[] = [];
     globalThis.fetch = (async (url: string) => {
       calls.push(url);
-      return githubApi("2026-08-21T15:42:00Z")(url);
+      return githubApi({
+        commit: { commit: { committer: { date: "2026-08-24T00:00:00Z" } } },
+        publishedAt: "2026-09-10T00:00:00Z",
+      })(url);
     }) as typeof fetch;
     try {
       await main(["--from-github", "v1.9.2", "--write"], { root });
@@ -379,30 +418,43 @@ describe("sync-changelog GitHub dates", () => {
       const entry = written.changelog.versions.find(
         (candidate: { version: string }) => candidate.version === "1.9.2",
       );
-      expect(entry.date).toBe("2026-08-21");
-      expect(calls.some((call) => call.includes("/releases/tags/v1.9.2"))).toBe(
-        true,
-      );
+      expect(entry.date).toBe("2026-08-24");
+      expect(calls.some((call) => call.includes("/commits/v1.9.2"))).toBe(true);
+      // The fallback source is never consulted once the commit date resolves.
+      expect(calls.some((call) => call.includes("/releases/tags/"))).toBe(false);
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  it("falls back to the tag commit date when the release API fails", async () => {
+  it("falls back to published_at when the tag commit lookup fails", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async (url: string) => {
-      if (url.includes("/releases/tags/"))
-        return new Response("missing", { status: 404 });
-      if (url.includes("/commits/v1.9.2"))
-        return Response.json({
-          commit: { committer: { date: "2026-08-20T09:00:00Z" } },
-        });
-      return new Response("unexpected", { status: 500 });
-    }) as typeof fetch;
+    globalThis.fetch = (async (url: string) =>
+      githubApi({
+        commitStatus: 404,
+        publishedAt: "2026-08-21T15:42:00Z",
+      })(url)) as typeof fetch;
     try {
       await expect(
-        fetchReleaseDate("ils15/open3dcalc", "v1.9.2"),
-      ).resolves.toBe("2026-08-20");
+        resolveReleaseDate("ils15/open3dcalc", "v1.9.2"),
+      ).resolves.toBe("2026-08-21");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns empty when published_at is null despite HTTP 200", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) =>
+      githubApi({
+        commitStatus: 404,
+        publishedAt: null,
+        releaseStatus: 200,
+      })(url)) as typeof fetch;
+    try {
+      await expect(
+        resolveReleaseDate("ils15/open3dcalc", "v1.9.2"),
+      ).resolves.toBe("");
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -414,8 +466,182 @@ describe("sync-changelog GitHub dates", () => {
       new Response("boom", { status: 500 })) as typeof fetch;
     try {
       await expect(
-        fetchReleaseDate("ils15/open3dcalc", "v1.9.2"),
+        resolveReleaseDate("ils15/open3dcalc", "v1.9.2"),
       ).resolves.toBe("");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("survives a fetch that throws without rejecting", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("offline");
+    }) as typeof fetch;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await expect(
+        resolveReleaseDate("ils15/open3dcalc", "v1.9.2"),
+      ).resolves.toBe("");
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns empty for an invalid tag without calling fetch", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return Response.json({});
+    }) as typeof fetch;
+    try {
+      await expect(
+        resolveReleaseDate("ils15/open3dcalc", "banana"),
+      ).resolves.toBe("");
+      await expect(resolveReleaseDate("ils15/open3dcalc", "")).resolves.toBe("");
+      expect(calls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rejects an invalid repository with a warning before interpolating", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return Response.json({});
+    }) as typeof fetch;
+    try {
+      await expect(
+        resolveReleaseDate("not a repo", "v1.9.2"),
+      ).resolves.toBe("");
+      await expect(
+        resolveReleaseDate("../etc/passwd", "v1.9.2"),
+      ).resolves.toBe("");
+      expect(calls).toBe(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("invalid repository"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      warn.mockRestore();
+    }
+  });
+
+  it("warns on 403/rate-limit failures without leaking the token", async () => {
+    const originalFetch = globalThis.fetch;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.GH_TOKEN = "super-secret-token";
+    globalThis.fetch = (async (url: string) =>
+      githubApi({ commitStatus: 403, releaseStatus: 403 })(url)) as typeof fetch;
+    try {
+      await expect(
+        resolveReleaseDate("ils15/open3dcalc", "v1.9.2"),
+      ).resolves.toBe("");
+      const messages = warn.mock.calls.map((call) => String(call[0]));
+      expect(messages.some((message) => message.includes("403"))).toBe(true);
+      expect(messages.join(" ")).not.toContain("super-secret-token");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.GH_TOKEN;
+      warn.mockRestore();
+    }
+  });
+
+  it("stays offline (no date lookup) without a token or fetch override", async () => {
+    const root = await tempRoot();
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return Response.json({});
+    }) as typeof fetch;
+    try {
+      await main(["--write"], { root });
+      expect(calls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("fills empty CHANGELOG.md dates via GitHub when a fetch override is given", async () => {
+    const root = await tempRoot();
+    const fetchImpl = githubApi({
+      commit: { commit: { committer: { date: "2026-05-25T00:00:00Z" } } },
+    });
+    const report = await main(["--write"], { root, fetch: fetchImpl });
+    const written = JSON.parse(
+      await readFile(
+        resolve(root, "src/shared/i18n/locales/pt-BR.json"),
+        "utf8",
+      ),
+    );
+    const v111 = written.changelog.versions.find(
+      (candidate: { version: string }) => candidate.version === "1.1.1",
+    );
+    expect(v111.date).toBe("2026-05-25");
+    expect(report.wrote).toBe(true);
+  });
+
+  it("enables offline date resolution in CI when GH_TOKEN is present", async () => {
+    const root = await tempRoot();
+    const originalFetch = globalThis.fetch;
+    process.env.GH_TOKEN = "ci-token";
+    globalThis.fetch = (async (url: string) =>
+      githubApi({
+        commit: { commit: { committer: { date: "2026-08-20T09:00:00Z" } } },
+      })(url)) as typeof fetch;
+    try {
+      await main(["--write"], { root });
+      const written = JSON.parse(
+        await readFile(
+          resolve(root, "src/shared/i18n/locales/pt-BR.json"),
+          "utf8",
+        ),
+      );
+      const v111 = written.changelog.versions.find(
+        (candidate: { version: string }) => candidate.version === "1.1.1",
+      );
+      expect(v111.date).toBe("2026-08-20");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.GH_TOKEN;
+    }
+  });
+
+  it("resolves every release date on the full --from-github list path", async () => {
+    const root = await tempRoot();
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    const stub = (url: string) => {
+      calls.push(url);
+      return githubApi({
+        commit: { commit: { committer: { date: "2026-08-20T09:00:00Z" } } },
+      })(url);
+    };
+    globalThis.fetch = (async (url: string) => stub(url)) as typeof fetch;
+    try {
+      await main(["--from-github", "--write"], {
+        root,
+        fetch: stub as unknown as typeof fetch,
+      });
+      const written = JSON.parse(
+        await readFile(
+          resolve(root, "src/shared/i18n/locales/pt-BR.json"),
+          "utf8",
+        ),
+      );
+      const entry = written.changelog.versions.find(
+        (candidate: { version: string }) => candidate.version === "1.9.2",
+      );
+      expect(entry.date).toBe("2026-08-20");
+      expect(calls.some((call) => call.includes("/releases"))).toBe(true);
+      expect(calls.some((call) => call.includes("/commits/v1.9.2"))).toBe(true);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -55,6 +55,8 @@ const EMOJI = /[\p{Extended_Pictographic}\uFE0F\u200D]/gu;
 const LEADING_EMOJI = /^[\p{Extended_Pictographic}\uFE0F\u200D\s]+/u;
 const SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
 const RELEASE_TAG = /^v\d+\.\d+\.\d+$/;
+/** `owner/repo` slugs only — validated before any URL interpolation. */
+const REPOSITORY = /^[\w.-]+\/[\w.-]+$/;
 const GITHUB_API = "https://api.github.com";
 const ISO_DATE = /^(\d{4}-\d{2}-\d{2})/;
 
@@ -72,29 +74,34 @@ const githubHeaders = () => ({
 });
 
 /**
- * Resolve a release tag's publication date as `YYYY-MM-DD`.
+ * Resolve a release's date as `YYYY-MM-DD`, preferring the tag commit.
  *
- * Primary source: `GET /repos/{owner}/{repo}/releases/tags/{tag}` →
- * `published_at`. When that call fails (404/network) or omits the field, fall
- * back to the deterministic committer date of the tag commit
- * (`GET /repos/{owner}/{repo}/commits/{tag}`). Returns `""` when neither source
+ * Preference order — the immutable tag-commit date
+ * (`GET /repos/{owner}/{repo}/commits/{tag}` → `commit.committer.date`) is the
+ * primary source: GitHub releases are often backfilled after the fact, so
+ * their `published_at` can be the backfill day rather than the historical
+ * release day. `published_at`
+ * (`GET /repos/{owner}/{repo}/releases/tags/{tag}`) is only a fallback when the
+ * commit lookup fails or omits the field. Returns `""` when neither source
  * yields a date — never a guessed value.
+ *
+ * Network, auth and rate-limit failures are non-fatal: they emit a token-free
+ * `console.warn` and degrade to the next source.
  */
-export async function fetchReleaseDate(repository, tag, fetchImpl = fetch) {
+export async function resolveReleaseDate(repository, tag, fetchImpl = fetch) {
   if (!tag || !RELEASE_TAG.test(tag)) return "";
-  const base = `${GITHUB_API}/repos/${repository}`;
-  try {
-    const response = await fetchImpl(`${base}/releases/tags/${tag}`, {
-      method: "GET",
-      headers: githubHeaders(),
-    });
-    if (response.ok) {
-      const date = isoDay((await response.json())?.published_at);
-      if (date) return date;
-    }
-  } catch {
-    // Network/parse failure: the deterministic commit fallback still applies.
+  if (!REPOSITORY.test(String(repository ?? ""))) {
+    console.warn(
+      `sync-changelog: invalid repository "${repository}"; skipping date lookup`,
+    );
+    return "";
   }
+  const base = `${GITHUB_API}/repos/${repository}`;
+  const warnFailure = (source, outcome) => {
+    // A missing release/tag/commit (404) is an expected fallback, not an error.
+    if (outcome === 404) return;
+    console.warn(`sync-changelog: ${source} failed for ${tag} (${outcome})`);
+  };
   try {
     const response = await fetchImpl(`${base}/commits/${tag}`, {
       method: "GET",
@@ -102,10 +109,25 @@ export async function fetchReleaseDate(repository, tag, fetchImpl = fetch) {
     });
     if (response.ok) {
       const commit = await response.json();
-      return isoDay(commit?.commit?.committer?.date);
+      const date = isoDay(commit?.commit?.committer?.date);
+      if (date) return date;
+    } else {
+      warnFailure("tag commit lookup", response.status);
     }
-  } catch {
+  } catch (error) {
+    // Network/parse failure: the release fallback still applies.
+    warnFailure("tag commit lookup", error?.message ?? "network error");
+  }
+  try {
+    const response = await fetchImpl(`${base}/releases/tags/${tag}`, {
+      method: "GET",
+      headers: githubHeaders(),
+    });
+    if (response.ok) return isoDay((await response.json())?.published_at);
+    warnFailure("release lookup", response.status);
+  } catch (error) {
     // Both sources failed; leave the date empty instead of guessing.
+    warnFailure("release lookup", error?.message ?? "network error");
   }
   return "";
 }
@@ -384,7 +406,7 @@ async function entriesFromGitHub(repository, tag, fetchImpl = fetch) {
   const { collect } = await import("./release-notes.mjs");
   const withReleaseDate = async (entry, releaseTag) => ({
     ...entry,
-    date: await fetchReleaseDate(repository, releaseTag, fetchImpl),
+    date: await resolveReleaseDate(repository, releaseTag, fetchImpl),
   });
   if (tag)
     return [
@@ -407,6 +429,39 @@ async function entriesFromGitHub(repository, tag, fetchImpl = fetch) {
       ),
     );
   return entries;
+}
+
+/**
+ * Whether the offline CHANGELOG.md path may reach for GitHub to complete
+ * missing dates. Off by default so the local/offline run stays deterministic;
+ * enabled in CI by `GH_TOKEN`, or in tests by an explicit fetch override.
+ */
+const shouldResolveOfflineDates = (overrides) =>
+  Boolean(overrides.fetch) || Boolean(process.env.GH_TOKEN);
+
+/**
+ * Best-effort completion of parsed CHANGELOG.md entries via the GitHub API.
+ *
+ * Only invoked when {@link shouldResolveOfflineDates} is true. Every lookup is
+ * swallowed on failure (`resolveReleaseDate` returns `""`), so a missing
+ * token/network keeps the previous empty-date behavior instead of breaking the
+ * run.
+ */
+async function fillMissingDates(repository, entries, fetchImpl) {
+  const filled = [];
+  for (const entry of entries) {
+    if (entry.date) {
+      filled.push(entry);
+      continue;
+    }
+    const date = await resolveReleaseDate(
+      repository,
+      `v${entry.version}`,
+      fetchImpl,
+    );
+    filled.push(date ? { ...entry, date } : entry);
+  }
+  return filled;
 }
 
 const usage = [
@@ -457,9 +512,13 @@ export async function main(argv = process.argv.slice(2), overrides = {}) {
   const localesDir =
     overrides.localesDir ?? resolve(root, "src/shared/i18n/locales");
   const repository = process.env.GITHUB_REPOSITORY ?? DEFAULT_REPOSITORY;
-  const parsed = options.fromGithub
+  let parsed = options.fromGithub
     ? await entriesFromGitHub(repository, options.githubTag, overrides.fetch)
     : parseChangelog(await readFile(changelogPath, "utf8"));
+  // Offline runs may still complete missing dates from GitHub (CI with a
+  // token). Without a token/network this is a no-op and stays deterministic.
+  if (!options.fromGithub && shouldResolveOfflineDates(overrides))
+    parsed = await fillMissingDates(repository, parsed, overrides.fetch);
 
   const reports = {};
   for (const name of LOCALE_NAMES) {

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -6,11 +6,19 @@
  * `changelog.versions` section of src/shared/i18n/locales/{pt-BR,en-US}.json.
  *
  * Merge semantics:
- * - Versions defined by CHANGELOG.md win: the app entry is regenerated from
+ * - en-US is canonical: its items always follow CHANGELOG.md, regenerated from
  *   the markdown sections (per-locale section titles, raw item text).
- * - Versions present only in the locale files are preserved untouched (the
- *   rich handwritten entries for releases the root changelog does not cover,
- *   e.g. 1.9.1/1.7.0) so the in-app history is never gutted.
+ * - pt-BR is durable: for a version already present in the locale, item text is
+ *   preserved by (version, section title, item index). The locale file is the
+ *   home of the human translations, so a resync must never overwrite an existing
+ *   translation with the English source. Only items beyond the existing section
+ *   length are genuinely new; they enter with the canonical (English) text,
+ *   ready for later translation.
+ * - Versions defined by CHANGELOG.md win for structure and section titles (with
+ *   the item-text exception above). Versions present only in the locale files
+ *   are preserved untouched (the rich handwritten entries for releases the root
+ *   changelog does not cover, e.g. 1.9.1/1.7.0) so the in-app history is never
+ *   gutted.
  * - Dates: inline `(YYYY-MM-DD)` in the version heading wins; otherwise the
  *   existing locale date is kept; otherwise empty.
  * - The final list is sorted by SemVer descending.
@@ -27,6 +35,8 @@
  *
  * Only `changelog.versions` is touched; every other JSON key is preserved
  * byte-for-byte (same 2-space indentation, key order, trailing newline).
+ * `--write` is a no-op when the array is already in sync, so durable
+ * translations are never rewritten or reformatted.
  */
 import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -36,6 +46,8 @@ export const LOCALE_NAMES = ["pt-BR", "en-US"];
 const DEFAULT_REPOSITORY = "ils15/open3dcalc";
 /** File basename → SECTION_TITLES key. */
 const LOCALE_KEYS = Object.freeze({ "pt-BR": "pt", "en-US": "en" });
+/** Locale whose item text is the canonical source (never translated in place). */
+export const CANONICAL_LOCALE = "en";
 
 // Lazy: under vitest's module runner import.meta.url is not a file:// URL.
 const repoRoot = () => {
@@ -277,6 +289,35 @@ export function localizeSections(locale, sections) {
 }
 
 /**
+ * Preserve already-translated item text for a non-canonical locale.
+ *
+ * Items are matched by position: `parsedSections` come from the canonical
+ * source and carry English item text, while `existingSections` are the locale's
+ * durable translations. For every section whose title matches, the existing item
+ * at each index wins; only indices beyond the existing array (genuinely new
+ * items) keep the canonical text. Positional matching is deterministic and
+ * intentionally simple — the changelog appends items, it does not reorder them.
+ */
+export function preserveTranslatedItems(parsedSections, existingSections) {
+  const existingByTitle = new Map(
+    (existingSections ?? []).map((section) => [
+      section.title,
+      Array.isArray(section.items) ? section.items : [],
+    ]),
+  );
+  return parsedSections.map((section) => {
+    const existingItems = existingByTitle.get(section.title);
+    if (!existingItems) return section;
+    return {
+      ...section,
+      items: section.items.map((item, index) =>
+        index < existingItems.length ? existingItems[index] : item,
+      ),
+    };
+  });
+}
+
+/**
  * CHANGELOG.md wins for the versions it defines; locale-only versions are
  * preserved. Missing dates fall back to the existing locale entry date.
  */
@@ -296,11 +337,20 @@ export function mergeEntries(parsed, existing) {
 }
 
 export function buildVersions(locale, parsed, existing) {
-  const localized = parsed.map((entry) => ({
-    version: entry.version,
-    date: entry.date,
-    sections: localizeSections(locale, entry.sections),
-  }));
+  const existingByVersion = new Map(
+    existing.map((entry) => [entry.version, entry]),
+  );
+  const localized = parsed.map((entry) => {
+    const sections = localizeSections(locale, entry.sections);
+    const old = existingByVersion.get(entry.version);
+    // Only the canonical locale regenerates item text; translated locales keep
+    // their existing items and receive genuinely new ones in English.
+    const reconciled =
+      locale !== CANONICAL_LOCALE && old
+        ? preserveTranslatedItems(sections, old.sections)
+        : sections;
+    return { version: entry.version, date: entry.date, sections: reconciled };
+  });
   return mergeEntries(localized, existing);
 }
 
@@ -530,9 +580,14 @@ export async function main(argv = process.argv.slice(2), overrides = {}) {
       ? data.changelog.versions
       : [];
     const versions = buildVersions(LOCALE_KEYS[name], parsed, existing);
-    reports[name] = diffVersions(existing, versions);
-    if (options.mode === "--write") {
-      // Surgical splice keeps every byte outside changelog.versions intact.
+    const report = diffVersions(existing, versions);
+    reports[name] = report;
+    const stale =
+      report.added.length || report.removed.length || report.changed.length;
+    if (options.mode === "--write" && stale) {
+      // Surgical splice keeps every byte outside changelog.versions intact; a
+      // no-op sync leaves the file untouched so preserved translations are never
+      // reformatted or rewritten.
       await writeFile(filePath, replaceVersionsArray(raw, versions), "utf8");
     }
   }

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -55,6 +55,60 @@ const EMOJI = /[\p{Extended_Pictographic}\uFE0F\u200D]/gu;
 const LEADING_EMOJI = /^[\p{Extended_Pictographic}\uFE0F\u200D\s]+/u;
 const SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
 const RELEASE_TAG = /^v\d+\.\d+\.\d+$/;
+const GITHUB_API = "https://api.github.com";
+const ISO_DATE = /^(\d{4}-\d{2}-\d{2})/;
+
+/** Normalize an ISO timestamp to the `YYYY-MM-DD` day used by the locales. */
+export const isoDay = (value) => {
+  const match = ISO_DATE.exec(String(value ?? ""));
+  return match ? match[1] : "";
+};
+
+const githubHeaders = () => ({
+  accept: "application/vnd.github+json",
+  ...(process.env.GH_TOKEN
+    ? { authorization: `Bearer ${process.env.GH_TOKEN}` }
+    : {}),
+});
+
+/**
+ * Resolve a release tag's publication date as `YYYY-MM-DD`.
+ *
+ * Primary source: `GET /repos/{owner}/{repo}/releases/tags/{tag}` →
+ * `published_at`. When that call fails (404/network) or omits the field, fall
+ * back to the deterministic committer date of the tag commit
+ * (`GET /repos/{owner}/{repo}/commits/{tag}`). Returns `""` when neither source
+ * yields a date — never a guessed value.
+ */
+export async function fetchReleaseDate(repository, tag, fetchImpl = fetch) {
+  if (!tag || !RELEASE_TAG.test(tag)) return "";
+  const base = `${GITHUB_API}/repos/${repository}`;
+  try {
+    const response = await fetchImpl(`${base}/releases/tags/${tag}`, {
+      method: "GET",
+      headers: githubHeaders(),
+    });
+    if (response.ok) {
+      const date = isoDay((await response.json())?.published_at);
+      if (date) return date;
+    }
+  } catch {
+    // Network/parse failure: the deterministic commit fallback still applies.
+  }
+  try {
+    const response = await fetchImpl(`${base}/commits/${tag}`, {
+      method: "GET",
+      headers: githubHeaders(),
+    });
+    if (response.ok) {
+      const commit = await response.json();
+      return isoDay(commit?.commit?.committer?.date);
+    }
+  } catch {
+    // Both sources failed; leave the date empty instead of guessing.
+  }
+  return "";
+}
 
 /**
  * CHANGELOG.md headings (emoji-stripped, lowercased) and release-notes.mjs
@@ -326,9 +380,19 @@ function entryFromCatalog(catalog) {
 }
 
 /** Fallback source: audited per-release catalogs from release-notes.mjs. */
-async function entriesFromGitHub(repository, tag) {
+async function entriesFromGitHub(repository, tag, fetchImpl = fetch) {
   const { collect } = await import("./release-notes.mjs");
-  if (tag) return [entryFromCatalog(await collect(repository, tag))];
+  const withReleaseDate = async (entry, releaseTag) => ({
+    ...entry,
+    date: await fetchReleaseDate(repository, releaseTag, fetchImpl),
+  });
+  if (tag)
+    return [
+      await withReleaseDate(
+        entryFromCatalog(await collect(repository, tag)),
+        tag,
+      ),
+    ];
   const catalog = await collect(repository);
   const tags = catalog.releases
     .map((release) => release.tag)
@@ -336,7 +400,12 @@ async function entriesFromGitHub(repository, tag) {
     .sort((a, b) => semverDesc(a.replace("v", ""), b.replace("v", "")));
   const entries = [];
   for (const releaseTag of tags)
-    entries.push(entryFromCatalog(await collect(repository, releaseTag)));
+    entries.push(
+      await withReleaseDate(
+        entryFromCatalog(await collect(repository, releaseTag)),
+        releaseTag,
+      ),
+    );
   return entries;
 }
 
@@ -389,7 +458,7 @@ export async function main(argv = process.argv.slice(2), overrides = {}) {
     overrides.localesDir ?? resolve(root, "src/shared/i18n/locales");
   const repository = process.env.GITHUB_REPOSITORY ?? DEFAULT_REPOSITORY;
   const parsed = options.fromGithub
-    ? await entriesFromGitHub(repository, options.githubTag)
+    ? await entriesFromGitHub(repository, options.githubTag, overrides.fetch)
     : parseChangelog(await readFile(changelogPath, "utf8"));
 
   const reports = {};

--- a/src/shared/components/ui/OnboardingModal.tsx
+++ b/src/shared/components/ui/OnboardingModal.tsx
@@ -1,11 +1,11 @@
-import { useState, useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
-import { AnimatePresence, motion } from 'framer-motion'
-import { X, ChevronRight, ArrowLeft, Play } from 'lucide-react'
-import { useReducedMotion } from '@/shared/hooks/useReducedMotion'
-import { useTutorialStore } from '@/shared/stores/tutorialStore'
+import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion } from "framer-motion";
+import { X, ChevronRight, ArrowLeft, Play } from "lucide-react";
+import { useReducedMotion } from "@/shared/hooks/useReducedMotion";
+import { useTutorialStore } from "@/shared/stores/tutorialStore";
 
-const ONBOARDING_KEY = 'open3dcalc_onboarded'
+const ONBOARDING_KEY = "open3dcalc_onboarded";
 
 const slideVariants = {
   enter: (direction: number) => ({
@@ -20,94 +20,99 @@ const slideVariants = {
     x: direction < 0 ? 300 : -300,
     opacity: 0,
   }),
-}
+};
 
 interface OnboardingModalProps {
-  onComplete?: () => void
+  onComplete?: () => void;
 }
 
 export function OnboardingModal({ onComplete }: OnboardingModalProps) {
-  const { t } = useTranslation()
-  const prefersReduced = useReducedMotion()
-  const [[slideIndex, direction], setSlideState] = useState([0, 0])
-  const [visible, setVisible] = useState(() => !localStorage.getItem(ONBOARDING_KEY))
+  const { t } = useTranslation();
+  const prefersReduced = useReducedMotion();
+  const [[slideIndex, direction], setSlideState] = useState([0, 0]);
+  const [visible, setVisible] = useState(
+    () => !localStorage.getItem(ONBOARDING_KEY),
+  );
 
-  const totalSlides = 3
-  const isLastSlide = slideIndex === totalSlides - 1
-  const isFirstSlide = slideIndex === 0
+  const totalSlides = 3;
+  const isLastSlide = slideIndex === totalSlides - 1;
+  const isFirstSlide = slideIndex === 0;
 
-  const goToSlide = useCallback((index: number) => {
-    setSlideState([index, index > slideIndex ? 1 : -1])
-  }, [slideIndex])
+  const goToSlide = useCallback(
+    (index: number) => {
+      setSlideState([index, index > slideIndex ? 1 : -1]);
+    },
+    [slideIndex],
+  );
 
   const nextSlide = useCallback(() => {
     if (slideIndex < totalSlides - 1) {
-      goToSlide(slideIndex + 1)
+      goToSlide(slideIndex + 1);
     }
-  }, [slideIndex, goToSlide])
+  }, [slideIndex, goToSlide]);
 
   const prevSlide = useCallback(() => {
     if (slideIndex > 0) {
-      goToSlide(slideIndex - 1)
+      goToSlide(slideIndex - 1);
     }
-  }, [slideIndex, goToSlide])
+  }, [slideIndex, goToSlide]);
 
-  const startTutorial = useTutorialStore(s => s.startTutorial)
+  const startTutorial = useTutorialStore((s) => s.startTutorial);
 
   const handleStartTutorial = useCallback(() => {
-    startTutorial()
-    localStorage.setItem(ONBOARDING_KEY, 'true')
-    setVisible(false)
-    onComplete?.()
-  }, [startTutorial, onComplete])
+    startTutorial();
+    localStorage.setItem(ONBOARDING_KEY, "true");
+    setVisible(false);
+    onComplete?.();
+  }, [startTutorial, onComplete]);
 
   const dismiss = useCallback(() => {
-    localStorage.setItem(ONBOARDING_KEY, 'true')
-    setVisible(false)
-    onComplete?.()
-  }, [onComplete])
+    localStorage.setItem(ONBOARDING_KEY, "true");
+    setVisible(false);
+    onComplete?.();
+  }, [onComplete]);
 
-  if (!visible) return null
+  if (!visible) return null;
 
   const slides = [
     {
-      icon: '🧮',
-      title: t('onboarding.slide1.title'),
-      description: t('onboarding.slide1.description'),
+      icon: "🧮",
+      title: t("onboarding.slide1.title"),
+      description: t("onboarding.slide1.description"),
     },
     {
-      icon: '⚙️',
-      title: t('onboarding.slide2.title'),
-      description: t('onboarding.slide2.description'),
+      icon: "⚙️",
+      title: t("onboarding.slide2.title"),
+      description: t("onboarding.slide2.description"),
     },
     {
-      icon: '💾',
-      title: t('onboarding.slide3.title'),
-      description: t('onboarding.slide3.description'),
+      icon: "💾",
+      title: t("onboarding.slide3.title"),
+      description: t("onboarding.slide3.description"),
     },
-  ]
+  ];
 
   return (
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center p-4"
-      style={{ background: 'rgba(0, 0, 0, 0.6)' }}
+      style={{ background: "rgba(0, 0, 0, 0.6)" }}
       role="dialog"
       aria-modal="true"
-      aria-label={t('onboarding.title')}
+      aria-label={t("onboarding.title")}
     >
       <div
         className="relative w-full max-w-md rounded-xl overflow-hidden"
         style={{
-          background: 'var(--color-bg-elevated)',
-          border: '1px solid var(--color-border)',
-          boxShadow: 'var(--shadow-md)',
+          background: "var(--color-bg-elevated)",
+          border: "1px solid var(--color-border)",
+          boxShadow: "var(--shadow-md)",
         }}
       >
         {/* Close / Skip button */}
         <button
           onClick={dismiss}
           className="absolute top-3 right-3 z-10 p-1.5 rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
-          aria-label={t('common.close')}
+          aria-label={t("common.close")}
         >
           <X className="w-4 h-4" />
         </button>
@@ -122,7 +127,10 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
               initial="enter"
               animate="center"
               exit="exit"
-              transition={{ duration: prefersReduced ? 0 : 0.25, ease: 'easeInOut' }}
+              transition={{
+                duration: prefersReduced ? 0 : 0.25,
+                ease: "easeInOut",
+              }}
               className="flex flex-col items-center gap-4 w-full"
             >
               <span className="text-5xl" role="img" aria-hidden="true">
@@ -142,7 +150,7 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
                   className="inline-flex items-center gap-2 mt-2 px-5 py-2.5 rounded-xl text-sm font-semibold bg-[var(--color-accent)] text-[var(--color-text-primary)] hover:bg-[var(--color-accent-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
                 >
                   <Play className="w-4 h-4" />
-                  {t('onboarding.startTutorial')}
+                  {t("onboarding.startTutorial")}
                 </button>
               )}
             </motion.div>
@@ -157,10 +165,10 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
             disabled={isFirstSlide}
             className={`p-2 rounded-xl transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none ${
               isFirstSlide
-                ? 'text-gray-700 cursor-not-allowed'
-                : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
+                ? "text-gray-700 cursor-not-allowed"
+                : "text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]"
             }`}
-            aria-label="Anterior"
+            aria-label={t("onboarding.previous")}
           >
             <ArrowLeft className="w-4 h-4" />
           </button>
@@ -173,10 +181,13 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
                 onClick={() => goToSlide(i)}
                 className={`w-2 h-2 rounded-full transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none ${
                   i === slideIndex
-                    ? 'bg-[var(--color-accent)] w-5'
-                    : 'bg-[var(--color-bg-hover)] hover:bg-[var(--color-bg-hover)]'
+                    ? "bg-[var(--color-accent)] w-5"
+                    : "bg-[var(--color-bg-hover)] hover:bg-[var(--color-bg-hover)]"
                 }`}
-                aria-label={`Slide ${i + 1}`}
+                aria-label={t("onboarding.slideOf", {
+                  current: i + 1,
+                  total: totalSlides,
+                })}
               />
             ))}
           </div>
@@ -187,14 +198,14 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
               onClick={dismiss}
               className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-semibold bg-[var(--color-accent)] text-[var(--color-text-primary)] hover:bg-[var(--color-accent-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
             >
-              {t('onboarding.start')}
+              {t("onboarding.start")}
               <ChevronRight className="w-3.5 h-3.5" />
             </button>
           ) : (
             <button
               onClick={nextSlide}
               className="p-2 rounded-xl text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-all focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
-              aria-label="Próximo"
+              aria-label={t("onboarding.next")}
             >
               <ChevronRight className="w-4 h-4" />
             </button>
@@ -202,5 +213,5 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/shared/components/ui/__tests__/OnboardingModal.test.tsx
+++ b/src/shared/components/ui/__tests__/OnboardingModal.test.tsx
@@ -1,44 +1,66 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { OnboardingModal } from '../OnboardingModal'
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { OnboardingModal } from "../OnboardingModal";
 
-// Mock i18n
-vi.mock('react-i18next', () => ({
+// Mock i18n — resolves the onboarding keys so tests assert translated labels
+vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        "onboarding.previous": "Anterior",
+        "onboarding.next": "Próximo",
+        "onboarding.slideOf": "Slide {{current}} de {{total}}",
+      };
+      let value = translations[key] ?? key;
+      if (options) {
+        for (const [name, replacement] of Object.entries(options)) {
+          value = value.replace(`{{${name}}}`, String(replacement));
+        }
+      }
+      return value;
+    },
   }),
-}))
+}));
 
-describe('OnboardingModal', () => {
+describe("OnboardingModal", () => {
   beforeEach(() => {
-    localStorage.clear()
-  })
+    localStorage.clear();
+  });
 
-  it('renders when not dismissed', () => {
-    render(<OnboardingModal />)
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-  })
+  it("renders when not dismissed", () => {
+    render(<OnboardingModal />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
 
-  it('does not render when previously dismissed', () => {
-    localStorage.setItem('open3dcalc_onboarded', 'true')
-    const { container } = render(<OnboardingModal />)
-    expect(container.innerHTML).toBe('')
-  })
+  it("does not render when previously dismissed", () => {
+    localStorage.setItem("open3dcalc_onboarded", "true");
+    const { container } = render(<OnboardingModal />);
+    expect(container.innerHTML).toBe("");
+  });
 
-  it('dismisses when close button is clicked', () => {
-    const onComplete = vi.fn()
-    render(<OnboardingModal onComplete={onComplete} />)
-    fireEvent.click(screen.getByLabelText('common.close'))
-    expect(onComplete).toHaveBeenCalled()
-    expect(localStorage.getItem('open3dcalc_onboarded')).toBe('true')
-  })
+  it("dismisses when close button is clicked", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingModal onComplete={onComplete} />);
+    fireEvent.click(screen.getByLabelText("common.close"));
+    expect(onComplete).toHaveBeenCalled();
+    expect(localStorage.getItem("open3dcalc_onboarded")).toBe("true");
+  });
 
-  it('navigates between slides', () => {
-    render(<OnboardingModal />)
+  it("navigates between slides", () => {
+    render(<OnboardingModal />);
     // Click next button
-    const nextButton = screen.getByLabelText('Próximo')
-    fireEvent.click(nextButton)
+    const nextButton = screen.getByLabelText("Próximo");
+    fireEvent.click(nextButton);
     // Should still be in dialog
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-  })
-})
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("renders navigation labels from i18n", () => {
+    render(<OnboardingModal />);
+    expect(screen.getByLabelText("Anterior")).toBeInTheDocument();
+    expect(screen.getByLabelText("Próximo")).toBeInTheDocument();
+    expect(screen.getByLabelText("Slide 1 de 3")).toBeInTheDocument();
+    expect(screen.getByLabelText("Slide 2 de 3")).toBeInTheDocument();
+    expect(screen.getByLabelText("Slide 3 de 3")).toBeInTheDocument();
+  });
+});

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -900,7 +900,7 @@
             "items": [
               "**Tutorial repositioned**: removed Floating UI, fixed card positioning (no drift)",
               "**MobileBottomBar**: no horizontal scroll, flex-1 layout, z-50 above section nav",
-              "**SectionNav**: full page height, 'Seções' title, subtle borders",
+              "**SectionNav**: full page height, 'Sections' title, subtle borders",
               "**QuickStartBanner**: dismissable (X button), compacted",
               "**ResultsPanel**: compressed mobile padding",
               "**Dual bottom bars**: main tabs + section nav, overflow-x-hidden"
@@ -909,18 +909,18 @@
           {
             "title": "🐛 Bug Fixes",
             "items": [
-              "**Electron CJS preload**: preload compilado em CommonJS para sandbox",
-              "**createRequire**: database.ts usa createRequire(import.meta.url) em vez de globalThis.require",
-              "**Lint errors**: SectionNav idx não usado, QuickStartBanner useEffect não usado, Tutorial setState em effect",
-              "**TypeScript scoping**: ElectronDBApi/ElectronUpdaterApi envoltos em declare global"
+              "**Electron CJS preload**: preload compiled to CommonJS for the sandbox",
+              "**createRequire**: database.ts uses createRequire(import.meta.url) instead of globalThis.require",
+              "**Lint errors**: unused SectionNav idx, unused QuickStartBanner useEffect, Tutorial setState in effect",
+              "**TypeScript scoping**: ElectronDBApi/ElectronUpdaterApi wrapped in declare global"
             ]
           },
           {
             "title": "🚪 Quality Gates",
             "items": [
-              "**Husky pre-commit**: ESLint roda nos arquivos staged antes de cada commit",
-              "**Husky pre-push**: typecheck + lint + test rodam antes de cada push",
-              "**CI/CD**: lint, typecheck e test rodam em todo push/PR"
+              "**Husky pre-commit**: ESLint runs on staged files before every commit",
+              "**Husky pre-push**: typecheck + lint + test run before every push",
+              "**CI/CD**: lint, typecheck and test run on every push/PR"
             ]
           },
           {
@@ -1034,58 +1034,58 @@
           {
             "title": "✨ Novo — Fase 5: Clientes & Orçamentos (LGPD-Safe)",
             "items": [
-              "**Cadastro de Clientes**: CRUD completo com busca por nome/empresa/email, export/import JSON, persistência em localStorage",
-              "**Orçamentos Multi-item**: crie orçamentos com múltiplos itens do histórico, vinculados a clientes, com cálculo automático de totais e descontos",
-              "**PDF Profissional**: template de orçamento com logo, dados do cliente, tabela de itens, condições de pagamento e nota de privacidade",
-              "**Dashboard de Orçamentos**: lista com filtros por status (Rascunho/Enviado/Aprovado/Recusado), busca e ordenação"
+              "**Customer Registration**: full CRUD with search by name/company/email, JSON export/import, localStorage persistence",
+              "**Multi-item Quotes**: create quotes with multiple items from history, linked to customers, with automatic totals and discounts calculation",
+              "**Professional PDF**: quote template with logo, customer data, item table, payment terms and privacy note",
+              "**Quotes Dashboard**: list with status filters (Draft/Sent/Approved/Rejected), search and sorting"
             ]
           },
           {
             "title": "✨ Novo — Fase 6: Edição de Impressoras",
             "items": [
-              "**Edição inline de impressoras**: botão ✏️ em todas as impressoras (inclusive padrão) com modal de edição para nome, marca, potência, valor, vida útil e manutenção/h",
-              "**Banco de dados expandido**: 385 impressoras de 56 marcas (era 143) com dados reais de build volume, velocidade máxima, preço EUR/USD/BRL",
-              "**Fonte de dados**: swordlab/open-3d-printer-database (CC-BY-4.0) integrado ao catálogo"
+              "**Inline printer editing**: ✏️ button on every printer (including the default) with an edit modal for name, brand, power, price, lifespan and maintenance/h",
+              "**Expanded database**: 385 printers from 56 brands (was 143) with real data for build volume, max speed and EUR/USD/BRL price",
+              "**Data source**: swordlab/open-3d-printer-database (CC-BY-4.0) integrated into the catalog"
             ]
           },
           {
             "title": "🔒 Privacidade (LGPD/GDPR)",
             "items": [
-              "**Banner de privacidade**: aviso fixo no topo informando \"Seus dados ficam apenas no seu navegador\"",
-              "**Modal de consentimento**: exibido na primeira vez que o usuário acessa Clientes/Orçamentos",
-              "**Política de privacidade inline**: 7 seções explicando o modelo de dados, direitos do titular e segurança"
+              "**Privacy banner**: fixed notice at the top stating \"Your data stays in your browser only\"",
+              "**Consent modal**: shown the first time the user opens Customers/Quotes",
+              "**Inline privacy policy**: 7 sections explaining the data model, data subject rights and security"
             ]
           },
           {
             "title": "🎨 UX",
             "items": [
-              "**9 abas no app**: Calculator, Catalog, Customers, Inventory, Quotes, History, Changelog, Dashboard, Settings",
-              "**Botão \"Criar Orçamento\"** no ResultsPanel para gerar orçamento a partir do cálculo atual",
-              "**Badges de impressora**: \"Padrão\" (verde) para impressoras default, \"Custom\" (indigo) para personalizadas"
+              "**9 tabs in the app**: Calculator, Catalog, Customers, Inventory, Quotes, History, Changelog, Dashboard, Settings",
+              "**\"Create Quote\" button** in ResultsPanel to generate a quote from the current calculation",
+              "**Printer badges**: \"Default\" (green) for default printers, \"Custom\" (indigo) for custom ones"
             ]
           },
           {
             "title": "🌐 i18n",
             "items": [
-              "Novas chaves: `customers`, `quotes`, `privacy` (banner, consent, policy) em pt-BR e en-US",
-              "`nav.customers`, `nav.quotes` para navegação",
+              "New keys: `customers`, `quotes`, `privacy` (banner, consent, policy) in pt-BR and en-US",
+              "`nav.customers`, `nav.quotes` for navigation",
               "`catalog.editPrinter`, `catalog.defaultPrinter`, `catalog.saveChanges`"
             ]
           },
           {
             "title": "🧪 Testes",
             "items": [
-              "**383 testes passando** (era 301) — 34 arquivos de teste, zero falhas",
-              "Novos: customerStore (21), quoteStore (31), consentStore (9), QuoteDoc (5), QuoteSection (3), CustomerTab (10), printer-edit (3)",
-              "Cobertura de todas as novas stores e componentes"
+              "**383 tests passing** (was 301) — 34 test files, zero failures",
+              "New: customerStore (21), quoteStore (31), consentStore (9), QuoteDoc (5), QuoteSection (3), CustomerTab (10), printer-edit (3)",
+              "Coverage for all new stores and components"
             ]
           },
           {
             "title": "📦 Dados",
             "items": [
-              "`src/data/printers-database.json` — 385 impressoras com specs detalhadas",
-              "`src/types/customer.ts` — interfaces Customer e CustomerFormData",
-              "`src/types/quote.ts` — interfaces Quote, QuoteItem, QuoteFormData"
+              "`src/data/printers-database.json` — 385 printers with detailed specs",
+              "`src/types/customer.ts` — Customer and CustomerFormData interfaces",
+              "`src/types/quote.ts` — Quote, QuoteItem, QuoteFormData interfaces"
             ]
           }
         ]
@@ -1097,24 +1097,24 @@
           {
             "title": "✨ New",
             "items": [
-              "**Tutorial interativo**: assistência guiada com 7 passos, spotlight/tooltip, navegação por teclado e suporte a `prefers-reduced-motion`",
-              "**Canal Telegram**: link para o canal [Impressão 3D BR](https://t.me/Impressao3DBR) no header e sidebar",
-              "**Créditos do desenvolvedor**: `ofertachina.com.br` no rodapé"
+              "**Interactive tutorial**: guided assistance with 7 steps, spotlight/tooltip, keyboard navigation and `prefers-reduced-motion` support",
+              "**Telegram channel**: link to the [Impressão 3D BR](https://t.me/Impressao3DBR) channel in the header and sidebar",
+              "**Developer credits**: `ofertachina.com.br` in the footer"
             ]
           },
           {
             "title": "🎨 UX",
             "items": [
-              "**Internacionalização completa**: todas as strings hardcoded em português extraídas para chaves de tradução (pt-BR/en-US)",
-              "**Botão de ajuda**: ícone `?` no header para reiniciar o tutorial a qualquer momento",
-              "**Auto-trigger do tutorial**: inicia automaticamente na primeira visita após 1.5s"
+              "**Full internationalization**: all hardcoded Portuguese strings extracted into translation keys (pt-BR/en-US)",
+              "**Help button**: `?` icon in the header to restart the tutorial at any time",
+              "**Tutorial auto-trigger**: starts automatically on the first visit after 1.5s"
             ]
           },
           {
             "title": "🧪 Testes",
             "items": [
-              "301 testes passando, cobertura estable",
-              "Build limpo, TypeScript strict sem erros"
+              "301 tests passing, stable coverage",
+              "Clean build, TypeScript strict with no errors"
             ]
           }
         ]
@@ -1126,21 +1126,21 @@
           {
             "title": "🔧 Technical",
             "items": [
-              "**Calculator.tsx refatorado**: de 1459 para 234 linhas — 11 componentes extraídos (TechToggle, LevelToggle, ProductName, SectionNav, SectionRenderer, MobileBottomBar, SectionHeader, HardwareSection, OpsSection, SalesSection, Calculator.constants).",
-              "**calculatorStore.ts refatorado**: de 561 para 278 linhas — types, defaults, helpers e compute extraídos para 4 arquivos.",
-              "**calculatorStore.test.ts dividido**: de 1483 linhas para 4 arquivos independentes (fdm 406, resin 439, logic 354, test-utils 52) — todos ≤ 500 linhas.",
-              "**useShallow do Zustand**: aplicado em 10 componentes para eliminar re-renders desnecessários.",
-              "**Lazy load recharts**: bundle principal reduzido de 1.115 kB para 614 kB (-45%), recharts em chunk lazy separado.",
-              "**Dead code removido**: 7 arquivos eliminados (productStore, skuManager, ErrorBoundary, SummaryRow, PwaUpdatePrompt, useKeyboardShortcuts, usePwaUpdate).",
-              "**PDF/CSV Export mobile**: botões de exportação rápida na bottom bar da calculadora."
+              "**Calculator.tsx refactored**: from 1459 to 234 lines — 11 extracted components (TechToggle, LevelToggle, ProductName, SectionNav, SectionRenderer, MobileBottomBar, SectionHeader, HardwareSection, OpsSection, SalesSection, Calculator.constants).",
+              "**calculatorStore.ts refactored**: from 561 to 278 lines — types, defaults, helpers and compute extracted into 4 files.",
+              "**calculatorStore.test.ts split**: from 1483 lines into 4 independent files (fdm 406, resin 439, logic 354, test-utils 52) — all ≤ 500 lines.",
+              "**Zustand useShallow**: applied to 10 components to eliminate unnecessary re-renders.",
+              "**Lazy load recharts**: main bundle reduced from 1,115 kB to 614 kB (-45%), recharts in a separate lazy chunk.",
+              "**Dead code removed**: 7 files deleted (productStore, skuManager, ErrorBoundary, SummaryRow, PwaUpdatePrompt, useKeyboardShortcuts, usePwaUpdate).",
+              "**Mobile PDF/CSV export**: quick export buttons in the calculator bottom bar."
             ]
           },
           {
             "title": "✅ Testes",
             "items": [
-              "**301 testes** (era 207 no v1.5.0) — 27 arquivos de teste, 100% passando.",
-              "Novos testes: historyStore +12, filamentInventory +11, Calculator mobile export +3.",
-              "Cobertura de testes do calculatorStore mantida em 93%."
+              "**301 tests** (was 207 in v1.5.0) — 27 test files, 100% passing.",
+              "New tests: historyStore +12, filamentInventory +11, Calculator mobile export +3.",
+              "calculatorStore test coverage kept at 93%."
             ]
           }
         ]
@@ -1204,56 +1204,56 @@
           {
             "title": "✨ New",
             "items": [
-              "**Onboarding para Novos Usuários** — modal de boas-vindas com 3 slides (\"O que é\", \"Como calcular\", \"Como salvar\"), detecção de primeira visita via localStorage, navegação entre slides com bolinhas, botão \"Pular\" persistente.",
-              "**Tooltips Informativos** — sistema de tooltips com Floating UI, delay 400ms, posicionamento inteligente em campos não-óbvios (taxa de falha, vida útil da máquina, break-even).",
-              "**Atalhos de Teclado** — Ctrl/Cmd+S (salvar configurações), Ctrl/Cmd+H (navegar para histórico), Ctrl/Cmd+D (navegar para dashboard), Escape (fechar modais). Indicadores visuais nos botões de navegação.",
-              "**Inventário — Dedução Livre** — campo de input numérico para deduzir peso exato em cada carretel, validação de saldo, combinado com filtro por marca (pills clicáveis) e filtro de material.",
-              "**Catálogo — Edição Inline** — ícone ✏️ em cards de impressora/material/marketplace, input substitui texto com Enter/blur para salvar, Escape para cancelar.",
-              "**Error Boundaries** — envolve ResultsPanel, Dashboard e StlPreview com fallback estilizado, botões \"Tentar novamente\" e \"Resetar calculadora\".",
-              "**PWA & Offline** — service worker com cache total de assets, notificação \"Nova versão disponível\" com botão de atualização."
+              "**New User Onboarding** — welcome modal with 3 slides (\"What is it\", \"How to calculate\", \"How to save\"), first-visit detection via localStorage, dot navigation between slides, persistent \"Skip\" button.",
+              "**Informative Tooltips** — tooltip system with Floating UI, 400ms delay, smart positioning on non-obvious fields (failure rate, machine lifespan, break-even).",
+              "**Keyboard Shortcuts** — Ctrl/Cmd+S (save settings), Ctrl/Cmd+H (go to history), Ctrl/Cmd+D (go to dashboard), Escape (close modals). Visual indicators on navigation buttons.",
+              "**Inventory — Free Deduction** — numeric input to deduct the exact weight on each spool, balance validation, combined with brand filter (clickable pills) and material filter.",
+              "**Catalog — Inline Editing** — ✏️ icon on printer/material/marketplace cards, input replaces the text, Enter/blur to save, Escape to cancel.",
+              "**Error Boundaries** — wraps ResultsPanel, Dashboard and StlPreview with a styled fallback, \"Try again\" and \"Reset calculator\" buttons.",
+              "**PWA & Offline** — service worker with full asset caching, \"New version available\" notification with an update button."
             ]
           },
           {
             "title": "🎨 UX",
             "items": [
-              "Tooltips com ícone ⓘ nos InputGroup com delay de 400ms e posicionamento automático (Floating UI).",
-              "Filtro combinado de material + marca no inventário com feedback visual.",
-              "Indicadores de atalho de teclado nos botões de navegação (Ctrl+H, Ctrl+D).",
-              "Glassmorphism consistente em todos os novos componentes (OnboardingModal, Tooltip, ErrorBoundary, PwaUpdatePrompt).",
-              "Edição inline no catálogo com confirmação visual (check verde / X vermelho)."
+              "Tooltips with ⓘ icon in InputGroup with 400ms delay and automatic positioning (Floating UI).",
+              "Combined material + brand filter in the inventory with visual feedback.",
+              "Keyboard shortcut indicators on navigation buttons (Ctrl+H, Ctrl+D).",
+              "Consistent glassmorphism across all new components (OnboardingModal, Tooltip, ErrorBoundary, PwaUpdatePrompt).",
+              "Inline editing in the catalog with visual confirmation (green check / red X)."
             ]
           },
           {
             "title": "🔧 Technical",
             "items": [
-              "`src/hooks/useKeyboardShortcuts.ts` — hook de atalhos com supressão em inputs/textarea/select.",
-              "`src/hooks/usePwaUpdate.ts` — hook de atualização PWA com service worker registration.",
-              "`src/components/ui/OnboardingModal.tsx` — modal com 3 slides, Framer Motion `AnimatePresence`, lazy initializer.",
-              "`src/components/ui/Tooltip.tsx` — tooltip com Floating UI, `useMergeRefs`, suporte a 4 direções.",
-              "`src/components/ui/ErrorBoundary.tsx` — ErrorBoundary classe com `componentDidCatch`, fallback com retry e reset.",
-              "`src/components/ui/PwaUpdatePrompt.tsx` — banner de atualização com `skipWaiting()` + reload.",
-              "`src/components/Catalog/FilamentInventory.tsx` — input de dedução livre + brand filter pills.",
-              "`src/components/Catalog/CatalogTab.tsx` — componente `InlineField` para edição inline nos 3 gerenciadores.",
-              "`vite.config.ts` — PWA config com runtime caching e globPatterns completo.",
-              "`src/main.tsx` — integração do PwaUpdatePrompt no root."
+              "`src/hooks/useKeyboardShortcuts.ts` — shortcuts hook with suppression in inputs/textarea/select.",
+              "`src/hooks/usePwaUpdate.ts` — PWA update hook with service worker registration.",
+              "`src/components/ui/OnboardingModal.tsx` — modal with 3 slides, Framer Motion `AnimatePresence`, lazy initializer.",
+              "`src/components/ui/Tooltip.tsx` — tooltip with Floating UI, `useMergeRefs`, 4-direction support.",
+              "`src/components/ui/ErrorBoundary.tsx` — class ErrorBoundary with `componentDidCatch`, fallback with retry and reset.",
+              "`src/components/ui/PwaUpdatePrompt.tsx` — update banner with `skipWaiting()` + reload.",
+              "`src/components/Catalog/FilamentInventory.tsx` — free deduction input + brand filter pills.",
+              "`src/components/Catalog/CatalogTab.tsx` — `InlineField` component for inline editing in all 3 managers.",
+              "`vite.config.ts` — PWA config with runtime caching and full globPatterns.",
+              "`src/main.tsx` — PwaUpdatePrompt integrated into the root."
             ]
           },
           {
             "title": "📚 Quality",
             "items": [
-              "**53 testes unitários** em `calculator.ts` — cobertura de **99.19%** (statements) e **82.95%** (branches).",
-              "**25 testes de integração** nas stores (calculatorStore 8, historyStore 9, filamentInventory 8).",
-              "**79 testes no total** passando, 0 lint errors, build limpo.",
-              "Performance: memoização com `useMemo`/`useShallow`, lazy loading de StlPreview e PDF.",
-              "Error Boundaries nos 3 componentes críticos com fallback padronizado."
+              "**53 unit tests** in `calculator.ts` — **99.19%** coverage (statements) and **82.95%** (branches).",
+              "**25 integration tests** in the stores (calculatorStore 8, historyStore 9, filamentInventory 8).",
+              "**79 tests in total** passing, 0 lint errors, clean build.",
+              "Performance: memoization with `useMemo`/`useShallow`, lazy loading of StlPreview and PDF.",
+              "Error Boundaries on the 3 critical components with a standardized fallback."
             ]
           },
           {
             "title": "🤖 CI & Automation",
             "items": [
-              "**changelogen** configurado para geração de changelog a partir de conventional commits.",
-              "`.changelogenrc` com categorias em português e emojis personalizados.",
-              "Workflow de Release manual no GitHub Actions (`release.yml`) com bump semântico e GitHub Release."
+              "**changelogen** configured to generate the changelog from conventional commits.",
+              "`.changelogenrc` with Portuguese categories and custom emojis.",
+              "Manual Release workflow in GitHub Actions (`release.yml`) with semantic bump and GitHub Release."
             ]
           }
         ]

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -735,9 +735,11 @@
             "items": [
               "**sync:** Add text label to DataSyncButton for better visibility (a6da01d)",
               "UI/UX improvements — STL support estimation, Resin preview, safety fixes (#57)",
-              "**calc:** Exibe lucro por hora (profit/hr) FDM+Resina (#77)",
-              "**products:** Cadastro produtos + vendido + CSV + sync (#78)",
-              "**estimators:** Modos simple/advanced + G-code opcional (#83)"
+              "**calc:** Show profit/hr for FDM + Resin (#77)",
+              "**products:** Product registration + sold + CSV + sync (#78)",
+              "**estimators:** Simple/advanced modes + optional G-code (#83)",
+              "**gcode:** Bambu/Klipper time headers + fallback by moves via `timeSource` HEADER/APPROXIMATE, first-wins cascade Cura > Prusa/Orca > Bambu > Klipper (#86, closes #84)",
+              "**calc:** Editable sale price (display-local BRL override) + calculator→product bridge with toast/event and pt-BR/en-US i18n (#87, closes #85)"
             ]
           },
           {
@@ -745,11 +747,27 @@
             "items": [
               "**ci:** Remove v1.10.0 exclusion and sync changelog (7794266)",
               "**dashboard:** Replace React.lazy with static recharts imports to fix #7463 crash (#7463)",
-              "**3mf:** Segue p:path da production extension e corrige volume 3x maior (#72)",
-              "**estimators:** Casca por area de superficie e fisica da extrusao no… (#73)",
-              "**release:** Windows exe + auto-update resiliente (#76)",
+              "**3mf:** Follow p:path from the production extension and fix 3x larger volume (#72)",
+              "**estimators:** Surface-area shell and extrusion physics in… (#73)",
+              "**release:** Windows exe + resilient auto-update (#76)",
               "**release:** Join --body into single quoted string in release PR step (#79)",
-              "**estimators:** Espessura de casca e média ponderada, não soma (#82)"
+              "**estimators:** Shell thickness and weighted average, not the sum (#82)",
+              "**gcode:** Dedup parsers, single-source 50MB cap, unified time/temperature helpers, centralized validation, 1-decimal rounding, i18n doc+tooltip (`gcodeEPathsNote` pt-BR) (#88)"
+            ]
+          },
+          {
+            "title": "⬆️ Dependencies",
+            "items": [
+              "Bump electron 43.4.1 → 44.1.1 (#62)",
+              "Bump @react-pdf/renderer 4.6.1 → 4.9.0 (#64)",
+              "Bump lucide-react 1.33.0 → 1.39.0 (#66)",
+              "Bump lint-staged 17.3.0 → 17.4.1 (#65)",
+              "Bump @vitejs/plugin-react 6.1.0 → 6.1.1 (#67)",
+              "Bump @testing-library/react 16.3.2 → 16.3.3 (#58)",
+              "Bump @types/node 26.2.0 → 26.4.1 (#59)",
+              "Bump @types/react-dom 19.2.4 → 19.2.5 (#60)",
+              "Bump pantheon-opencode 1.3.6 → 1.4.3 (#61)",
+              "Bump anomalyco/opencode/github action (#63)"
             ]
           },
           {
@@ -815,14 +833,13 @@
               "**layout:** Responsive calculator columns for complete mode (#30)",
               "**changelog:** Localize version cards and polish header controls (#33)",
               "**layout:** Results sidebar only with space, portal dropdowns, ultrawide shell (#34)",
-              "**gcode:** Não ignora gcode sem TIME header e suporta Prusa/Orca (#32, #51)",
-              "**gcode:** não ignora gcode sem TIME header e suporta formato Prusa/Orca (closes #32) — remove gate silencioso `if(printTimeMinutes>0)` em `StlPreview.tsx:242`, parser `d/h/m/s` (`1h 23m 45s`/`2d 5h`/`45m 30s`) em `gcodeParser.ts`, `geometry: BufferGeometry | null`, `setGeometry(null)` no branch GCODE, drop zone permanece visível (`!modelInfo?.geometry`), botão `stl.clear` para GCODE, 13 testes novos (7 parser + 6 StlPreview), 893/893 passing, lint/typecheck clean, Themis PASS_WITH_NOTES resolvido"
+              "**gcode:** Do not ignore gcode without a TIME header and support Prusa/Orca (#32, #51)"
             ]
           },
           {
             "title": "🧹 Other",
             "items": [
-              "**ci:** Pre-commit — gitleaks + guardião .env + AI Bifrost (9afa29b)",
+              "**ci:** Pre-commit — gitleaks + .env guardian + AI Bifrost (9afa29b)",
               "**ci:** Security phase 2 — deepwork CI/CD, pre-commit and scan (fe56338)"
             ]
           },
@@ -841,7 +858,7 @@
             "items": [
               "**ci:** Add AI code review workflow via Bifrost LLM Gateway (8287e51)",
               "**ci:** Switch AI review to alibaba/open-code-review, fix release artifacts (#11)",
-              "CI/CD otimizado — self-hosted runner, husky-only, AI commit review, i18n (#12)",
+              "Optimized CI/CD — self-hosted runner, husky-only, AI commit review, i18n (#12)",
               "Auto-deduct filament + date filters (Issue #16) (#17, #16)",
               "Phase 2+3 — STL & Dashboard optimization (dead code removal, calc integration) (#20)"
             ]
@@ -853,7 +870,7 @@
               "Safety Sprint — security & quality hardening (#19)",
               "**release:** Remove [skip ci] from release commit (#21)",
               "**release:** Push tag only, use release branch + PR for version bump (#22)",
-              "**release:** Padronizar pipeline protegido e idempotente (#23)"
+              "**release:** Standardize protected and idempotent pipeline (#23)"
             ]
           },
           {
@@ -990,23 +1007,23 @@
           {
             "title": "🎨 UI/UX",
             "items": [
-              "Redesign Bifrost: superfícies planas, sem glassmorphism",
-              "Tema claro/escuro no web",
-              "Badges retangulares (6px), border-radius reduzido (14px)",
-              "Sistema de CSS variables unificado"
+              "Bifrost redesign: flat surfaces, no glassmorphism",
+              "Light/dark theme on web",
+              "Rectangular badges (6px), reduced border-radius (14px)",
+              "Unified CSS variables system"
             ]
           },
           {
-            "title": "🔧 Técnico",
+            "title": "🔧 Technical",
             "items": [
-              "Codebase unificada em monorepo (`src/shared/` + `src/platform/`)",
-              "Git migrado para raiz (história preservada)",
-              "`web/` e `desktop/` mantidos para referência histórica"
+              "Unified codebase in a monorepo (`src/shared/` + `src/platform/`)",
+              "Git migrated to root (history preserved)",
+              "`web/` and `desktop/` kept for historical reference"
             ]
           },
           {
-            "title": "✅ Testes",
-            "items": ["417 testes, 36/36 arquivos passando", "Cobertura >80%"]
+            "title": "✅ Tests",
+            "items": ["417 tests, 36/36 files passing", "Coverage >80%"]
           }
         ]
       },

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -725,7 +725,7 @@
     "versions": [
       {
         "version": "1.11.0",
-        "date": "",
+        "date": "2026-09-06",
         "sections": [
           {
             "title": "🚀 Features",
@@ -769,7 +769,7 @@
       },
       {
         "version": "1.10.0",
-        "date": "",
+        "date": "2026-08-24",
         "sections": [
           {
             "title": "🚀 Features",
@@ -794,7 +794,7 @@
       },
       {
         "version": "1.9.3",
-        "date": "",
+        "date": "2026-08-21",
         "sections": [
           {
             "title": "🚀 Features",
@@ -831,7 +831,7 @@
       },
       {
         "version": "1.9.2",
-        "date": "",
+        "date": "2026-07-31",
         "sections": [
           {
             "title": "🚀 Features",
@@ -977,7 +977,7 @@
       },
       {
         "version": "1.8.1",
-        "date": "",
+        "date": "2026-06-29",
         "sections": []
       },
       {
@@ -1072,7 +1072,7 @@
       },
       {
         "version": "1.6.0",
-        "date": "2026-06-27",
+        "date": "2026-06-28",
         "sections": [
           {
             "title": "✨ New",

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -570,6 +570,9 @@
     "start": "Start",
     "startTutorial": "Start Interactive Tutorial",
     "skip": "Skip",
+    "previous": "Previous",
+    "next": "Next",
+    "slideOf": "Slide {{current}} of {{total}}",
     "slide1": {
       "title": "What is Open3DCalc?",
       "description": "A free and open-source calculator to accurately estimate 3D printing costs."

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -570,6 +570,9 @@
     "start": "Começar",
     "startTutorial": "Começar Tutorial Interativo",
     "skip": "Pular",
+    "previous": "Anterior",
+    "next": "Próximo",
+    "slideOf": "Slide {{current}} de {{total}}",
     "slide1": {
       "title": "O que é o Open3DCalc?",
       "description": "Uma calculadora gratuita e open-source para estimar custos de impressão 3D com precisão."

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -733,53 +733,53 @@
           {
             "title": "🚀 Novidades",
             "items": [
-              "**sync:** Add text label to DataSyncButton for better visibility (a6da01d)",
-              "UI/UX improvements — STL support estimation, Resin preview, safety fixes (#57)",
-              "**calc:** Show profit/hr for FDM + Resin (#77)",
-              "**products:** Product registration + sold + CSV + sync (#78)",
-              "**estimators:** Simple/advanced modes + optional G-code (#83)",
-              "**gcode:** Bambu/Klipper time headers + fallback by moves via `timeSource` HEADER/APPROXIMATE, first-wins cascade Cura > Prusa/Orca > Bambu > Klipper (#86, closes #84)",
-              "**calc:** Editable sale price (display-local BRL override) + calculator→product bridge with toast/event and pt-BR/en-US i18n (#87, closes #85)"
+              "**sync:** Adiciona rótulo de texto ao DataSyncButton para melhor visibilidade (a6da01d)",
+              "Melhorias de UI/UX — estimativa de suporte STL, pré-visualização de resina, correções de segurança (#57)",
+              "**calc:** Exibe lucro/hora para FDM + Resina (#77)",
+              "**products:** Cadastro de produtos + vendidos + CSV + sync (#78)",
+              "**estimators:** Modos simples/avançado + G-code opcional (#83)",
+              "**gcode:** Cabeçalhos de tempo Bambu/Klipper + fallback por movimentos via `timeSource` HEADER/APPROXIMATE, cascata first-wins Cura > Prusa/Orca > Bambu > Klipper (#86, encerra #84)",
+              "**calc:** Preço de venda editável (override BRL local de exibição) + ponte calculadora→produto com toast/evento e i18n pt-BR/en-US (#87, encerra #85)"
             ]
           },
           {
             "title": "🐛 Correções",
             "items": [
-              "**ci:** Remove v1.10.0 exclusion and sync changelog (7794266)",
-              "**dashboard:** Replace React.lazy with static recharts imports to fix #7463 crash (#7463)",
-              "**3mf:** Follow p:path from the production extension and fix 3x larger volume (#72)",
-              "**estimators:** Surface-area shell and extrusion physics in… (#73)",
-              "**release:** Windows exe + resilient auto-update (#76)",
-              "**release:** Join --body into single quoted string in release PR step (#79)",
-              "**estimators:** Shell thickness and weighted average, not the sum (#82)",
-              "**gcode:** Dedup parsers, single-source 50MB cap, unified time/temperature helpers, centralized validation, 1-decimal rounding, i18n doc+tooltip (`gcodeEPathsNote` pt-BR) (#88)"
+              "**ci:** Remove a exclusão da v1.10.0 e sincroniza o changelog (7794266)",
+              "**dashboard:** Substitui React.lazy por imports estáticos do recharts para corrigir o crash #7463 (#7463)",
+              "**3mf:** Segue p:path da extensão de produção e corrige volume 3x maior (#72)",
+              "**estimators:** Casca por área de superfície e física de extrusão em… (#73)",
+              "**release:** Executável Windows + auto-update resiliente (#76)",
+              "**release:** Junta --body em uma única string entre aspas no passo de PR de release (#79)",
+              "**estimators:** Espessura de casca e média ponderada, não a soma (#82)",
+              "**gcode:** Desduplica parsers, limite único de 50MB, helpers unificados de tempo/temperatura, validação centralizada, arredondamento para 1 decimal, doc+tooltip i18n (`gcodeEPathsNote` pt-BR) (#88)"
             ]
           },
           {
             "title": "⬆️ Dependências",
             "items": [
-              "Bump electron 43.4.1 → 44.1.1 (#62)",
-              "Bump @react-pdf/renderer 4.6.1 → 4.9.0 (#64)",
-              "Bump lucide-react 1.33.0 → 1.39.0 (#66)",
-              "Bump lint-staged 17.3.0 → 17.4.1 (#65)",
-              "Bump @vitejs/plugin-react 6.1.0 → 6.1.1 (#67)",
-              "Bump @testing-library/react 16.3.2 → 16.3.3 (#58)",
-              "Bump @types/node 26.2.0 → 26.4.1 (#59)",
-              "Bump @types/react-dom 19.2.4 → 19.2.5 (#60)",
-              "Bump pantheon-opencode 1.3.6 → 1.4.3 (#61)",
-              "Bump anomalyco/opencode/github action (#63)"
+              "Atualiza electron 43.4.1 → 44.1.1 (#62)",
+              "Atualiza @react-pdf/renderer 4.6.1 → 4.9.0 (#64)",
+              "Atualiza lucide-react 1.33.0 → 1.39.0 (#66)",
+              "Atualiza lint-staged 17.3.0 → 17.4.1 (#65)",
+              "Atualiza @vitejs/plugin-react 6.1.0 → 6.1.1 (#67)",
+              "Atualiza @testing-library/react 16.3.2 → 16.3.3 (#58)",
+              "Atualiza @types/node 26.2.0 → 26.4.1 (#59)",
+              "Atualiza @types/react-dom 19.2.4 → 19.2.5 (#60)",
+              "Atualiza pantheon-opencode 1.3.6 → 1.4.3 (#61)",
+              "Atualiza a action anomalyco/opencode/github (#63)"
             ]
           },
           {
             "title": "✅ Tests",
             "items": [
-              "Increase ChangelogPage test timeout to 15s for CI stability (1bee06d)"
+              "Aumenta o timeout dos testes do ChangelogPage para 15s para estabilidade da CI (1bee06d)"
             ]
           },
           {
             "title": "🤖 CI/CD",
             "items": [
-              "Split quality into checks+test and run on fork PRs (#74)"
+              "Divide a qualidade em checks+test e roda em PRs de fork (#74)"
             ]
           },
           {
@@ -795,16 +795,16 @@
           {
             "title": "🚀 Novidades",
             "items": [
-              "**sync:** Cross-device data sync via encrypted export/import (#56, closes #55)"
+              "**sync:** Sincronização de dados entre dispositivos via export/import criptografado (#56, encerra #55)"
             ]
           },
           {
             "title": "🐛 Correções",
             "items": [
-              "**ci:** Fix npm ci failure — regenerate lock file with missing Windows-only optional deps",
-              "**ci:** Make postinstall (`electron-rebuild`) conditional — skips in CI environments",
-              "**vite:** Resolve CJS interop issues with `use-sync-external-store` and `scheduler`",
-              "**ui:** Resolve recharts infinite loop via i18n `useSuspense: false` workaround (recharts#7463)"
+              "**ci:** Corrige falha do npm ci — regenera o lock file com dependências opcionais exclusivas do Windows ausentes",
+              "**ci:** Torna o postinstall (`electron-rebuild`) condicional — pula em ambientes de CI",
+              "**vite:** Resolve problemas de interoperabilidade CJS com `use-sync-external-store` e `scheduler`",
+              "**ui:** Resolve o loop infinito do recharts via workaround de i18n `useSuspense: false` (recharts#7463)"
             ]
           },
           {
@@ -820,27 +820,27 @@
           {
             "title": "🚀 Novidades",
             "items": [
-              "**release:** Deterministic audited English release notes generator (dry-run) (#26)",
-              "**stlpreview:** Auto-fit camera, fullscreen overlay and clear model (#29)",
-              "**changelog:** Sync in-app changelog automatically on release (#31)"
+              "**release:** Gerador determinístico e auditado de release notes em inglês (dry-run) (#26)",
+              "**stlpreview:** Ajuste automático de câmera, overlay em tela cheia e limpar modelo (#29)",
+              "**changelog:** Sincroniza o changelog in-app automaticamente no release (#31)"
             ]
           },
           {
             "title": "🐛 Correções",
             "items": [
-              "**release:** Correct notes generator normalization and nested commit titles (#27)",
-              "**release:** Scope notes per tag range with root commit and hardened URLs (#28)",
-              "**layout:** Responsive calculator columns for complete mode (#30)",
-              "**changelog:** Localize version cards and polish header controls (#33)",
-              "**layout:** Results sidebar only with space, portal dropdowns, ultrawide shell (#34)",
-              "**gcode:** Do not ignore gcode without a TIME header and support Prusa/Orca (#32, #51)"
+              "**release:** Corrige a normalização do gerador de notes e títulos de commits aninhados (#27)",
+              "**release:** Limita os notes por intervalo de tag com commit raiz e URLs reforçadas (#28)",
+              "**layout:** Colunas responsivas da calculadora no modo completo (#30)",
+              "**changelog:** Localiza os cards de versão e refina os controles do cabeçalho (#33)",
+              "**layout:** Sidebar de resultados apenas com espaço, dropdowns em portal, shell ultrawide (#34)",
+              "**gcode:** Não ignora mais gcode sem cabeçalho TIME e suporta Prusa/Orca (#32, #51)"
             ]
           },
           {
             "title": "🧹 Outros",
             "items": [
-              "**ci:** Pre-commit — gitleaks + .env guardian + AI Bifrost (9afa29b)",
-              "**ci:** Security phase 2 — deepwork CI/CD, pre-commit and scan (fe56338)"
+              "**ci:** Pre-commit — gitleaks + guardião de .env + AI Bifrost (9afa29b)",
+              "**ci:** Fase 2 de segurança — CI/CD deepwork, pre-commit e scan (fe56338)"
             ]
           },
           {
@@ -856,33 +856,33 @@
           {
             "title": "🚀 Novidades",
             "items": [
-              "**ci:** Add AI code review workflow via Bifrost LLM Gateway (8287e51)",
-              "**ci:** Switch AI review to alibaba/open-code-review, fix release artifacts (#11)",
-              "Optimized CI/CD — self-hosted runner, husky-only, AI commit review, i18n (#12)",
-              "Auto-deduct filament + date filters (Issue #16) (#17, #16)",
-              "Phase 2+3 — STL & Dashboard optimization (dead code removal, calc integration) (#20)"
+              "**ci:** Adiciona workflow de revisão de código com IA via Bifrost LLM Gateway (8287e51)",
+              "**ci:** Muda a revisão de IA para alibaba/open-code-review e corrige artefatos de release (#11)",
+              "CI/CD otimizada — runner self-hosted, apenas husky, revisão de commits com IA, i18n (#12)",
+              "Dedução automática de filamento + filtros de data (Issue #16) (#17, #16)",
+              "Fase 2+3 — otimização de STL e Dashboard (remoção de código morto, integração com a calculadora) (#20)"
             ]
           },
           {
             "title": "🐛 Correções",
             "items": [
-              "**changelog:** Sort versions by semver + add v1.9.1 entry (ffc68bb)",
-              "Safety Sprint — security & quality hardening (#19)",
-              "**release:** Remove [skip ci] from release commit (#21)",
-              "**release:** Push tag only, use release branch + PR for version bump (#22)",
-              "**release:** Standardize protected and idempotent pipeline (#23)"
+              "**changelog:** Ordena versões por semver + adiciona entrada v1.9.1 (ffc68bb)",
+              "Sprint de Segurança — endurecimento de segurança e qualidade (#19)",
+              "**release:** Remove [skip ci] do commit de release (#21)",
+              "**release:** Envia apenas a tag e usa branch de release + PR para o bump de versão (#22)",
+              "**release:** Padroniza pipeline protegida e idempotente (#23)"
             ]
           },
           {
             "title": "🧹 Outros",
             "items": [
-              "Translate missing pt-BR keys, remove stale web/ and desktop/ copies (cc5b0e9)"
+              "Traduz chaves pt-BR ausentes e remove cópias obsoletas de web/ e desktop/ (cc5b0e9)"
             ]
           },
           {
             "title": "🤖 CI/CD",
             "items": [
-              "Remove themis review, add opencode github integration (#13)"
+              "Remove a revisão do themis e adiciona integração opencode github (#13)"
             ]
           },
           {
@@ -898,12 +898,12 @@
           {
             "title": "🎨 Visual Polish & Mobile",
             "items": [
-              "**Tutorial repositioned**: removed Floating UI, fixed card positioning (no drift)",
-              "**MobileBottomBar**: no horizontal scroll, flex-1 layout, z-50 above section nav",
-              "**SectionNav**: full page height, 'Seções' title, subtle borders",
-              "**QuickStartBanner**: dismissable (X button), compacted",
-              "**ResultsPanel**: compressed mobile padding",
-              "**Dual bottom bars**: main tabs + section nav, overflow-x-hidden"
+              "**Tutorial reposicionado**: removido Floating UI, posicionamento do card corrigido (sem drift)",
+              "**MobileBottomBar**: sem scroll horizontal, layout flex-1, z-50 acima da nav de seção",
+              "**SectionNav**: altura total da página, título 'Seções', bordas sutis",
+              "**QuickStartBanner**: dispensável (botão X), compactado",
+              "**ResultsPanel**: padding mobile comprimido",
+              "**Barras inferiores duplas**: abas principais + nav de seção, overflow-x-hidden"
             ]
           },
           {
@@ -926,8 +926,8 @@
           {
             "title": "📦 Auto-Update",
             "items": [
-              "**latest.yml** now included in GitHub releases — auto-updater finds updates",
-              "**Blockmap** for delta updates"
+              "**latest.yml** agora incluído nos releases do GitHub — o auto-updater encontra atualizações",
+              "**Blockmap** para atualizações delta"
             ]
           }
         ]
@@ -939,27 +939,27 @@
           {
             "title": "🚀 Novidades",
             "items": [
-              "**ui:** Usability improvements — tooltips, quick mode labels, tutorial overhaul (72720a4)",
-              "**ui:** Accessibility and i18n fixes (1e30bc0)",
-              "**ui:** Quick Start, Empty States, Scroll, Keyboard Shortcuts (80c2f29)"
+              "**ui:** Melhorias de usabilidade — tooltips, rótulos do modo rápido, reformulação do tutorial (72720a4)",
+              "**ui:** Correções de acessibilidade e i18n (1e30bc0)",
+              "**ui:** Início Rápido, Estados Vazios, Scroll, Atalhos de Teclado (80c2f29)"
             ]
           },
           {
             "title": "🐛 Correções",
             "items": [
-              "**release:** Use bash array for artifact upload (a719447)",
-              "**ui:** Resolve 5 audit bugs — tutorial navigation, H1, touch targets, export (5b032ca)",
-              "**ui:** Tutorial spotlight positioning + remaining touch targets (5d6b8ae)",
-              "**ui:** Remaining touch targets in SectionNav + MobileBottomBar (87e1cd9)",
-              "**ui:** Min-h-[44px] in SectionNav buttons (d875147)",
-              "Lint error in useKeyboardShortcuts + enforce CI/CD gate in AGENTS.md (60a72b1)",
-              "Type error document.querySelector().click() → cast to HTMLElement (61ebfab)"
+              "**release:** Usa array bash para upload de artefatos (a719447)",
+              "**ui:** Resolve 5 bugs de auditoria — navegação do tutorial, H1, alvos de toque, exportação (5b032ca)",
+              "**ui:** Posicionamento do spotlight do tutorial + alvos de toque restantes (5d6b8ae)",
+              "**ui:** Alvos de toque restantes na SectionNav + MobileBottomBar (87e1cd9)",
+              "**ui:** Min-h-[44px] nos botões da SectionNav (d875147)",
+              "Erro de lint em useKeyboardShortcuts + aplica o gate de CI/CD no AGENTS.md (60a72b1)",
+              "Erro de tipo document.querySelector().click() → cast para HTMLElement (61ebfab)"
             ]
           },
           {
             "title": "📖 Documentação",
             "items": [
-              "Add RELEASE.md with step-by-step release process (01d42fb)"
+              "Adiciona RELEASE.md com o processo de release passo a passo (01d42fb)"
             ]
           },
           {
@@ -982,7 +982,7 @@
           {
             "title": "🐛 Correções",
             "items": [
-              "**release:** Use bash array for artifact upload (a719447)"
+              "**release:** Usa array bash para upload de artefatos (a719447)"
             ]
           },
           {
@@ -1007,23 +1007,23 @@
           {
             "title": "🎨 UI/UX",
             "items": [
-              "Bifrost redesign: flat surfaces, no glassmorphism",
-              "Light/dark theme on web",
-              "Rectangular badges (6px), reduced border-radius (14px)",
-              "Unified CSS variables system"
+              "Redesign Bifrost: superfícies planas, sem glassmorphism",
+              "Tema claro/escuro na web",
+              "Badges retangulares (6px), border-radius reduzido (14px)",
+              "Sistema unificado de variáveis CSS"
             ]
           },
           {
             "title": "🔧 Technical",
             "items": [
-              "Unified codebase in a monorepo (`src/shared/` + `src/platform/`)",
-              "Git migrated to root (history preserved)",
-              "`web/` and `desktop/` kept for historical reference"
+              "Base de código unificada em um monorepo (`src/shared/` + `src/platform/`)",
+              "Git migrado para a raiz (histórico preservado)",
+              "`web/` e `desktop/` mantidos como referência histórica"
             ]
           },
           {
             "title": "✅ Tests",
-            "items": ["417 tests, 36/36 files passing", "Coverage >80%"]
+            "items": ["417 testes, 36/36 arquivos passando", "Cobertura >80%"]
           }
         ]
       },

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -725,7 +725,7 @@
     "versions": [
       {
         "version": "1.11.0",
-        "date": "",
+        "date": "2026-09-06",
         "sections": [
           {
             "title": "🚀 Novidades",
@@ -769,7 +769,7 @@
       },
       {
         "version": "1.10.0",
-        "date": "",
+        "date": "2026-08-24",
         "sections": [
           {
             "title": "🚀 Novidades",
@@ -794,7 +794,7 @@
       },
       {
         "version": "1.9.3",
-        "date": "",
+        "date": "2026-08-21",
         "sections": [
           {
             "title": "🚀 Novidades",
@@ -831,7 +831,7 @@
       },
       {
         "version": "1.9.2",
-        "date": "",
+        "date": "2026-07-31",
         "sections": [
           {
             "title": "🚀 Novidades",
@@ -977,7 +977,7 @@
       },
       {
         "version": "1.8.1",
-        "date": "",
+        "date": "2026-06-29",
         "sections": []
       },
       {
@@ -1072,7 +1072,7 @@
       },
       {
         "version": "1.6.0",
-        "date": "2026-06-27",
+        "date": "2026-06-28",
         "sections": [
           {
             "title": "✨ Novo",

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -735,9 +735,11 @@
             "items": [
               "**sync:** Add text label to DataSyncButton for better visibility (a6da01d)",
               "UI/UX improvements — STL support estimation, Resin preview, safety fixes (#57)",
-              "**calc:** Exibe lucro por hora (profit/hr) FDM+Resina (#77)",
-              "**products:** Cadastro produtos + vendido + CSV + sync (#78)",
-              "**estimators:** Modos simple/advanced + G-code opcional (#83)"
+              "**calc:** Show profit/hr for FDM + Resin (#77)",
+              "**products:** Product registration + sold + CSV + sync (#78)",
+              "**estimators:** Simple/advanced modes + optional G-code (#83)",
+              "**gcode:** Bambu/Klipper time headers + fallback by moves via `timeSource` HEADER/APPROXIMATE, first-wins cascade Cura > Prusa/Orca > Bambu > Klipper (#86, closes #84)",
+              "**calc:** Editable sale price (display-local BRL override) + calculator→product bridge with toast/event and pt-BR/en-US i18n (#87, closes #85)"
             ]
           },
           {
@@ -745,11 +747,27 @@
             "items": [
               "**ci:** Remove v1.10.0 exclusion and sync changelog (7794266)",
               "**dashboard:** Replace React.lazy with static recharts imports to fix #7463 crash (#7463)",
-              "**3mf:** Segue p:path da production extension e corrige volume 3x maior (#72)",
-              "**estimators:** Casca por area de superficie e fisica da extrusao no… (#73)",
-              "**release:** Windows exe + auto-update resiliente (#76)",
+              "**3mf:** Follow p:path from the production extension and fix 3x larger volume (#72)",
+              "**estimators:** Surface-area shell and extrusion physics in… (#73)",
+              "**release:** Windows exe + resilient auto-update (#76)",
               "**release:** Join --body into single quoted string in release PR step (#79)",
-              "**estimators:** Espessura de casca e média ponderada, não soma (#82)"
+              "**estimators:** Shell thickness and weighted average, not the sum (#82)",
+              "**gcode:** Dedup parsers, single-source 50MB cap, unified time/temperature helpers, centralized validation, 1-decimal rounding, i18n doc+tooltip (`gcodeEPathsNote` pt-BR) (#88)"
+            ]
+          },
+          {
+            "title": "⬆️ Dependências",
+            "items": [
+              "Bump electron 43.4.1 → 44.1.1 (#62)",
+              "Bump @react-pdf/renderer 4.6.1 → 4.9.0 (#64)",
+              "Bump lucide-react 1.33.0 → 1.39.0 (#66)",
+              "Bump lint-staged 17.3.0 → 17.4.1 (#65)",
+              "Bump @vitejs/plugin-react 6.1.0 → 6.1.1 (#67)",
+              "Bump @testing-library/react 16.3.2 → 16.3.3 (#58)",
+              "Bump @types/node 26.2.0 → 26.4.1 (#59)",
+              "Bump @types/react-dom 19.2.4 → 19.2.5 (#60)",
+              "Bump pantheon-opencode 1.3.6 → 1.4.3 (#61)",
+              "Bump anomalyco/opencode/github action (#63)"
             ]
           },
           {
@@ -815,14 +833,13 @@
               "**layout:** Responsive calculator columns for complete mode (#30)",
               "**changelog:** Localize version cards and polish header controls (#33)",
               "**layout:** Results sidebar only with space, portal dropdowns, ultrawide shell (#34)",
-              "**gcode:** Não ignora gcode sem TIME header e suporta Prusa/Orca (#32, #51)",
-              "**gcode:** não ignora gcode sem TIME header e suporta formato Prusa/Orca (closes #32) — remove gate silencioso `if(printTimeMinutes>0)` em `StlPreview.tsx:242`, parser `d/h/m/s` (`1h 23m 45s`/`2d 5h`/`45m 30s`) em `gcodeParser.ts`, `geometry: BufferGeometry | null`, `setGeometry(null)` no branch GCODE, drop zone permanece visível (`!modelInfo?.geometry`), botão `stl.clear` para GCODE, 13 testes novos (7 parser + 6 StlPreview), 893/893 passing, lint/typecheck clean, Themis PASS_WITH_NOTES resolvido"
+              "**gcode:** Do not ignore gcode without a TIME header and support Prusa/Orca (#32, #51)"
             ]
           },
           {
             "title": "🧹 Outros",
             "items": [
-              "**ci:** Pre-commit — gitleaks + guardião .env + AI Bifrost (9afa29b)",
+              "**ci:** Pre-commit — gitleaks + .env guardian + AI Bifrost (9afa29b)",
               "**ci:** Security phase 2 — deepwork CI/CD, pre-commit and scan (fe56338)"
             ]
           },
@@ -841,7 +858,7 @@
             "items": [
               "**ci:** Add AI code review workflow via Bifrost LLM Gateway (8287e51)",
               "**ci:** Switch AI review to alibaba/open-code-review, fix release artifacts (#11)",
-              "CI/CD otimizado — self-hosted runner, husky-only, AI commit review, i18n (#12)",
+              "Optimized CI/CD — self-hosted runner, husky-only, AI commit review, i18n (#12)",
               "Auto-deduct filament + date filters (Issue #16) (#17, #16)",
               "Phase 2+3 — STL & Dashboard optimization (dead code removal, calc integration) (#20)"
             ]
@@ -853,7 +870,7 @@
               "Safety Sprint — security & quality hardening (#19)",
               "**release:** Remove [skip ci] from release commit (#21)",
               "**release:** Push tag only, use release branch + PR for version bump (#22)",
-              "**release:** Padronizar pipeline protegido e idempotente (#23)"
+              "**release:** Standardize protected and idempotent pipeline (#23)"
             ]
           },
           {
@@ -990,23 +1007,23 @@
           {
             "title": "🎨 UI/UX",
             "items": [
-              "Redesign Bifrost: superfícies planas, sem glassmorphism",
-              "Tema claro/escuro no web",
-              "Badges retangulares (6px), border-radius reduzido (14px)",
-              "Sistema de CSS variables unificado"
+              "Bifrost redesign: flat surfaces, no glassmorphism",
+              "Light/dark theme on web",
+              "Rectangular badges (6px), reduced border-radius (14px)",
+              "Unified CSS variables system"
             ]
           },
           {
-            "title": "🔧 Técnico",
+            "title": "🔧 Technical",
             "items": [
-              "Codebase unificada em monorepo (`src/shared/` + `src/platform/`)",
-              "Git migrado para raiz (história preservada)",
-              "`web/` e `desktop/` mantidos para referência histórica"
+              "Unified codebase in a monorepo (`src/shared/` + `src/platform/`)",
+              "Git migrated to root (history preserved)",
+              "`web/` and `desktop/` kept for historical reference"
             ]
           },
           {
-            "title": "✅ Testes",
-            "items": ["417 testes, 36/36 arquivos passando", "Cobertura >80%"]
+            "title": "✅ Tests",
+            "items": ["417 tests, 36/36 files passing", "Coverage >80%"]
           }
         ]
       },


### PR DESCRIPTION
## Resumo

Corrige datas de releases no changelog e padroniza o suporte a idiomas (EN canônico + PT-BR).

## Mudanças

### Changelog
- **`fix(changelog)`:** preenche datas faltantes via `published_at` do GitHub
- **`fix(changelog)`:** prefere data do commit/tag sobre `published_at` quando disponível
- **`chore(changelog)`:** gera fonte canônica em inglês (EN) e resincroniza traduções

### i18n
- **`chore(i18n)`:** traduz itens do changelog para PT-BR
- **`fix(i18n)`:** preserva traduções PT-BR existentes ao re-sincronizar com EN
- **`fix(i18n)`:** localiza `aria-labels` do `OnboardingModal`

### Releases (backfill)
- Backfill de releases no GitHub via script (`changelog_release_dates.ts`) para datas consistentes

## Notas
- 86 testes, 1187 assertions — todos passando ✅
- Sem quebras de API; mudanças são internas ao changelog e locale files