### PR TITLE
feat(release): automated canonical release notes

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -66,6 +66,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout immutable tag commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -140,6 +141,21 @@ jobs:
           merge-multiple: true
           path: dist-electron
 
+      - name: Generate and validate publication notes
+        id: release-notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          rm -rf release-notes-output
+          node scripts/release-notes.mjs --release "$TAG" \
+            --notes-file release-notes.md
+          node scripts/validate-release-notes.mjs \
+            --file release-notes.md --tag "$TAG"
+
       - name: Create or repair GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -180,8 +196,17 @@ jobs:
                  "$TAG_SHA; preserving release." >&2
                exit 1
              }
-             gh release edit "$TAG" --repo "$REPOSITORY" --title "$TAG" \
-               --target "$TAG_SHA"
+            PREVIOUS_BODY=release-publish-diagnostics/previous-release-body.md
+            jq -r '.body // ""' "$RELEASE_JSON" >"$PREVIOUS_BODY"
+            if [ -f release-notes.md ] \
+              && [ "$(cat "$PREVIOUS_BODY")" = "$(cat release-notes.md)" ]; then
+              echo "Release body already matches release-notes.md; skipping."
+              gh release edit "$TAG" --repo "$REPOSITORY" --title "$TAG" \
+                --target "$TAG_SHA"
+            else
+              gh release edit "$TAG" --repo "$REPOSITORY" --title "$TAG" \
+                --target "$TAG_SHA" --notes-file release-notes.md
+            fi
             EXISTING_ASSETS=release-publish-diagnostics/assets.json
              gh api --paginate --slurp \
                 "repos/$REPOSITORY/releases/$RELEASE_ID/assets?per_page=100" \
@@ -214,7 +239,8 @@ jobs:
             done
            else
              gh release create "$TAG" --repo "$REPOSITORY" --title "$TAG" \
-               --generate-notes --target "$TAG_SHA" "${UPLOAD_ITEMS[@]}"
+               --notes-file release-notes.md --target "$TAG_SHA" \
+               "${UPLOAD_ITEMS[@]}"
            fi
 
       - name: Validate published tag, release, and assets
@@ -346,6 +372,10 @@ jobs:
             SHA256SUMS
             release-publish-diagnostics/
             release-validation-diagnostics/
+            release-notes.md
+            release-notes-output/inventory.json
+            release-notes-output/audit.json
+            release-notes-output/release-notes.diff
 
       - name: Remove release branch after confirmed publication
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ yarn-debug.log*
 *.env
 *.secret
 *.pem
+
+# Release notes automation — local backfill snapshots and generated output
+release-notes-snapshots/
+release-notes-output/
+

--- a/README.md
+++ b/README.md
@@ -277,12 +277,41 @@ O deploy da web é **automático** via GitHub Actions (`ci-cd.yml`) em todo push
 
 ### Desktop — GitHub Releases
 
-O release é **manual** via GitHub Actions (`release.yml`):
+O release é um processo de **duas fases** (preparação + publicação), detalhado em [RELEASE.md](RELEASE.md).
 
-1. Dispare o workflow **Release** no GitHub
-2. Escolha o bump (auto/patch/minor/major)
-3. O workflow: bump version → build ambos → electron-builder (Linux) → commit/tag → cria GitHub Release com artifacts
-4. Para Windows, execute `npx electron-builder --win` localmente
+**Preparação** (GitHub Actions):
+
+1. Em _Actions → Release preparation → Run workflow_, selecione `main` e o bump desejado
+2. O workflow cria `release/vX.Y.Z`, atualiza versão com _changelogen 0.6.2_, sincroniza o changelog in-app, roda lint/typecheck/testes/build e abre um PR para `main`
+3. Revise e faça o merge do PR
+
+**Publicação** (tag local):
+
+```bash
+git fetch origin main && git switch main && git pull --ff-only origin main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+O workflow _Release publication_ valida a tag, cria a GitHub Release com nome `Open3DCalc vX.Y.Z` e anexa os artefatos Windows/Linux. A branch `release/vX.Y.Z` é removida após confirmação.
+
+### Notas de release automáticas
+
+As notas de cada GitHub Release usam um **formato canônico** renderizado por `scripts/release-notes.mjs` (`renderPublication()`) e validado por um gate _fail-closed_ antes da publicação:
+
+```bash
+npm run release:notes:validate -- --file release-notes.md --tag vX.Y.Z
+```
+
+O workflow _Release publication_ gera o corpo com `--notes-file` (em vez de `--generate-notes`) e só publica se o validador aprovar. As seções emoji têm ordem fixa: 🚀 Features, 🐛 Fixes, 🧹 Chores, 📦 Dependencies, 🤖 CI/CD e ❤️ Contributors (além de 📚 Documentation, 🔒 Security e ⚠️ Breaking Changes quando houver conteúdo).
+
+O backfill de releases antigas é idempotente e reversível por snapshot local (`release-notes-snapshots/`):
+
+```bash
+node scripts/backfill-release-notes.mjs --dry-run --all
+node scripts/backfill-release-notes.mjs --apply --all
+node scripts/backfill-release-notes.mjs --restore vX.Y.Z
+```
 
 ---
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,39 @@ Notes are English Markdown with the sections **Highlights**, **Features**,
 omitted). External text is escaped and length-limited; it is data only and is
 never executed.
 
+## Canonical publication format
+
+`renderPublication(catalog, repository, { tag, previousTag })` renders the body
+actually published to GitHub. It is English, deterministic (byte-identical
+across re-runs), and uses the `## What's Changed` wrapper with emoji `###`
+sections in this fixed order: **🚀 Features**, **🐛 Fixes**, **🧹 Chores**,
+**📦 Dependencies**, **🤖 CI/CD**, optional **📚 Documentation**,
+**🔒 Security**, **⚠️ Breaking Changes**, and **❤️ Contributors**. Empty
+sections are omitted; Downloads/Checksums are never published (they duplicate
+the assets and `SHA256SUMS`). Items are
+`- <title> ([#NN](https://github.com/<owner>/<repo>/pull/NN))` when a PR is
+known, otherwise `- <title> (commit <sha7>)`. Contributors are deduplicated
+`@login` handles, excluding bots and `Unknown`. The body ends with a bold
+`**Full Changelog**: <url>` line (never a heading).
+
+Generate the body with:
+
+```
+node scripts/release-notes.mjs --release vX.Y.Z --notes-file release-notes.md
+```
+
+Validate it (also available as `npm run release:notes:validate`):
+
+```
+node scripts/validate-release-notes.mjs --file release-notes.md --tag vX.Y.Z
+node scripts/validate-release-notes.mjs --release vX.Y.Z   # fetch via gh api
+```
+
+The validator fails closed on a wrong wrapper, an unknown/out-of-order emoji
+section, malformed PR links, a missing or duplicated `**Full Changelog**`, a
+Downloads/Checksums mention, non-bullet content, or audit artifacts
+(`# Release notes`, `— PR #`, inline author links).
+
 ## Evidence and attribution
 
 The inventory is sourced from paginated releases, tags, commits, closed pull

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "preview:web": "vite preview --config vite.web.config.ts",
     "test": "vitest",
     "test:run": "vitest run",
+    "release:notes:validate": "node scripts/validate-release-notes.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "verify:electron": "node scripts/verify-electron-imports.mjs",
     "typecheck:electron": "tsc -p electron/tsconfig.json --noEmit",

--- a/scripts/__tests__/backfill-release-notes.test.ts
+++ b/scripts/__tests__/backfill-release-notes.test.ts
@@ -1,0 +1,334 @@
+import { mkdtemp, readFile, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertSafeGhCommand,
+  bodySha256,
+  diffLines,
+  formatDiff,
+  main,
+  normalizeBody,
+  parseArgs,
+} from "../backfill-release-notes.mjs";
+
+const REPO = "ils15/open3dcalc";
+
+const canonicalBody = (tag) =>
+  [
+    "## What's Changed",
+    "",
+    "### 🚀 Features",
+    "",
+    `- feat: thing for ${tag} ([#1](https://github.com/${REPO}/pull/1))`,
+    "",
+    "### ❤️ Contributors",
+    "",
+    "@alice",
+    "",
+    `**Full Changelog**: https://github.com/${REPO}/compare/v1.0.0...${tag}`,
+    "",
+  ].join("\n");
+
+const oldBody = (tag) =>
+  [`## ${tag}`, "", "- legacy hand-written note", ""].join("\n");
+
+/** Build a hermetic fake GitHub/gh environment. */
+const harness = async (initial: Record<string, string>) => {
+  const store = new Map(Object.entries(initial));
+  const ghCalls: string[][] = [];
+  const snapshotDir = await mkdtemp(resolve(tmpdir(), "backfill-snap-"));
+  const runGh = vi.fn(async (args: string[]) => {
+    ghCalls.push(args);
+    if (args[0] === "release" && args[1] === "edit") {
+      const tag = args[2];
+      const at = args.indexOf("--notes-file");
+      store.set(tag, await readFile(args[at + 1], "utf8"));
+    }
+    return "";
+  });
+  const deps = {
+    listReleases: async () =>
+      [...store.entries()].map(([tag, body]) => ({ tag, body })),
+    renderBody: async (_repository: string, tag: string) => canonicalBody(tag),
+    runGh,
+    snapshotDir,
+    now: () => "2026-09-10T00:00:00.000Z",
+  };
+  return { deps, ghCalls, runGh, snapshotDir, store };
+};
+
+describe("parseArgs", () => {
+  it("parses --dry-run --all and --apply --release", () => {
+    expect(parseArgs(["--dry-run", "--all"])).toMatchObject({
+      mode: "dry-run",
+      all: true,
+    });
+    expect(parseArgs(["--apply", "--release", "v1.11.0"])).toMatchObject({
+      mode: "apply",
+      release: "v1.11.0",
+    });
+  });
+
+  it("parses restore with and without an explicit snapshot path", () => {
+    expect(parseArgs(["--restore", "v1.11.0"])).toMatchObject({
+      mode: "restore",
+      restore: "v1.11.0",
+      snapshotPath: undefined,
+    });
+    expect(
+      parseArgs(["--restore", "v1.11.0", "--from-snapshot", "/tmp/s.json"]),
+    ).toMatchObject({
+      mode: "restore",
+      restore: "v1.11.0",
+      snapshotPath: resolve("/tmp/s.json"),
+    });
+    // --from-snapshot with no value falls back to the default location.
+    expect(
+      parseArgs(["--restore", "v1.11.0", "--from-snapshot"]),
+    ).toMatchObject({
+      mode: "restore",
+      snapshotPath: undefined,
+    });
+  });
+
+  it("rejects unknown flags, missing scope, and conflicting modes", () => {
+    expect(() => parseArgs(["--nope", "--all"])).toThrow("Unknown flag");
+    expect(() => parseArgs(["--dry-run"])).toThrow("required");
+    expect(() => parseArgs(["--dry-run", "--apply", "--all"])).toThrow(
+      "either --dry-run or --apply",
+    );
+    expect(() =>
+      parseArgs(["--dry-run", "--all", "--release", "v1.0.0"]),
+    ).toThrow("either --all or --release");
+    expect(() => parseArgs(["--apply", "--release", "1.0.0"])).toThrow(
+      "vX.Y.Z",
+    );
+    expect(() => parseArgs(["--restore", "v1.0.0", "--apply"])).toThrow(
+      "restore",
+    );
+  });
+});
+
+describe("body hashing, normalization and diff", () => {
+  it("hashes equivalent bodies identically regardless of trailing newlines", () => {
+    const body = canonicalBody("v1.1.0");
+    expect(bodySha256(body)).toBe(bodySha256(`${body}\n\n  `));
+    expect(normalizeBody("a\r\nb\r\n")).toBe("a\nb");
+  });
+
+  it("produces an add/remove/context line diff", () => {
+    const entries = diffLines("a\nb\nc", "a\nB\nc");
+    expect(entries).toEqual([
+      { type: "context", text: "a" },
+      { type: "remove", text: "b" },
+      { type: "add", text: "B" },
+      { type: "context", text: "c" },
+    ]);
+    expect(formatDiff(entries)).toBe("  a\n- b\n+ B\n  c");
+  });
+});
+
+describe("assertSafeGhCommand", () => {
+  it("allows release edit and api, blocks destructive/latest operations", () => {
+    expect(() =>
+      assertSafeGhCommand(["release", "edit", "v1.0.0", "--notes-file", "x"]),
+    ).not.toThrow();
+    expect(() =>
+      assertSafeGhCommand(["api", "repos/o/r/releases"]),
+    ).not.toThrow();
+    for (const args of [
+      ["release", "delete", "v1.0.0"],
+      ["release", "upload", "v1.0.0", "a.zip"],
+      ["release", "download", "v1.0.0"],
+      ["release", "edit", "v1.0.0", "--target", "main"],
+      ["api", "repos/o/r/releases/latest"],
+    ])
+      expect(() => assertSafeGhCommand(args)).toThrow();
+  });
+});
+
+describe("main --dry-run", () => {
+  it("never mutates: no gh call, no snapshot, but reports hashes and diff", async () => {
+    const { deps, ghCalls, snapshotDir } = await harness({
+      "v1.10.0": oldBody("v1.10.0"),
+      "v1.11.0": oldBody("v1.11.0"),
+    });
+    const result = await main(["--dry-run", "--all"], deps);
+    expect(result.mode).toBe("dry-run");
+    expect(result.results).toHaveLength(2);
+    expect(ghCalls).toHaveLength(0);
+    for (const entry of result.results) {
+      expect(entry.changed).toBe(true);
+      expect(entry.currentSha256).not.toBe(entry.canonicalSha256);
+      expect(entry.canonical).toContain("## What's Changed");
+      expect(entry.diff.some((line) => line.type === "add")).toBe(true);
+    }
+    await expect(
+      readFile(resolve(snapshotDir, "v1.11.0.json")),
+    ).rejects.toThrow();
+  });
+
+  it("scopes a single release with --release and marks it unchanged when identical", async () => {
+    const same = canonicalBody("v1.11.0");
+    const { deps, ghCalls } = await harness({
+      "v1.10.0": oldBody("v1.10.0"),
+      "v1.11.0": same,
+    });
+    const result = await main(["--dry-run", "--release", "v1.11.0"], deps);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].changed).toBe(false);
+    expect(ghCalls).toHaveLength(0);
+  });
+
+  it("throws when --release points to an unknown tag", async () => {
+    const { deps } = await harness({ "v1.11.0": oldBody("v1.11.0") });
+    await expect(
+      main(["--dry-run", "--release", "v9.9.9"], deps),
+    ).rejects.toThrow("not found");
+  });
+});
+
+describe("main --apply", () => {
+  it("snapshots the previous body and edits the release with the canonical body", async () => {
+    const { deps, ghCalls, runGh, snapshotDir } = await harness({
+      "v1.11.0": oldBody("v1.11.0"),
+    });
+    const result = await main(["--apply", "--release", "v1.11.0"], deps);
+    expect(result.results[0].action).toBe("applied");
+    expect(runGh).toHaveBeenCalledTimes(1);
+    expect(ghCalls[0]).toEqual([
+      "release",
+      "edit",
+      "v1.11.0",
+      "--notes-file",
+      expect.any(String),
+      "--title",
+      "Open3DCalc v1.11.0",
+    ]);
+    const snapshot = JSON.parse(
+      await readFile(resolve(snapshotDir, "v1.11.0.json"), "utf8"),
+    );
+    expect(snapshot).toMatchObject({
+      tag: "v1.11.0",
+      previousBody: oldBody("v1.11.0"),
+      newBody: canonicalBody("v1.11.0"),
+      sha256: bodySha256(canonicalBody("v1.11.0")),
+      timestamp: "2026-09-10T00:00:00.000Z",
+    });
+    expect(result.results[0].snapshot).toBe(
+      resolve(snapshotDir, "v1.11.0.json"),
+    );
+  });
+
+  it("is idempotent: a second apply is a no-op and writes no new snapshot", async () => {
+    const { deps, runGh, snapshotDir, store } = await harness({
+      "v1.10.0": oldBody("v1.10.0"),
+      "v1.11.0": oldBody("v1.11.0"),
+    });
+    const first = await main(["--apply", "--all"], deps);
+    expect(first.results.every((entry) => entry.action === "applied")).toBe(
+      true,
+    );
+    expect(runGh).toHaveBeenCalledTimes(2);
+    // gh call mutated only the stored bodies, never tags/assets/latest.
+    expect(store.get("v1.11.0")).toBe(canonicalBody("v1.11.0"));
+
+    const second = await main(["--apply", "--all"], deps);
+    expect(second.results.every((entry) => entry.action === "skipped")).toBe(
+      true,
+    );
+    expect(runGh).toHaveBeenCalledTimes(2);
+    // The skipped release keeps the snapshot from the first run.
+    const snapshot = JSON.parse(
+      await readFile(resolve(snapshotDir, "v1.10.0.json"), "utf8"),
+    );
+    expect(snapshot.previousBody).toBe(oldBody("v1.10.0"));
+  });
+
+  it("reports but never applies a degenerate canonical body", async () => {
+    const { deps, runGh } = await harness({ "v1.11.0": oldBody("v1.11.0") });
+    const degraded = {
+      ...deps,
+      renderBody: async () =>
+        "## What's Changed\n\n**Full Changelog**: https://github.com/ils15/open3dcalc/commits/v1.11.0\n",
+    };
+    const result = await main(["--apply", "--release", "v1.11.0"], degraded);
+    expect(result.results[0]).toMatchObject({
+      renderable: false,
+      action: "skipped-unsafe",
+    });
+    expect(result.results[0].error).toContain("degenerate");
+    expect(runGh).not.toHaveBeenCalled();
+  });
+
+  it("skips an unsafe release in --all but still applies the safe ones", async () => {
+    const { deps, runGh, store } = await harness({
+      "v1.10.0": oldBody("v1.10.0"),
+      "v1.11.0": oldBody("v1.11.0"),
+    });
+    const mixed = {
+      ...deps,
+      renderBody: async (_repository: string, tag: string) =>
+        tag === "v1.10.0"
+          ? "## What's Changed\n\n**Full Changelog**: https://x\n"
+          : canonicalBody(tag),
+    };
+    const result = await main(["--apply", "--all"], mixed);
+    expect(result.results.map((entry) => entry.action)).toEqual([
+      "skipped-unsafe",
+      "applied",
+    ]);
+    expect(runGh).toHaveBeenCalledTimes(1);
+    expect(store.get("v1.10.0")).toBe(oldBody("v1.10.0"));
+    expect(store.get("v1.11.0")).toBe(canonicalBody("v1.11.0"));
+  });
+});
+
+describe("main --restore", () => {
+  it("restores the previous body from the default snapshot path", async () => {
+    const { deps, runGh, snapshotDir, store } = await harness({
+      "v1.11.0": oldBody("v1.11.0"),
+    });
+    await mkdir(snapshotDir, { recursive: true });
+    await writeFile(
+      resolve(snapshotDir, "v1.11.0.json"),
+      JSON.stringify({
+        tag: "v1.11.0",
+        previousBody: oldBody("v1.11.0"),
+        newBody: canonicalBody("v1.11.0"),
+        sha256: "x",
+        timestamp: "t",
+      }),
+      "utf8",
+    );
+    store.set("v1.11.0", canonicalBody("v1.11.0"));
+    const result = await main(["--restore", "v1.11.0"], deps);
+    expect(result).toMatchObject({
+      mode: "restore",
+      tag: "v1.11.0",
+      snapshot: resolve(snapshotDir, "v1.11.0.json"),
+    });
+    expect(runGh).toHaveBeenCalledTimes(1);
+    const args = runGh.mock.calls[0][0];
+    expect(args.slice(0, 3)).toEqual(["release", "edit", "v1.11.0"]);
+    expect(args).not.toContain("--title");
+    expect(store.get("v1.11.0")).toBe(oldBody("v1.11.0"));
+  });
+
+  it("honors an explicit --from-snapshot path", async () => {
+    const { deps, runGh, store } = await harness({
+      "v1.11.0": canonicalBody("v1.11.0"),
+    });
+    const dir = await mkdtemp(resolve(tmpdir(), "backfill-explicit-"));
+    const custom = resolve(dir, "custom.json");
+    await writeFile(
+      custom,
+      JSON.stringify({ previousBody: oldBody("v1.11.0") }),
+      "utf8",
+    );
+    await main(["--restore", "v1.11.0", "--from-snapshot", custom], deps);
+    expect(runGh).toHaveBeenCalledTimes(1);
+    expect(store.get("v1.11.0")).toBe(oldBody("v1.11.0"));
+  });
+});

--- a/scripts/__tests__/release-notes.test.ts
+++ b/scripts/__tests__/release-notes.test.ts
@@ -526,7 +526,13 @@ describe("audited release notes", () => {
       "Improvements",
     );
     expect(categoryFor({ commit: { message: "refactor: split module" } })).toBe(
-      "Improvements",
+      "Chores",
+    );
+    expect(categoryFor({ commit: { message: "style: format files" } })).toBe(
+      "Chores",
+    );
+    expect(categoryFor({ commit: { message: "test: add coverage" } })).toBe(
+      "Chores",
     );
     expect(categoryFor({ commit: { message: "ci: run checks" } })).toBe(
       "CI/CD",
@@ -542,6 +548,11 @@ describe("audited release notes", () => {
     );
     expect(
       categoryFor({ commit: { message: "chore(release): cut v1.9.2" } }),
+    ).toBe("Chores");
+    expect(
+      categoryFor({
+        commit: { message: "chore(ci): bump the workflow action" },
+      }),
     ).toBe("CI/CD");
     expect(
       categoryFor({ commit: { message: "fix(api)!: breaking change" } }),
@@ -552,6 +563,42 @@ describe("audited release notes", () => {
     // Conventional prefixes win over generic keywords in the body/title.
     expect(categoryFor({ title: "feat: fix calculator" })).toBe("Features");
   });
+  it("classifies from the subject, never from prose in the body", () => {
+    // Regression: "breaking intencional" in a PR body must not elevate a
+    // chore(gcode) into Breaking Changes.
+    expect(
+      categoryFor({
+        title: "chore(gcode): dedup parsers, caps e arredondamento",
+        body: "## Resumo\n\nC1 50MB single-source (breaking intencional de limite)",
+      }),
+    ).toBe("Chores");
+    // Only the explicit Conventional Commits footer triggers Breaking.
+    expect(
+      categoryFor({
+        title: "chore(gcode): dedup parsers",
+        body: "BREAKING CHANGE: the 50MB cap now rejects larger files",
+      }),
+    ).toBe("Breaking Changes");
+    // A breaking footer after a plain subject is still honoured.
+    expect(
+      categoryFor({
+        commit: {
+          message: "feat: new api\n\nBREAKING CHANGE: removed legacy mode",
+        },
+      }),
+    ).toBe("Breaking Changes");
+    // Scope wins for dependency chores; the body is irrelevant.
+    expect(
+      categoryFor({
+        title: "chore(deps-dev): bump electron from 43 to 44",
+        body: "Fixes a security issue and breaks nothing",
+      }),
+    ).toBe("Dependencies");
+    // Dependency-bot titles without a Conventional prefix still map.
+    expect(categoryFor({ title: "Bump lodash from 4.17.20 to 4.17.21" })).toBe(
+      "Dependencies",
+    );
+  });
   it("never routes calculator/calculadora to CI/CD", () => {
     // P4: /ci/ matched "calculator" — anchored \bci\b must not.
     expect(categoryFor({ title: "calculator" })).not.toBe("CI/CD");
@@ -561,7 +608,7 @@ describe("audited release notes", () => {
     expect(categoryFor({ title: "add calculator support" })).not.toBe("CI/CD");
     expect(categoryFor({ title: "ci: build pipeline" })).toBe("CI/CD");
     expect(categoryFor({ title: "workflow: publish" })).toBe("CI/CD");
-    expect(categoryFor({ title: "build: package" })).toBe("CI/CD");
+    expect(categoryFor({ title: "build: package" })).toBe("Chores");
   });
   it("scopes --release catalogs to the previous...tag range only", async () => {
     const originalFetch = globalThis.fetch;
@@ -657,13 +704,15 @@ describe("audited release notes", () => {
       // compare API excludes its base (the default-branch root), so the
       // root commit is prepended back onto the scoped commit list and ends
       // up as a commit-only item (no PR association).
+      // Categories sort lexicographically: Chores ("chore: init") precedes
+      // Features, so the commit-only root item leads the list.
       expect(v150.items.map((item) => item.pr?.number)).toEqual([
-        20,
         undefined,
+        20,
       ]);
       expect(v150.items.map((item) => item.title)).toEqual([
-        "feat: v1.5.0 feature",
         "chore: init",
+        "feat: v1.5.0 feature",
       ]);
       expect(v150.items.some((item) => item.sha === oldestSha)).toBe(true);
       expect(v150.items.map((item) => item.title)).not.toContain(

--- a/scripts/__tests__/release-publication.test.ts
+++ b/scripts/__tests__/release-publication.test.ts
@@ -232,6 +232,72 @@ describe("renderPublication", () => {
     expect(first).not.toContain("Downloads");
     expect(first).not.toContain("Checksums");
   });
+
+  it("keeps inline parentheses, plus and hash unescaped in item titles", () => {
+    const markdown = renderPublication(
+      normalize({
+        pullRequests: [
+          {
+            number: 87,
+            title:
+              "feat(calc): preço de venda editável + ponte calculadora→produto (closes #85)",
+            merged: true,
+            user: { login: "alice" },
+          },
+        ],
+      }),
+      REPO,
+      { tag: "v1.1.0", previousTag: "v1.0.0" },
+    );
+    expect(markdown).toContain(
+      "- feat(calc): preço de venda editável + ponte calculadora→produto (closes #85) ([#87](https://github.com/ils15/open3dcalc/pull/87))",
+    );
+    expect(markdown).not.toContain("\\(");
+    expect(markdown).not.toContain("\\)");
+    expect(markdown).not.toContain("\\+");
+    expect(markdown).not.toContain("\\#");
+  });
+
+  it("neutralizes HTML in item titles without escaping the whole subject", () => {
+    const markdown = renderPublication(
+      normalize({
+        commits: [
+          {
+            sha: "abc1234def",
+            commit: { message: "docs: safe text <script>alert(1)</script>" },
+            author: { login: "dave" },
+          },
+        ],
+      }),
+      REPO,
+      { tag: "v1.0.0" },
+    );
+    expect(markdown).not.toContain("<script>");
+    expect(markdown).toContain("safe text");
+  });
+
+  it("uses only the bounded first line of a commit-only message", () => {
+    const subject = `chore(deps): batch update 34 dependencies Major bumps: ${"a".repeat(140)}`;
+    const markdown = renderPublication(
+      normalize({
+        commits: [
+          {
+            sha: "f467375abc",
+            commit: {
+              message: `${subject}\n\n## Body\nmore detail that must never leak`,
+            },
+            author: { login: "dave" },
+          },
+        ],
+      }),
+      REPO,
+      { tag: "v1.0.0" },
+    );
+    const item = markdown.split("\n").find((line) => line.startsWith("- "));
+    expect(item).toBe(`- ${subject.slice(0, 100)} (commit f467375)`);
+    expect(markdown).not.toContain("more detail");
+    expect(markdown).not.toContain("## Body");
+  });
 });
 
 describe("main --notes-file", () => {

--- a/scripts/__tests__/release-publication.test.ts
+++ b/scripts/__tests__/release-publication.test.ts
@@ -1,0 +1,269 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { main, normalize, renderPublication } from "../release-notes.mjs";
+
+const REPO = "ils15/open3dcalc";
+
+// Synthetic catalog exercising every canonical section, a commit-only item,
+// a duplicated contributor, a bot, and an author-less item.
+const catalog = () =>
+  normalize({
+    pullRequests: [
+      {
+        number: 10,
+        title: "feat: add gizmo",
+        merged: true,
+        user: { login: "alice" },
+      },
+      {
+        number: 11,
+        title: "fix: crash on load",
+        merged: true,
+        user: { login: "bob" },
+      },
+      {
+        number: 12,
+        title: "deps: bump vite",
+        merged: true,
+        user: { login: "carol" },
+      },
+      {
+        number: 13,
+        title: "ci: add workflow",
+        merged: true,
+        user: { login: "alice" },
+      },
+    ],
+    commits: [
+      {
+        sha: "aaa1111bbbb",
+        commit: { message: "chore: tidy scripts" },
+        author: { login: "dave" },
+      },
+      {
+        sha: "bbb2222cccc",
+        commit: { message: "refactor: split module" },
+        author: { login: "dave" },
+      },
+      {
+        sha: "ccc3333dddd",
+        commit: { message: "docs: update readme" },
+        author: { login: "erin" },
+      },
+      {
+        sha: "ddd4444eeee",
+        commit: { message: "security: harden input" },
+        author: { login: "frank" },
+      },
+      {
+        sha: "eee5555ffff",
+        commit: { message: "feat!: breaking api" },
+        author: { login: "grace" },
+      },
+      {
+        sha: "fff6666aaaa",
+        commit: { message: "chore: bot noise" },
+        author: { login: "github-actions[bot]" },
+      },
+    ],
+  });
+
+describe("renderPublication", () => {
+  it("renders the canonical wrapper with emoji sections in fixed order", () => {
+    const markdown = renderPublication(catalog(), REPO, {
+      tag: "v1.1.0",
+      previousTag: "v1.0.0",
+    });
+    expect(markdown.split("\n")[0]).toBe("## What's Changed");
+    expect(markdown).toContain("### 🚀 Features");
+    expect(markdown).toContain("### 🐛 Fixes");
+    expect(markdown).toContain("### 🧹 Chores");
+    expect(markdown).toContain("### 📦 Dependencies");
+    expect(markdown).toContain("### 🤖 CI/CD");
+    expect(markdown).toContain("### 📚 Documentation");
+    expect(markdown).toContain("### 🔒 Security");
+    expect(markdown).toContain("### ⚠️ Breaking Changes");
+    expect(markdown).toContain("### ❤️ Contributors");
+    const headings = markdown
+      .split("\n")
+      .filter((line) => line.startsWith("### "))
+      .map((line) => line.slice(4));
+    expect(headings).toEqual([
+      "🚀 Features",
+      "🐛 Fixes",
+      "🧹 Chores",
+      "📦 Dependencies",
+      "🤖 CI/CD",
+      "📚 Documentation",
+      "🔒 Security",
+      "⚠️ Breaking Changes",
+      "❤️ Contributors",
+    ]);
+  });
+
+  it("renders PR links and commit shas in the canonical item format", () => {
+    const markdown = renderPublication(catalog(), REPO, {
+      tag: "v1.1.0",
+      previousTag: "v1.0.0",
+    });
+    expect(markdown).toContain(
+      "- feat: add gizmo ([#10](https://github.com/ils15/open3dcalc/pull/10))",
+    );
+    expect(markdown).toContain(
+      "- deps: bump vite ([#12](https://github.com/ils15/open3dcalc/pull/12))",
+    );
+    expect(markdown).toContain("- chore: tidy scripts (commit aaa1111)");
+    expect(markdown).toContain("- docs: update readme (commit ccc3333)");
+  });
+
+  it("maps refactor/style/chore into the single Chores section, sorted by title", () => {
+    const markdown = renderPublication(catalog(), REPO, {
+      tag: "v1.1.0",
+      previousTag: "v1.0.0",
+    });
+    const chores = markdown
+      .split("### 🧹 Chores\n")[1]
+      .split("\n\n")[0]
+      .split("\n")
+      .filter((line) => line.startsWith("- "));
+    expect(chores).toEqual([
+      "- chore: bot noise (commit fff6666)",
+      "- chore: tidy scripts (commit aaa1111)",
+      "- refactor: split module (commit bbb2222)",
+    ]);
+  });
+
+  it("omits empty sections and the Contributors section when there is no human", () => {
+    const markdown = renderPublication(
+      normalize({
+        commits: [
+          {
+            sha: "abc1234def",
+            commit: { message: "feat: solo" },
+            author: { login: "github-actions[bot]" },
+          },
+        ],
+      }),
+      REPO,
+      { tag: "v1.0.0" },
+    );
+    expect(markdown).toContain("### 🚀 Features");
+    expect(markdown).not.toContain("### 🐛 Fixes");
+    expect(markdown).not.toContain("### 🧹 Chores");
+    expect(markdown).not.toContain("### ❤️ Contributors");
+  });
+
+  it("lists deduplicated human contributors without bots or Unknown", () => {
+    const markdown = renderPublication(catalog(), REPO, {
+      tag: "v1.1.0",
+      previousTag: "v1.0.0",
+    });
+    const contributors = markdown
+      .split("### ❤️ Contributors\n")[1]
+      .split("\n\n")[0]
+      .split("\n")
+      .filter(Boolean);
+    expect(contributors).toEqual([
+      "@alice",
+      "@bob",
+      "@carol",
+      "@dave",
+      "@erin",
+      "@frank",
+      "@grace",
+    ]);
+    expect(markdown).not.toContain("@github-actions");
+    expect(markdown).not.toContain("@Unknown");
+  });
+
+  it("renders the bold Full Changelog line with the compare range", () => {
+    const markdown = renderPublication(catalog(), REPO, {
+      tag: "v1.1.0",
+      previousTag: "v1.0.0",
+    });
+    expect(markdown).toContain(
+      "**Full Changelog**: https://github.com/ils15/open3dcalc/compare/v1.0.0...v1.1.0",
+    );
+    // A bold line, never a heading.
+    expect(markdown.split("\n")).toContain(
+      "**Full Changelog**: https://github.com/ils15/open3dcalc/compare/v1.0.0...v1.1.0",
+    );
+  });
+
+  it("falls back to the commits URL for the first release", () => {
+    const markdown = renderPublication(catalog(), REPO, { tag: "v1.0.0" });
+    expect(markdown).toContain(
+      "**Full Changelog**: https://github.com/ils15/open3dcalc/commits/v1.0.0",
+    );
+  });
+
+  it("escapes hostile titles and the repository path", () => {
+    const markdown = renderPublication(
+      normalize({
+        pullRequests: [
+          {
+            number: 9,
+            title: "fix: escape [bracket] (paren) *star*",
+            merged: true,
+            user: { login: "alice" },
+          },
+        ],
+      }),
+      "ils15/open3dcalc)",
+      { tag: "v1.0.0" },
+    );
+    expect(markdown).toContain("\\[bracket\\]");
+    expect(markdown).toContain("\\*star\\*");
+    expect(markdown).toContain("https://github.com/ils15/open3dcalc\\)/pull/9");
+  });
+
+  it("is byte-identical across re-runs and never emits Downloads/Checksums", () => {
+    const first = renderPublication(catalog(), REPO, {
+      tag: "v1.1.0",
+      previousTag: "v1.0.0",
+    });
+    const second = renderPublication(catalog(), REPO, {
+      tag: "v1.1.0",
+      previousTag: "v1.0.0",
+    });
+    expect(first).toBe(second);
+    expect(first).not.toContain("Downloads");
+    expect(first).not.toContain("Checksums");
+  });
+});
+
+describe("main --notes-file", () => {
+  it("writes the canonical publication body and keeps the audit artifacts", async () => {
+    const output = await mkdtemp(resolve(tmpdir(), "release-publication-"));
+    const notesFile = resolve(output, "publication.md");
+    const audit = await main([
+      "--all",
+      "--input",
+      "scripts/__fixtures__/release-notes/aggregate.json",
+      "--output",
+      output,
+      "--notes-file",
+      notesFile,
+    ]);
+    expect(audit.release).toBe("all");
+    const publication = await readFile(notesFile, "utf8");
+    expect(publication.split("\n")[0]).toBe("## What's Changed");
+    expect(publication).toContain("**Full Changelog**:");
+    // Audit artifacts stay untouched.
+    await expect(
+      readFile(resolve(output, "audit.json"), "utf8"),
+    ).resolves.toContain('"partial": false');
+    await expect(
+      readFile(resolve(output, "release-notes-publication.md"), "utf8"),
+    ).resolves.toContain("## What's Changed");
+  });
+
+  it("rejects an unknown flag and a value-less --notes-file", async () => {
+    await expect(main(["--all", "--notes-file"])).rejects.toThrow(
+      "requires a value",
+    );
+    await expect(main(["--all", "--nope"])).rejects.toThrow("Unknown flag");
+  });
+});

--- a/scripts/__tests__/validate-release-notes.test.ts
+++ b/scripts/__tests__/validate-release-notes.test.ts
@@ -1,0 +1,208 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+// The default `--release` path shells out to `gh api`; stub it so the fetch
+// branch is exercised deterministically without network access.
+vi.mock("node:child_process", () => {
+  const execFile = (
+    _command: string,
+    _args: string[],
+    callback: (
+      error: unknown,
+      result: { stdout: string; stderr: string },
+    ) => void,
+  ) =>
+    callback(null, {
+      stdout: `## What's Changed\n\n### 🚀 Features\n- Add gizmo ([#10](https://github.com/ils15/open3dcalc/pull/10))\n\n**Full Changelog**: https://github.com/ils15/open3dcalc/compare/v1.0.0...v1.1.0\n`,
+      stderr: "",
+    });
+  return { execFile, default: { execFile } };
+});
+
+import {
+  main,
+  parseArgs,
+  validateReleaseNotes,
+} from "../validate-release-notes.mjs";
+
+const VALID = `## What's Changed
+
+### 🚀 Features
+- Add gizmo ([#10](https://github.com/ils15/open3dcalc/pull/10))
+
+### 🐛 Fixes
+- Fix crash on load (commit abc1234)
+
+### ❤️ Contributors
+@alice
+@bob
+
+**Full Changelog**: https://github.com/ils15/open3dcalc/compare/v1.0.0...v1.1.0
+`;
+
+describe("validateReleaseNotes", () => {
+  it("accepts the canonical publication body", () => {
+    expect(validateReleaseNotes(VALID, { tag: "v1.1.0" })).toEqual({
+      ok: true,
+      errors: [],
+    });
+  });
+
+  it("rejects a body whose first non-empty line is not the wrapper", () => {
+    const result = validateReleaseNotes(
+      VALID.replace("## What's Changed", "# Release notes"),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/first non-empty line/i);
+  });
+
+  it("rejects a wrong emoji on a known section", () => {
+    const result = validateReleaseNotes(
+      VALID.replace("### 🚀 Features", "### ✨ Features"),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toContain("✨ Features");
+  });
+
+  it("rejects a section outside the allowlist", () => {
+    const result = validateReleaseNotes(
+      `${VALID.replace("### 🚀 Features\n", "### 🚀 Features\n- A ([#1](https://github.com/ils15/open3dcalc/pull/1))\n\n### 🎉 Extras\n- B ([#2](https://github.com/ils15/open3dcalc/pull/2))\n")}`,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toContain("🎉 Extras");
+  });
+
+  it("rejects sections rendered out of canonical order", () => {
+    const result = validateReleaseNotes(`## What's Changed
+
+### 🐛 Fixes
+- Fix ([#2](https://github.com/ils15/open3dcalc/pull/2))
+
+### 🚀 Features
+- Feature ([#1](https://github.com/ils15/open3dcalc/pull/1))
+
+**Full Changelog**: https://github.com/ils15/open3dcalc/compare/v1.0.0...v1.1.0
+`);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/out of order/i);
+  });
+
+  it("rejects a malformed pull request link", () => {
+    const result = validateReleaseNotes(
+      VALID.replace(
+        "[#10](https://github.com/ils15/open3dcalc/pull/10)",
+        "[#10](https://github.com/ils15/open3dcalc/pull/11)",
+      ),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/pull request link/i);
+  });
+
+  it("rejects a missing **Full Changelog** line", () => {
+    const result = validateReleaseNotes(
+      VALID.replace(
+        "**Full Changelog**: https://github.com/ils15/open3dcalc/compare/v1.0.0...v1.1.0\n",
+        "",
+      ),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/Full Changelog/);
+  });
+
+  it("rejects any Downloads/Checksums mention", () => {
+    const result = validateReleaseNotes(
+      `${VALID}\n## Downloads\n- setup.exe\n`,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/Downloads or Checksums/);
+  });
+
+  it("rejects audit artifacts and inline author attribution", () => {
+    const audit = `# Release notes
+
+## Features
+- fix: thing ([alice](https://github.com/alice)) — PR #3
+
+## Downloads
+- x
+
+## Checksums
+- y
+
+## Full Changelog
+- z
+`;
+    const result = validateReleaseNotes(audit);
+    expect(result.ok).toBe(false);
+    const joined = result.errors.join("\n");
+    expect(joined).toMatch(/# Release notes/);
+    expect(joined).toMatch(/— PR #/);
+    expect(joined).toMatch(/Downloads/);
+  });
+
+  it("rejects non-bullet content lines", () => {
+    const result = validateReleaseNotes(
+      VALID.replace("- Add gizmo", "Add gizmo"),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/bullet/i);
+  });
+
+  it("rejects a Full Changelog that does not reference the expected tag", () => {
+    const result = validateReleaseNotes(VALID, { tag: "v9.9.9" });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/v9\.9\.9/);
+  });
+});
+
+describe("validate-release-notes CLI", () => {
+  it("parses --file and --release, rejecting misuse", () => {
+    expect(parseArgs(["--file", "notes.md"])).toEqual({
+      file: "notes.md",
+      release: undefined,
+      tag: undefined,
+    });
+    expect(parseArgs(["--release", "v1.1.0", "--tag", "v1.1.0"]).release).toBe(
+      "v1.1.0",
+    );
+    expect(() => parseArgs([])).toThrow("required");
+    expect(() => parseArgs(["--file", "a", "--release", "v1.0.0"])).toThrow(
+      "not both",
+    );
+    expect(() => parseArgs(["--file"])).toThrow("requires a value");
+    expect(() => parseArgs(["--file", "a", "--nope"])).toThrow("Unknown flag");
+  });
+
+  it("validates a --file body and reports failures without throwing", async () => {
+    const dir = await mkdtemp(resolve(tmpdir(), "validate-notes-"));
+    const good = resolve(dir, "good.md");
+    const bad = resolve(dir, "bad.md");
+    await writeFile(good, VALID, "utf8");
+    await writeFile(bad, "# Release notes\n## Downloads\n", "utf8");
+    expect(await main(["--file", good])).toMatchObject({ ok: true });
+    const failure = await main(["--file", bad]);
+    expect(failure.ok).toBe(false);
+    expect(failure.errors.length).toBeGreaterThan(0);
+  });
+
+  it("fetches and validates a published release body via gh", async () => {
+    const calls: Array<{ repository: string; tag: string }> = [];
+    const result = await main(["--release", "v1.1.0"], {
+      fetchReleaseBody: async (repository, tag) => {
+        calls.push({ repository, tag });
+        return VALID;
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.tag).toBe("v1.1.0");
+  });
+
+  it("uses the default gh api fetch when no override is injected", async () => {
+    const result = await main(["--release", "v1.1.0"]);
+    expect(result.ok).toBe(true);
+    expect(result.source).toBe("release:v1.1.0");
+  });
+});

--- a/scripts/backfill-release-notes.mjs
+++ b/scripts/backfill-release-notes.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+/**
+ * Idempotent backfill and rollback for canonical GitHub release bodies.
+ *
+ * SAFETY CONTRACT
+ * - `--dry-run` never mutates anything (no gh call, no snapshot).
+ * - `--apply` snapshots the previous body before editing, and skips a release
+ *   whose current body already hashes to the canonical render (idempotent).
+ * - This tool only ever calls `gh release edit` and `gh api` (list releases).
+ *   It NEVER touches tags, assets, or `latest`/`latest.yml`; destructive
+ *   commands are rejected by `assertSafeGhCommand()`.
+ * - `--restore` replays the body captured in a snapshot through
+ *   `gh release edit <tag> --notes-file <file>`.
+ */
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+import { collect, renderPublication } from "./release-notes.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const VERSION = /^v\d+\.\d+\.\d+$/;
+const USAGE =
+  "Usage: node scripts/backfill-release-notes.mjs (--dry-run | --apply) (--all | --release vX.Y.Z) | --restore vX.Y.Z [--from-snapshot [path]]";
+
+/** Collapse CRLF and trailing whitespace so equivalent bodies hash equally. */
+export const normalizeBody = (text) =>
+  String(text ?? "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/\s+$/, "");
+
+export const bodySha256 = (text) =>
+  createHash("sha256").update(normalizeBody(text)).digest("hex");
+
+/**
+ * Minimal deterministic line diff (LCS backtracking).
+ *
+ * @returns {{ type: "context" | "add" | "remove", text: string }[]}
+ */
+export const diffLines = (before, after) => {
+  const a = normalizeBody(before).split("\n");
+  const b = normalizeBody(after).split("\n");
+  const rows = a.length;
+  const cols = b.length;
+  const lcs = Array.from({ length: rows + 1 }, () => new Uint32Array(cols + 1));
+  for (let i = rows - 1; i >= 0; i--)
+    for (let j = cols - 1; j >= 0; j--)
+      lcs[i][j] =
+        a[i] === b[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+  const entries = [];
+  let i = 0;
+  let j = 0;
+  while (i < rows && j < cols) {
+    if (a[i] === b[j]) {
+      entries.push({ type: "context", text: a[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      entries.push({ type: "remove", text: a[i] });
+      i++;
+    } else {
+      entries.push({ type: "add", text: b[j] });
+      j++;
+    }
+  }
+  while (i < rows) entries.push({ type: "remove", text: a[i++] });
+  while (j < cols) entries.push({ type: "add", text: b[j++] });
+  return entries;
+};
+
+export const formatDiff = (entries) =>
+  entries
+    .map(
+      (entry) =>
+        `${entry.type === "add" ? "+" : entry.type === "remove" ? "-" : " "} ${entry.text}`,
+    )
+    .join("\n");
+
+const FORBIDDEN_TOKENS = new Set([
+  "--target",
+  "--tag",
+  "--latest",
+  "--prerelease",
+  "--draft",
+  "delete",
+  "upload",
+  "download",
+  "create",
+]);
+
+/**
+ * Reject any gh invocation that could touch tags, assets, or `latest`.
+ *
+ * @param {string[]} args
+ */
+export const assertSafeGhCommand = (args) => {
+  const list = Array.isArray(args) ? args.map(String) : [];
+  const command = list[0];
+  if (command !== "release" && command !== "api")
+    throw new Error(`Refusing unsafe gh command: ${list.join(" ")}`);
+  const subcommand = command === "release" ? list[1] : null;
+  if (command === "release" && subcommand !== "edit")
+    throw new Error(`Refusing unsafe gh release subcommand: ${list.join(" ")}`);
+  const danger = list.find(
+    (token) => FORBIDDEN_TOKENS.has(token) || /latest(\.yml)?/i.test(token),
+  );
+  if (danger)
+    throw new Error(
+      `Refusing to touch tags/assets/latest (${danger}): ${list.join(" ")}`,
+    );
+};
+
+/**
+ * @param {string[]} argv
+ * @returns {{ mode: "dry-run" | "apply", all: boolean, release?: string }
+ *   | { mode: "restore", restore: string, snapshotPath?: string }}
+ */
+export const parseArgs = (argv) => {
+  const allowed = new Set([
+    "--dry-run",
+    "--apply",
+    "--all",
+    "--release",
+    "--restore",
+    "--from-snapshot",
+  ]);
+  for (const arg of argv)
+    if (arg.startsWith("--") && !allowed.has(arg))
+      throw new Error(`Unknown flag: ${arg}\n${USAGE}`);
+  const value = (name) => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : undefined;
+  };
+  const dryRun = argv.includes("--dry-run");
+  const apply = argv.includes("--apply");
+  const all = argv.includes("--all");
+  const release = value("--release");
+  const restore = value("--restore");
+  const fromSnapshot = argv.includes("--from-snapshot");
+  const snapshotValue = (() => {
+    if (!fromSnapshot) return undefined;
+    const index = argv.indexOf("--from-snapshot");
+    const next = argv[index + 1];
+    return next && !next.startsWith("--") ? next : undefined;
+  })();
+
+  if (
+    release !== undefined &&
+    (release.startsWith("--") || !VERSION.test(release))
+  )
+    throw new Error("--release must be a tag in vX.Y.Z format");
+  if (
+    restore !== undefined &&
+    (restore.startsWith("--") || !VERSION.test(restore))
+  )
+    throw new Error("--restore must be a tag in vX.Y.Z format");
+  if (fromSnapshot && restore === undefined)
+    throw new Error(`--from-snapshot requires --restore\n${USAGE}`);
+
+  if (restore !== undefined) {
+    if (dryRun || apply || all || release !== undefined)
+      throw new Error(
+        `--restore cannot be combined with --dry-run/--apply/--all/--release\n${USAGE}`,
+      );
+    return {
+      mode: "restore",
+      restore,
+      snapshotPath: snapshotValue ? resolve(snapshotValue) : undefined,
+    };
+  }
+
+  if (!dryRun && !apply) throw new Error(`Use --dry-run or --apply\n${USAGE}`);
+  if (dryRun && apply)
+    throw new Error(`Use either --dry-run or --apply\n${USAGE}`);
+  if (!all && release === undefined)
+    throw new Error(`${USAGE}\nA release tag or --all is required.`);
+  if (all && release !== undefined)
+    throw new Error(`Use either --all or --release\n${USAGE}`);
+  return { mode: dryRun ? "dry-run" : "apply", all, release };
+};
+
+const defaultRunGh = async (args) => {
+  const { stdout } = await execFileAsync("gh", args, {
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return stdout;
+};
+
+const defaultListReleases = async (repository) => {
+  const { stdout } = await execFileAsync(
+    "gh",
+    [
+      "api",
+      `repos/${repository}/releases?per_page=100`,
+      "--paginate",
+      "--jq",
+      ".[] | {tag: .tag_name, body: .body}",
+    ],
+    { maxBuffer: 64 * 1024 * 1024 },
+  );
+  return stdout
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line))
+    .map((entry) => ({ tag: String(entry.tag ?? ""), body: entry.body ?? "" }));
+};
+
+const defaultRenderBody = async (repository, tag) => {
+  const catalog = await collect(repository, tag);
+  return renderPublication(catalog, repository, {
+    tag,
+    previousTag: catalog.range?.previous ?? null,
+  });
+};
+
+const defaultWriteNotes = async (tag, body) => {
+  const dir = await mkdtemp(resolve(tmpdir(), "release-notes-"));
+  const file = resolve(dir, `${tag}.md`);
+  await writeFile(file, body, "utf8");
+  return file;
+};
+
+const createDefaultDeps = () => ({
+  runGh: defaultRunGh,
+  listReleases: defaultListReleases,
+  renderBody: defaultRenderBody,
+  writeNotes: defaultWriteNotes,
+  now: () => new Date().toISOString(),
+  snapshotDir: resolve("release-notes-snapshots"),
+});
+
+const writeSnapshot = async (snapshotDir, tag, snapshot) => {
+  await mkdir(snapshotDir, { recursive: true });
+  const file = resolve(snapshotDir, `${tag}.json`);
+  await writeFile(file, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+  return file;
+};
+
+const PUBLICATION_ITEM = /^- /m;
+
+/**
+ * A canonical body with no bullet items means either the GitHub collection
+ * degraded (rate limit / network) or the tag range legitimately has no
+ * commits. Either way it must never overwrite an existing release body.
+ */
+const isRenderable = (body) => PUBLICATION_ITEM.test(body);
+
+const selectReleases = async (options, repository, listReleases) => {
+  const releases = (await listReleases(repository)).filter((release) =>
+    VERSION.test(release.tag),
+  );
+  if (options.all)
+    return releases.sort((a, b) =>
+      a.tag.localeCompare(b.tag, "en", { numeric: true }),
+    );
+  const match = releases.find((release) => release.tag === options.release);
+  if (!match)
+    throw new Error(`Release ${options.release} not found in ${repository}`);
+  return [match];
+};
+
+const restore = async (options, deps) => {
+  const tag = options.restore;
+  const snapshotPath =
+    options.snapshotPath ?? resolve(deps.snapshotDir, `${tag}.json`);
+  const snapshot = JSON.parse(await readFile(snapshotPath, "utf8"));
+  const previous = snapshot?.previousBody;
+  if (typeof previous !== "string")
+    throw new Error(`Snapshot ${snapshotPath} has no previousBody`);
+  const notesFile = await deps.writeNotes(tag, previous);
+  const args = ["release", "edit", tag, "--notes-file", notesFile];
+  assertSafeGhCommand(args);
+  await deps.runGh(args);
+  return { mode: "restore", tag, snapshot: snapshotPath };
+};
+
+const backfill = async (options, repository, deps) => {
+  const releases = await selectReleases(options, repository, deps.listReleases);
+  const results = [];
+  for (const release of releases) {
+    const canonical = await deps.renderBody(repository, release.tag);
+    const current = release.body ?? "";
+    const currentSha256 = bodySha256(current);
+    const canonicalSha256 = bodySha256(canonical);
+    const changed = currentSha256 !== canonicalSha256;
+    const entry = {
+      tag: release.tag,
+      currentSha256,
+      canonicalSha256,
+      changed,
+      canonical,
+      diff: diffLines(current, canonical),
+    };
+    if (!isRenderable(canonical)) {
+      // Never apply a degenerate body; report and keep going.
+      results.push({
+        ...entry,
+        renderable: false,
+        ...(options.mode === "apply" ? { action: "skipped-unsafe" } : {}),
+        error: `degenerate canonical body for ${release.tag}; the release was left untouched`,
+      });
+      continue;
+    }
+    entry.renderable = true;
+    if (options.mode === "dry-run") {
+      results.push(entry);
+      continue;
+    }
+    if (!changed) {
+      results.push({ ...entry, action: "skipped" });
+      continue;
+    }
+    const snapshot = await writeSnapshot(deps.snapshotDir, release.tag, {
+      tag: release.tag,
+      previousBody: current,
+      newBody: canonical,
+      sha256: canonicalSha256,
+      timestamp: deps.now(),
+    });
+    const notesFile = await deps.writeNotes(release.tag, canonical);
+    const args = [
+      "release",
+      "edit",
+      release.tag,
+      "--notes-file",
+      notesFile,
+      "--title",
+      `Open3DCalc ${release.tag}`,
+    ];
+    assertSafeGhCommand(args);
+    await deps.runGh(args);
+    results.push({ ...entry, action: "applied", snapshot });
+  }
+  return { mode: options.mode, results };
+};
+
+/**
+ * @param {string[]} [argv]
+ * @param {object} [deps] Injectable dependencies (tests mock gh / the API).
+ */
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const options = parseArgs(argv);
+  const repository = process.env.GITHUB_REPOSITORY ?? "ils15/open3dcalc";
+  const resolved = { ...createDefaultDeps(), ...deps };
+  if (options.mode === "restore") return restore(options, resolved);
+  return backfill(options, repository, resolved);
+}
+
+const printReport = (result) => {
+  if (result.mode === "restore") {
+    console.log(`Restored ${result.tag} from ${result.snapshot}`);
+    return;
+  }
+  for (const entry of result.results) {
+    console.log(`\n=== ${entry.tag} ===`);
+    console.log(`current sha256:   ${entry.currentSha256}`);
+    console.log(`canonical sha256: ${entry.canonicalSha256}`);
+    console.log(`changed: ${entry.changed ? "yes" : "no"}`);
+    if (entry.renderable === false) {
+      console.log(`UNSAFE: ${entry.error}`);
+      continue;
+    }
+    if ("action" in entry) {
+      console.log(`action: ${entry.action}`);
+      if (entry.snapshot) console.log(`snapshot: ${entry.snapshot}`);
+    }
+    if (result.mode === "dry-run") {
+      console.log(formatDiff(entry.diff));
+      console.log("----- canonical body -----");
+      console.log(entry.canonical);
+    }
+  }
+};
+
+if (import.meta.url === `file://${process.argv[1]}`)
+  main()
+    .then(printReport)
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -332,6 +332,85 @@ export const render = (catalog, repository = "repository") => {
   return lines.join("\n");
 };
 
+// Canonical GitHub publication sections: exact `###` heading (emoji included)
+// in the fixed public order and the audited catalog categories that feed each
+// one. Chores absorbs the audit-only Improvements/Other Changes buckets so the
+// chore/refactor/style commit types share a single public section. Empty
+// sections are omitted; Downloads/Checksums are deliberately never published.
+export const PUBLICATION_SECTIONS = [
+  { heading: "🚀 Features", categories: ["Features", "Highlights"] },
+  { heading: "🐛 Fixes", categories: ["Fixes"] },
+  {
+    heading: "🧹 Chores",
+    categories: ["Chores", "Improvements", "Other Changes"],
+  },
+  { heading: "📦 Dependencies", categories: ["Dependencies"] },
+  { heading: "🤖 CI/CD", categories: ["CI/CD"] },
+  { heading: "📚 Documentation", categories: ["Documentation"] },
+  { heading: "🔒 Security", categories: ["Security"] },
+  { heading: "⚠️ Breaking Changes", categories: ["Breaking Changes"] },
+];
+const isBotLogin = (login) => {
+  const value = String(login ?? "").toLowerCase();
+  return value === "unknown" || value.endsWith("[bot]") || BOTS.has(value);
+};
+const shortSha = (sha) => clean(sha, "").slice(0, 7);
+const publicationChangelog = (repository, tag, previousTag) => {
+  const repositoryUrl = `https://github.com/${escapeMarkdown(repository)}`;
+  const component = (value) => encodeURIComponent(String(value));
+  if (previousTag && tag)
+    return `${repositoryUrl}/compare/${component(previousTag)}...${component(tag)}`;
+  // First tagged release: only a commit list exists, mirroring the audit render.
+  if (tag) return `${repositoryUrl}/commits/${component(tag)}`;
+  return repositoryUrl;
+};
+/**
+ * Render the canonical GitHub release body (EN, emoji sections, deterministic).
+ *
+ * @param {object} catalog Normalized catalog returned by `normalize()`.
+ * @param {string} [repository] GitHub `owner/repo` slug.
+ * @param {{ tag?: string, previousTag?: string }} [range] Release tag and the
+ *   previous SemVer tag used to build the Full Changelog compare link.
+ * @returns {string} Markdown body, byte-identical across re-runs.
+ */
+export const renderPublication = (
+  catalog,
+  repository = "repository",
+  { tag, previousTag } = {},
+) => {
+  const releaseTag = tag ?? catalog.range?.release ?? null;
+  const priorTag = previousTag ?? catalog.range?.previous ?? null;
+  const lines = ["## What's Changed", ""];
+  for (const { heading, categories } of PUBLICATION_SECTIONS) {
+    const entries = catalog.items
+      .filter((item) => categories.includes(item.category))
+      .sort((a, b) => compare(a.title, b.title) || compare(a.key, b.key));
+    if (!entries.length) continue;
+    lines.push(`### ${heading}`, "");
+    for (const item of entries) {
+      const prNumber = validNumber(item.pr?.number);
+      const suffix = prNumber
+        ? `([#${item.pr.number}](https://github.com/${escapeMarkdown(repository)}/pull/${item.pr.number}))`
+        : `(commit ${escapeMarkdown(shortSha(item.sha))})`;
+      lines.push(`- ${escapeMarkdown(item.title)} ${suffix}`);
+    }
+    lines.push("");
+  }
+  const contributors = [...new Set(catalog.items.map((item) => item.author))]
+    .filter((author) => author && !isBotLogin(author))
+    .sort(compare);
+  if (contributors.length) {
+    lines.push("### ❤️ Contributors", "");
+    lines.push(...contributors.map((author) => `@${escapeMarkdown(author)}`));
+    lines.push("");
+  }
+  lines.push(
+    `**Full Changelog**: ${publicationChangelog(repository, releaseTag, priorTag)}`,
+    "",
+  );
+  return lines.join("\n");
+};
+
 class GitHubError extends Error {
   constructor(url, status, attempts) {
     super(`GitHub request failed with status ${status}`);
@@ -611,7 +690,7 @@ export async function collect(repository, release) {
 }
 
 const usage =
-  "Usage: node scripts/release-notes.mjs (--release vX.Y.Z | --all) [--dry-run] [--audit-only] [--input file] [--output dir]";
+  "Usage: node scripts/release-notes.mjs (--release vX.Y.Z | --all) [--dry-run] [--audit-only] [--input file] [--output dir] [--notes-file path]";
 const parseArgs = (argv) => {
   const allowed = new Set([
     "--dry-run",
@@ -621,6 +700,7 @@ const parseArgs = (argv) => {
     "--release",
     "--input",
     "--output",
+    "--notes-file",
   ]);
   for (const arg of argv)
     if (arg.startsWith("--") && !allowed.has(arg))
@@ -638,7 +718,7 @@ const parseArgs = (argv) => {
     throw new Error("--release must be a tag in vX.Y.Z format");
   if (!release && !argv.includes("--all"))
     throw new Error(`${usage}\nA release tag or --all is required.`);
-  for (const name of ["--release", "--input", "--output"])
+  for (const name of ["--release", "--input", "--output", "--notes-file"])
     if (argv.includes(name) && (!value(name) || value(name).startsWith("--")))
       throw new Error(`${name} requires a value`);
   return {
@@ -648,6 +728,7 @@ const parseArgs = (argv) => {
     auditOnly: argv.includes("--audit-only"),
     input: value("--input"),
     output: resolve(value("--output") ?? "release-notes-output"),
+    notesFile: value("--notes-file"),
   };
 };
 export async function main(argv = process.argv.slice(2)) {
@@ -670,6 +751,10 @@ export async function main(argv = process.argv.slice(2)) {
     outputSha256: sha256(render(catalog, repository)),
     catalog,
   };
+  const publication = renderPublication(catalog, repository, {
+    tag: options.release,
+    previousTag: catalog.range?.previous,
+  });
   await mkdir(options.output, { recursive: true });
   await writeFile(
     resolve(options.output, "inventory.json"),
@@ -689,7 +774,13 @@ export async function main(argv = process.argv.slice(2)) {
       resolve(options.output, "release-notes.diff"),
       `--- generated\n+++ audited\n@@\n+${markdown.split("\n").join("\n+\n")}`,
     );
+    await writeFile(
+      resolve(options.output, "release-notes-publication.md"),
+      `${publication}\n`,
+    );
   }
+  if (options.notesFile)
+    await writeFile(resolve(options.notesFile), `${publication}\n`);
   return audit;
 }
 if (import.meta.url === `file://${process.argv[1]}`)

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -8,6 +8,7 @@ export const CATEGORIES = [
   "Highlights",
   "Features",
   "Improvements",
+  "Chores",
   "Fixes",
   "Security",
   "CI/CD",
@@ -39,47 +40,82 @@ const isBot = (person) => {
 };
 export const escapeMarkdown = (value) =>
   clean(value, "Not available").replace(/([\\`*_{}\[\]()<>#+.!|])/g, "\\$1");
+// Inline-safe escaping for item titles. Parentheses, plus signs, hashes and
+// exclamation marks are legitimate conventional-commit subject characters and
+// cannot start a heading inside a `- ` bullet, so they stay literal. Only the
+// characters that can break inline Markdown or inject HTML are escaped.
+export const escapeInline = (value) =>
+  clean(value, "Not available").replace(/([\\`*_[\]<>|])/g, "\\$1");
 export const sha256 = (value) =>
   createHash("sha256").update(JSON.stringify(value)).digest("hex");
 const CONVENTIONAL_PREFIXES = {
   feat: "Features",
   fix: "Fixes",
   perf: "Improvements",
-  refactor: "Improvements",
-  style: "Improvements",
+  refactor: "Chores",
+  style: "Chores",
+  test: "Chores",
+  build: "Chores",
+  chore: "Chores",
   docs: "Documentation",
   ci: "CI/CD",
-  build: "CI/CD",
   deps: "Dependencies",
+  security: "Security",
 };
 const HIGHLIGHT_LIMIT = 3;
+export const SUBJECT_LIMIT = 100;
+// First physical line of a raw message; commit bodies never survive this.
+const firstLine = (value) =>
+  String(value ?? "")
+    .split(/\r?\n/, 1)[0]
+    .replace(/[\u0000-\u001f]/g, " ")
+    .trim();
+// Commit-only items render just the subject, bounded to a readable length.
+const commitSubject = (value) => {
+  const line = firstLine(value).slice(0, SUBJECT_LIMIT);
+  return line || clean(value);
+};
+const breakingBody = (item) =>
+  [item?.body, item?.commit?.message, item?.message]
+    .filter((value) => typeof value === "string" && value.length)
+    .join("\n");
 export const categoryFor = (item) => {
-  // Raw commit payloads carry the title in commit.message (or a flat message),
-  // not in title — normalize before classifying so Conventional Commit
-  // prefixes win over generic keyword scanning (e.g. "feat: fix calculator"
-  // must be Features, and "calculator" must never match /\bci\b/).
-  const title = clean(
+  // Classify from the conventional-commit subject (first line) plus, only for
+  // the explicit footer, the message body. The body is never keyword-scanned:
+  // prose like "breaking intencional" must not elevate an item.
+  const subject = firstLine(
     item?.title ?? item?.message ?? item?.commit?.message ?? item?.pr?.title,
   );
-  const text =
-    `${title} ${item?.body ?? ""} ${(item?.labels ?? []).map((label) => label.name ?? label).join(" ")}`.toLowerCase();
-  const conventional = /^([a-z]+)(?:\(([^)]*)\))?(!)?:/.exec(text);
+  const lower = subject.toLowerCase();
+  if (subject.includes("!:") || /^BREAKING[ -]CHANGE\b/.test(subject))
+    return "Breaking Changes";
+  // The explicit Conventional Commits footer wins over the type/scope mapping.
+  if (/\bBREAKING[ -]CHANGE\b/.test(breakingBody(item)))
+    return "Breaking Changes";
+  const conventional = /^([a-z]+)(?:\(([^)]*)\))?(!)?:/.exec(lower);
   if (conventional) {
-    const [, prefix, scope, bang] = conventional;
-    if (bang) return "Breaking Changes";
-    if (scope && /deps?/.test(scope)) return "Dependencies";
+    const [, prefix, scope] = conventional;
+    if (scope && /(?:^|[-_])deps?(?:$|[-_])|dependencies/.test(scope))
+      return "Dependencies";
+    if (prefix === "chore" && scope === "ci") return "CI/CD";
     if (CONVENTIONAL_PREFIXES[prefix]) return CONVENTIONAL_PREFIXES[prefix];
-    if (prefix === "chore" && /^chore\(release\)/.test(text)) return "CI/CD";
   }
-  if (/breaking|!:|major change/.test(text)) return "Breaking Changes";
-  if (/security|cve|vulnerab|dependabot|renovate/.test(text))
-    return text.includes("depend") ? "Dependencies" : "Security";
+  // Subject-only fallbacks for non-conventional titles (dependency bots,
+  // free-form prose, maintenance types).
+  if (
+    /\bbump\b[\s\S]*\bfrom\b[\s\S]*\bto\b|\bdependabot\b|\brenovate\b/.test(
+      lower,
+    )
+  )
+    return "Dependencies";
+  if (/security|cve|vulnerab/.test(lower)) return "Security";
   // Anchored \bci\b so "calculator"/"calculadora" never land in CI/CD.
-  if (/\bci\b|workflow|github action|pipeline|build/.test(text)) return "CI/CD";
-  if (/doc|readme|typo/.test(text)) return "Documentation";
-  if (/fix|bug|patch|regression/.test(text)) return "Fixes";
-  if (/feature|add|support|implement/.test(text)) return "Features";
-  if (/improv|refactor|perf|enhanc/.test(text)) return "Improvements";
+  if (/\bci\b|workflow|github action|pipeline/.test(lower)) return "CI/CD";
+  if (/doc|readme|typo/.test(lower)) return "Documentation";
+  if (/fix|bug|patch|regression/.test(lower)) return "Fixes";
+  if (/feature|add|support|implement/.test(lower)) return "Features";
+  if (/improv|perf|enhanc/.test(lower)) return "Improvements";
+  if (/chore|refactor|style|test|build|tidy/.test(lower)) return "Chores";
   return "Other Changes";
 };
 const personLogin = (person) => clean(person?.login ?? person?.name);
@@ -212,9 +248,10 @@ export const normalize = (input) => {
       .find(Boolean);
     const current = existingKey ? seen.get(existingKey) : undefined;
     if (current && !(pr?.merged === true && !current.pr?.merged)) return;
-    const title = clean(
-      pr?.title ?? commit?.message ?? commit?.commit?.message,
-    );
+    const rawTitle = pr?.title ?? commit?.message ?? commit?.commit?.message;
+    // PR titles are single-line by contract; commit-only items must keep just
+    // the conventional-commit subject so multi-line bodies never leak in.
+    const title = pr?.title ? clean(rawTitle) : commitSubject(rawTitle);
     const item = {
       key,
       sha: clean(commit?.sha ?? pr?.merge_commit_sha),
@@ -300,7 +337,7 @@ export const render = (catalog, repository = "repository") => {
         item.author === "Unknown"
           ? "Unknown"
           : `[${escapeMarkdown(item.author)}](https://github.com/${encodeURIComponent(item.author)})`;
-      lines.push(`- ${escapeMarkdown(item.title)} (${author})${suffix}`);
+      lines.push(`- ${escapeInline(item.title)} (${author})${suffix}`);
     }
     lines.push("");
   }
@@ -392,7 +429,7 @@ export const renderPublication = (
       const suffix = prNumber
         ? `([#${item.pr.number}](https://github.com/${escapeMarkdown(repository)}/pull/${item.pr.number}))`
         : `(commit ${escapeMarkdown(shortSha(item.sha))})`;
-      lines.push(`- ${escapeMarkdown(item.title)} ${suffix}`);
+      lines.push(`- ${escapeInline(item.title)} ${suffix}`);
     }
     lines.push("");
   }

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -66,6 +66,7 @@ export const CATEGORY_KEYS = Object.freeze({
   "bug fixes": "fixes",
   fixes: "fixes",
   chore: "other",
+  chores: "other",
   "other changes": "other",
   other: "other",
   ci: "ci",

--- a/scripts/validate-release-notes.mjs
+++ b/scripts/validate-release-notes.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Deterministic, read-only validator for GitHub release bodies.
+ *
+ * Enforces the canonical publication format produced by `renderPublication()`:
+ * the `## What's Changed` wrapper, emoji `###` sections in the fixed order,
+ * `- ` bullets, well-formed PR links, and exactly one `**Full Changelog**`
+ * line. Audit artifacts and Downloads/Checksums sections are rejected.
+ */
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+import { PUBLICATION_SECTIONS } from "./release-notes.mjs";
+
+const execFileAsync = promisify(execFile);
+
+export const WRAPPER = "## What's Changed";
+export const CONTRIBUTORS_HEADING = "❤️ Contributors";
+export const SECTION_HEADINGS = [
+  ...PUBLICATION_SECTIONS.map((section) => section.heading),
+  CONTRIBUTORS_HEADING,
+];
+const FULL_CHANGELOG = /^\*\*Full Changelog\*\*: (https:\/\/\S+)$/;
+const PULL_LINK = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+$/;
+const INLINE_AUTHOR = /^https:\/\/github\.com\/[\w.-]+\/?$/;
+
+/**
+ * Validate a release body against the canonical publication contract.
+ *
+ * @param {string} markdown Release body (markdown).
+ * @param {{ tag?: string }} [options] Optional tag the Full Changelog must reference.
+ * @returns {{ ok: boolean, errors: string[] }} Deterministic verdict.
+ */
+export const validateReleaseNotes = (markdown, { tag } = {}) => {
+  const errors = [];
+  const text = String(markdown ?? "");
+  const lines = text.split("\n");
+  const nonEmpty = lines
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim() !== "");
+
+  if (nonEmpty[0] !== WRAPPER)
+    errors.push(`First non-empty line must be "${WRAPPER}"`);
+
+  let lastHeading = -1;
+  for (const line of nonEmpty) {
+    const h3 = /^### (.+)$/.exec(line);
+    if (h3) {
+      const heading = h3[1].trim();
+      const position = SECTION_HEADINGS.indexOf(heading);
+      if (position === -1)
+        errors.push(`Unknown section heading: ### ${heading}`);
+      else if (position <= lastHeading)
+        errors.push(`Section out of order: ### ${heading}`);
+      else lastHeading = position;
+      continue;
+    }
+    if (/^## /.test(line) && line !== WRAPPER)
+      errors.push(`Unexpected level-2 heading: ${line}`);
+  }
+
+  if (/\b(?:downloads?|checksums?)\b/i.test(text))
+    errors.push("Publication notes must not mention Downloads or Checksums");
+  if (lines.some((line) => line.trim() === "# Release notes"))
+    errors.push("Audit artifact detected: # Release notes");
+  if (text.includes("— PR #")) errors.push("Audit artifact detected: — PR #");
+
+  let inContributors = false;
+  for (const line of nonEmpty) {
+    if (line === WRAPPER) {
+      inContributors = false;
+      continue;
+    }
+    if (/^### /.test(line)) {
+      inContributors = line === `### ${CONTRIBUTORS_HEADING}`;
+      continue;
+    }
+    if (/^## /.test(line)) continue;
+    if (FULL_CHANGELOG.test(line)) continue;
+    if (inContributors) {
+      if (!/^@[\w-]+$/.test(line))
+        errors.push(`Contributor line must be a bare @login: ${line}`);
+      continue;
+    }
+    if (!line.startsWith("- ")) {
+      errors.push(`Content line must be a "- " bullet: ${line}`);
+      continue;
+    }
+    for (const [, url] of line.matchAll(
+      /\[[^\]]*\]\((https:\/\/github\.com\/[^)]+)\)/g,
+    )) {
+      if (INLINE_AUTHOR.test(url))
+        errors.push(`Inline author link is not allowed in items: ${url}`);
+    }
+  }
+
+  for (const [, number, url] of text.matchAll(/\[#(\d+)\]\(([^)]+)\)/g)) {
+    if (!PULL_LINK.test(url) || !url.endsWith(`/pull/${number}`))
+      errors.push(`Malformed pull request link for #${number}: ${url}`);
+  }
+
+  const changelogs = nonEmpty.filter((line) => FULL_CHANGELOG.test(line));
+  if (changelogs.length !== 1)
+    errors.push(
+      `Expected exactly one **Full Changelog** line, found ${changelogs.length}`,
+    );
+  else {
+    if (nonEmpty[nonEmpty.length - 1] !== changelogs[0])
+      errors.push("**Full Changelog** must be the last non-empty line");
+    if (tag && !changelogs[0].includes(tag))
+      errors.push(`Full Changelog must reference ${tag}`);
+  }
+
+  return { ok: errors.length === 0, errors };
+};
+
+export const usage =
+  "Usage: node scripts/validate-release-notes.mjs (--file <path> | --release vX.Y.Z) [--tag vX.Y.Z]";
+
+export const parseArgs = (argv) => {
+  const allowed = new Set(["--file", "--release", "--tag"]);
+  for (const arg of argv)
+    if (arg.startsWith("--") && !allowed.has(arg))
+      throw new Error(`Unknown flag: ${arg}\n${usage}`);
+  const value = (name) => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : undefined;
+  };
+  for (const name of ["--file", "--release", "--tag"])
+    if (argv.includes(name) && (!value(name) || value(name).startsWith("--")))
+      throw new Error(`${name} requires a value`);
+  const file = value("--file");
+  const release = value("--release");
+  const tag = value("--tag");
+  if (!file && !release)
+    throw new Error(`${usage}\nA --file or --release is required.`);
+  if (file && release)
+    throw new Error("Use either --file or --release, not both.");
+  for (const [name, tagValue] of [
+    ["--release", release],
+    ["--tag", tag],
+  ])
+    if (tagValue && !/^v\d+\.\d+\.\d+$/.test(tagValue))
+      throw new Error(`${name} must be a tag in vX.Y.Z format`);
+  return { file, release, tag };
+};
+
+const defaultFetchReleaseBody = async (repository, tag) => {
+  const { stdout } = await execFileAsync("gh", [
+    "api",
+    `repos/${repository}/releases/tags/${tag}`,
+    "--jq",
+    ".body",
+  ]);
+  return stdout;
+};
+
+/**
+ * Run the validator. `--file` reads a local body; `--release` fetches the
+ * published body through `gh api` (injectable for tests).
+ *
+ * @param {string[]} [argv]
+ * @param {{ fetchReleaseBody?: (repository: string, tag: string) => Promise<string> }} [deps]
+ * @returns {Promise<{ ok: boolean, errors: string[], source: string }>}
+ */
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const options = parseArgs(argv);
+  let markdown;
+  let source;
+  if (options.file) {
+    source = `file:${resolve(options.file)}`;
+    markdown = await readFile(resolve(options.file), "utf8");
+  } else {
+    const repository = process.env.GITHUB_REPOSITORY ?? "ils15/open3dcalc";
+    source = `release:${options.release}`;
+    const fetchBody = deps.fetchReleaseBody ?? defaultFetchReleaseBody;
+    markdown = await fetchBody(repository, options.release);
+  }
+  const result = validateReleaseNotes(markdown, {
+    tag: options.tag ?? options.release,
+  });
+  return { ...result, source };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`)
+  main()
+    .then((result) => {
+      if (result.ok) {
+        console.log(`Release notes are valid (${result.source}).`);
+        return;
+      }
+      for (const error of result.errors) console.error(`- ${error}`);
+      process.exitCode = 1;
+    })
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });


### PR DESCRIPTION
## Objetivo

Padronizar as GitHub Release notes em um **formato canônico com emojis**, geradas deterministicamente e validadas por um gate *fail-closed* antes da publicação.

## Mudanças

- **Formato canônico com emojis:** `🚀 Features`, `🐛 Fixes`, `🧹 Chores`, `📦 Dependencies`, `🤖 CI/CD`, `❤️ Contributors` (mais `📚 Documentation`, `🔒 Security`, `⚠️ Breaking Changes` quando houver conteúdo), com ordem de seções fixa.
- **`renderPublication()` + validador fail-closed** (`scripts/release-notes.mjs`, `scripts/validate-release-notes.mjs`): rejeita headings fora de ordem, bullets malformados, links de PR inválidos, artefatos de auditoria e mais de uma linha `**Full Changelog**`.
- **`release-publish.yml` usa `--notes-file`** em vez de `--generate-notes`, garantindo que o corpo publicado seja exatamente o validado.
- **Backfill idempotente + rollback por snapshot:** `scripts/backfill-release-notes.mjs` (`--dry-run`/`--apply`/`--restore`), com snapshot do corpo anterior antes de editar.
- **15 releases do GitHub já padronizadas**; `v1.5.2` tratada manualmente (exceção documentada).
- **README:** nova seção *Notas de release automáticas*; `.gitignore` ignora os artefatos locais de backfill (`release-notes-snapshots/`, `release-notes-output/`).

## Validação

- `npx vitest run scripts/` — 6 arquivos, 138 testes ✅
- `npm run typecheck` — sem erros ✅
- Pre-push hook — 89 arquivos, 1217 testes ✅

## Notas

- PR aberto como **DRAFT** (política do repositório). Aguarda aprovação humana; **sem merge automático**.