### PR TITLE
feat(privacy): D1.1 S1 — SPEC-01 manifest loader, gate and gated storage

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,56 +1,61 @@
-# Deepwork D0 — G-code weight reliability
+# Deepwork D1.1 S1 — SPEC-01 manifest loader + gated storage
 
-- **Branch/worktree:** `fix/gcode-weight-reliability` / `../open3dcalc-d0-gcode-reliability`
-- **Status:** implementation revised — awaiting Themis review; D1 not started.
-- **Scope:** Investigate and minimally correct issue #102 only, with regression tests and verification.
-- **Last update:** 2026-09-10 — isolated worktree created from current `main`.
+- **Branch/worktree:** `feat/d1-s1-manifest-loader` / `../open3dcalc-d1-s1-manifest`
+- **Status:** implementation complete — local gates green; awaiting Themis review (PR next).
+- **Scope (OWNERS-RUNBOOK §6 declared):** SPEC-01 manifest loader + validation, manifest
+  gate, gated storage wrappers, gate wiring into all localStorage writers, fixture
+  registration of the runtime key set, contract tests (TEST-MATRIX §1 rows + S1 wiring).
+  No other contract documents touched; `policy_version` bumped for the fixture edit.
+- **Base:** `main` @ `cc90ae4` (includes PR #105 D0 fix and PR #106 D1.0 contracts).
 
-## Discovery evidence
+## What landed in this slice
 
-- UI path: `StlPreview.tsx` dynamically imports `parseGcode()` and uses
-  `filamentUsedGrams` directly as the displayed/anchored weight.
-- `parseGcode()` handles `;Filament used:` and otherwise tracks the largest
-  absolute positive `E` value; it does not account for `M83`, `M82` deltas,
-  retractions, or `G92` resets. `parseGcodeTotals()` already contains the
-  safer stateful algorithm, but is not used by this UI path.
-- The reported `0.026842945729516288 g` equals the existing formula for
-  exactly 9 mm of 1.75 mm filament at PLA density 1.24 g/cm³. An equivalent
-  sanitized file with an absolute `E9` move followed by a reset/restart and
-  later extrusion reproduces the undercount mechanism.
-- PR #72 fixes 3MF path/transform/volume handling; PR #73 fixes mesh weight and
-  print-time estimation; PR #84 is the issue behind time-header work; PR #86
-  adds the shared time/fallback cascade. None fixes the legacy G-code weight
-  path used by this UI. Issue #102 has no attached fixture.
+- `src/shared/lib/dataManifest.ts` — normative vocabularies mirrored from SPEC-01
+  `$defs`, entry/document validation (TEST-MATRIX 1.2–1.11), loader with duplicate-key
+  rejection, shipped-fixture loader, policy-version accessors, orphan-key enumeration.
+- `src/shared/lib/manifestGate.ts` — fail-closed choke point: known keys pass with their
+  full policy record; unknown keys throw `ManifestError` in dev and deny-safely in
+  production; unreadable manifest denies everything; `isKeyAllowed` non-throwing variant
+  for bulk paths. Logs carry key NAMES only (TEST-MATRIX 3.2).
+- `src/shared/lib/manifestStorage.ts` — `manifestStorage()` (zustand `PersistStorage`
+  drop-in) and `guardedStorage` (localStorage-shaped facade). Deny is a true no-op
+  (reads return null, writes/removed are skipped); unavailable backing storage degrades
+  to no-ops.
+- Fixture (`SPEC-01-manifest-fixture.json`): `policy_version` 1.0 → 1.1; renamed
+  `open3dcalc_migration_flags` → `open3dcalc_migration_done_v2` and
+  `open3dcalc_quickstart_done` → `open3dcalc_quickstart_dismissed` to match shipped code;
+  registered `open3dcalc_onboarded` and `i18nextLng` (i18next detector cache). 27 keys.
+- Gate wiring: zustand persist stores (consent, customer, history, product, quote) via
+  `manifestStorage()`; direct-localStorage writers (calculator store + helpers, catalog,
+  filaments, tutorial, storeBridge, web/desktop App migration + onboarding + settings,
+  Dashboard, QuickStartBanner, OnboardingModal, useTheme, theme-persistence, dataSync)
+  via `guardedStorage`; desktop persistence-bridge gates SQLite↔localStorage copies and
+  skips unknown keys without aborting the whole backup (fail-closed per key).
 
-## Correction and verification
+## Verification
 
-- Minimal fix: retain a valid `;Filament used:` header as authoritative; when
-  absent, make the UI parser consume `parseGcodeTotals()` for stateful E
-  accumulation and then apply the existing diameter/density formula.
-- TDD: regression tests were red before the revision and green after the fix;
-  the original equivalent fixture remains `34,200 mm` /
-  `102.00319377216188 g`.
-- Focused tests: 100 passed across 3 files (45 in `gcodeParser.test.ts`).
-  Full suite: 1,180 passed across 86 files.
-- Typecheck (app + Electron), lint, desktop/web build, coverage and
-  `git diff --check` passed. Overall coverage is 64.55% statements /
-  66.56% lines versus the reported
-  baseline of ~46.69%; altered critical paths are `gcodeParser.ts` 100% lines,
-  `gcodeTotals.ts` 98.42% lines, and `StlPreview.tsx` 86.86% lines.
-- Build emitted pre-existing Vite warnings about native config loading,
-  ineffective dynamic imports and large chunks; no build failure.
+- Contract tests: 35 tests across `dataManifest.test.ts` (loader + TEST-MATRIX 1.1–1.11),
+  `manifestGate.test.ts` (deny paths, fail-closed, reset semantics) and
+  `manifestStorage.test.ts` (pass-through, dev-throw, production safe-deny, no-value
+  logging, SSR no-op). Coverage on the three contract modules: 94.6% / 91.9% / 96% lines
+  (≥80% bar of TEST-MATRIX §9.1).
+- Full suite: 1,275 passed across 92 files. Typecheck (app + Electron), lint, desktop and
+  web builds passed. Build emits pre-existing Vite warnings only.
+- `SPEC-01-manifest-fixture.json` validated against `SPEC-01-manifest.schema.json`
+  (draft 2020-12) with `jsonschema`.
 
-## Themis findings revision
+## Defects found and fixed during the slice
 
-- Finding 1: a valid `;Filament used:` header is now latched as authoritative;
-  later `G0/G1` moves and the stateful second pass cannot replace it. Multiple
-  valid headers retain the documented last-valid-header precedence, while
-  supported plain-mm, `mm`, and metre forms remain accepted.
-- Finding 2: malformed, non-finite, negative, or absurd filament headers are
-  ignored rather than treated as present, so `parseGcodeTotals()` handles
-  `M82`, `M83`, `G92`, positive deltas, retractions, and restarts.
-- Regression coverage added for header position, multiple headers/units,
-  malformed and unsafe values, plus the stateful M82/M83/G92 path. The fixture
-  remains generated/sanitized and contains no PII or secrets.
+- Production fail-open: the original gate wrappers discarded `checkKey`'s decision and
+  wrote anyway when it returned `{ allowed: false }` (production safe-deny path). Deny is
+  now a real no-op; regression tests cover both environments.
+- `guardedStorage` crashed when `window.localStorage` was unavailable (the zustand
+  wrapper already degraded); facade now shares the same no-op fallback.
 
-**D0 remains pending Themis review. D1 is not started.**
+## Rollback (OWNERS-RUNBOOK §7)
+
+Single-slice flag flip: reverting the branch returns stores to direct-key behavior; the
+fixture remains a read-only document. No data migration happened in S1.
+
+**D1.1 S1 is pending Themis review. S2 (crypto capability) is the next dependency-free
+slice after S1 lands.**

--- a/docs/privacy/SPEC-01-manifest-fixture.json
+++ b/docs/privacy/SPEC-01-manifest-fixture.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "1.0",
-  "policy_version": "1.0",
+  "policy_version": "1.1",
   "keys": [
     {
       "key": "open3dcalc_consent_v1",
@@ -35,7 +35,7 @@
       "version": "1.0"
     },
     {
-      "key": "open3dcalc_migration_flags",
+      "key": "open3dcalc_migration_done_v2",
       "surface": "localStorage",
       "platforms": ["electron", "web", "pwa"],
       "class": "onboarding_flag",
@@ -45,23 +45,55 @@
       "export": "never",
       "erasure": "erase_on_delete_all",
       "retention": { "policy": "user_controlled", "max_days": 0 },
-      "purpose": "One-shot migration markers (e.g., settings v1->v2) so migrations run once; local-only.",
+      "purpose": "One-shot marker for the v2 localStorage-to-SQLite migration so it runs once; local-only. Key renamed from the D1.0 fixture to match the shipped code.",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
+      "version": "1.1"
+    },
+    {
+      "key": "open3dcalc_quickstart_dismissed",
+      "surface": "localStorage",
+      "platforms": ["electron", "web", "pwa"],
+      "class": "onboarding_flag",
+      "pii": false,
+      "persistence": "plaintext_allowed",
+      "sync": "never",
+      "export": "never",
+      "erasure": "erase_on_delete_all",
+      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "purpose": "Quick Start banner dismissal flag; local-only, never a consent substitute. Key renamed from the D1.0 fixture to match the shipped code.",
+      "legal_basis": "not_personal_data",
+      "owner": "aphrodite",
+      "version": "1.1"
+    },
+    {
+      "key": "open3dcalc_onboarded",
+      "surface": "localStorage",
+      "platforms": ["electron", "web", "pwa"],
+      "class": "onboarding_flag",
+      "pii": false,
+      "persistence": "plaintext_allowed",
+      "sync": "never",
+      "export": "never",
+      "erasure": "erase_on_delete_all",
+      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "purpose": "Onboarding completion flag so the intro modal is not re-shown; local-only, never a consent substitute.",
+      "legal_basis": "not_personal_data",
+      "owner": "aphrodite",
       "version": "1.0"
     },
     {
-      "key": "open3dcalc_quickstart_done",
+      "key": "i18nextLng",
       "surface": "localStorage",
       "platforms": ["electron", "web", "pwa"],
-      "class": "onboarding_flag",
+      "class": "user_preference",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
       "retention": { "policy": "user_controlled", "max_days": 0 },
-      "purpose": "Quickstart overlay dismissal flag; local-only, never a consent substitute.",
+      "purpose": "Interface language cached by the i18next browser language detector; local-only, falls back to navigator when absent.",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
       "version": "1.0"

--- a/src/platform/desktop/App.tsx
+++ b/src/platform/desktop/App.tsx
@@ -12,6 +12,7 @@ import { CustomerTab } from "@/shared/components/Catalog/CustomerTab";
 import { ProductInventory } from "@/shared/components/Catalog/ProductInventory";
 import { QuoteSection } from "@/shared/components/Calculator/QuoteSection";
 import { restoreAutoSnapshot } from "@/shared/stores/storeBridge";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 import { useHistoryStore } from "@/shared/stores/historyStore";
 import { useCalculatorStore } from "@/shared/stores/calculatorStore";
 import { computeStoreResults } from "@/shared/stores/calculatorStore.compute";
@@ -158,14 +159,14 @@ function App() {
       const existing = historyStore.entries.length;
 
       // Skip if already migrated
-      if (localStorage.getItem("open3dcalc_migration_done_v2")) return;
+      if (guardedStorage.getItem("open3dcalc_migration_done_v2")) return;
 
       // Only migrate if historyStore is empty (prevent duplicates)
       if (existing > 0) return;
 
       // Migrar productStore antigo
       try {
-        const oldProducts = localStorage.getItem("open3dcalc_products");
+        const oldProducts = guardedStorage.getItem("open3dcalc_products");
         if (oldProducts) {
           const parsed = JSON.parse(oldProducts) as unknown;
           if (Array.isArray(parsed)) {
@@ -189,7 +190,7 @@ function App() {
               });
             });
           }
-          localStorage.removeItem("open3dcalc_products");
+          guardedStorage.removeItem("open3dcalc_products");
         }
       } catch (error) {
         console.warn("Failed to migrate open3dcalc_products", error);
@@ -197,7 +198,7 @@ function App() {
 
       // Migrar calculatorStore.history antigo (v1)
       try {
-        const oldHistory = localStorage.getItem("open3dcalc_history_v2");
+        const oldHistory = guardedStorage.getItem("open3dcalc_history_v2");
         if (oldHistory) {
           const parsed = JSON.parse(oldHistory) as unknown;
           if (Array.isArray(parsed)) {
@@ -239,7 +240,7 @@ function App() {
                 snapshot: legacyItem.snapshot || null,
               });
             });
-            localStorage.removeItem("open3dcalc_history_v2");
+            guardedStorage.removeItem("open3dcalc_history_v2");
           }
         }
       } catch (error) {
@@ -283,7 +284,7 @@ function App() {
         targetMarginMode: calc.targetMarginMode,
         enabledSections: calc.enabledSections,
       };
-      localStorage.setItem("open3dcalc_settings_v2", JSON.stringify(data));
+      guardedStorage.setItem("open3dcalc_settings_v2", JSON.stringify(data));
     };
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
@@ -366,7 +367,7 @@ function App() {
   useEffect(() => {
     const timer = setTimeout(() => {
       // Don't start tutorial if onboarding is still pending
-      const onboardingDone = localStorage.getItem("open3dcalc_onboarded");
+      const onboardingDone = guardedStorage.getItem("open3dcalc_onboarded");
       if (!onboardingDone) return;
 
       const store = useTutorialStore.getState();

--- a/src/platform/desktop/overrides/persistence-bridge.ts
+++ b/src/platform/desktop/overrides/persistence-bridge.ts
@@ -15,12 +15,14 @@
  * double-serialization because localStorage already stores JSON strings.
  */
 
+import { isKeyAllowed } from "@/shared/lib/manifestGate";
+
 /* ------------------------------------------------------------------ */
 /*  Error tracking                                                      */
 /* ------------------------------------------------------------------ */
 
-let consecutiveDbFailures = 0
-const MAX_FAILURES_BEFORE_WARN = 5
+let consecutiveDbFailures = 0;
+const MAX_FAILURES_BEFORE_WARN = 5;
 
 /* ------------------------------------------------------------------ */
 /*  Known localStorage keys used throughout the app                    */
@@ -28,19 +30,19 @@ const MAX_FAILURES_BEFORE_WARN = 5
 /* ------------------------------------------------------------------ */
 
 const LOCALSTORAGE_KEYS = [
-  'open3dcalc_settings_v2',
-  'open3dcalc_history_v2',
-  'open3dcalc_customers_v1',
-  'open3dcalc_quotes_v1',
-  'open3dcalc_catalog_v1',
-  'open3dcalc_filaments',
-  'open3dcalc_consent_v1',
-  'open3dcalc_tutorial_v1',
-  'open3dcalc_onboarded',
-  'open3dcalc_dashboard_v1',
-  'open3dcalc_migration_done_v2',
-  'open3dcalc_sections',
-  'open3dcalc_theme',
+  "open3dcalc_settings_v2",
+  "open3dcalc_history_v2",
+  "open3dcalc_customers_v1",
+  "open3dcalc_quotes_v1",
+  "open3dcalc_catalog_v1",
+  "open3dcalc_filaments",
+  "open3dcalc_consent_v1",
+  "open3dcalc_tutorial_v1",
+  "open3dcalc_onboarded",
+  "open3dcalc_dashboard_v1",
+  "open3dcalc_migration_done_v2",
+  "open3dcalc_sections",
+  "open3dcalc_theme",
 ] as const;
 
 /* ------------------------------------------------------------------ */
@@ -51,7 +53,7 @@ const LOCALSTORAGE_KEYS = [
  * Check whether we're running inside Electron with the IPC bridge available.
  */
 function isElectron(): boolean {
-  return typeof window !== 'undefined' && !!window.electronAPI?.db;
+  return typeof window !== "undefined" && !!window.electronAPI?.db;
 }
 
 /**
@@ -80,6 +82,8 @@ async function loadFromDatabase(): Promise<void> {
 
     for (const key of keys) {
       const raw = await db().load(key);
+      // SPEC-01 gate: unknown keys are never materialized locally.
+      if (!isKeyAllowed(key)) continue;
       if (raw !== null && raw !== undefined) {
         localStorage.setItem(key, raw);
         loaded++;
@@ -91,16 +95,19 @@ async function loadFromDatabase(): Promise<void> {
     );
   } catch (error) {
     console.warn(
-      '[persistence-bridge] Failed to load from SQLite, using localStorage fallback:',
+      "[persistence-bridge] Failed to load from SQLite, using localStorage fallback:",
       error,
     );
-    consecutiveDbFailures++
+    consecutiveDbFailures++;
     if (consecutiveDbFailures === MAX_FAILURES_BEFORE_WARN) {
-      if (typeof document !== 'undefined') {
-        const event = new CustomEvent('open3dcalc:db-error', {
-          detail: { message: 'Database unavailable — data will not persist between sessions.' }
-        })
-        document.dispatchEvent(event)
+      if (typeof document !== "undefined") {
+        const event = new CustomEvent("open3dcalc:db-error", {
+          detail: {
+            message:
+              "Database unavailable — data will not persist between sessions.",
+          },
+        });
+        document.dispatchEvent(event);
       }
     }
   }
@@ -118,6 +125,8 @@ async function saveToDatabase(): Promise<void> {
 
     // 1. Save known keys from the static list
     for (const key of LOCALSTORAGE_KEYS) {
+      // SPEC-01 gate: unknown keys are denied and never copied to SQLite.
+      if (!isKeyAllowed(key)) continue;
       const raw = localStorage.getItem(key);
       if (raw !== null) {
         await db().save(key, raw);
@@ -130,9 +139,12 @@ async function saveToDatabase(): Promise<void> {
       const key = localStorage.key(i);
       if (
         key &&
-        !LOCALSTORAGE_KEYS.includes(key as (typeof LOCALSTORAGE_KEYS)[number]) &&
-        key.startsWith('open3dcalc_')
+        !LOCALSTORAGE_KEYS.includes(
+          key as (typeof LOCALSTORAGE_KEYS)[number],
+        ) &&
+        key.startsWith("open3dcalc_")
       ) {
+        if (!isKeyAllowed(key)) continue;
         const raw = localStorage.getItem(key);
         if (raw !== null) {
           await db().save(key, raw);
@@ -143,14 +155,17 @@ async function saveToDatabase(): Promise<void> {
 
     console.log(`[persistence-bridge] Saved ${saved} keys to SQLite`);
   } catch (error) {
-    console.warn('[persistence-bridge] Failed to save to SQLite:', error);
-    consecutiveDbFailures++
+    console.warn("[persistence-bridge] Failed to save to SQLite:", error);
+    consecutiveDbFailures++;
     if (consecutiveDbFailures === MAX_FAILURES_BEFORE_WARN) {
-      if (typeof document !== 'undefined') {
-        const event = new CustomEvent('open3dcalc:db-error', {
-          detail: { message: 'Database unavailable — data will not persist between sessions.' }
-        })
-        document.dispatchEvent(event)
+      if (typeof document !== "undefined") {
+        const event = new CustomEvent("open3dcalc:db-error", {
+          detail: {
+            message:
+              "Database unavailable — data will not persist between sessions.",
+          },
+        });
+        document.dispatchEvent(event);
       }
     }
   }
@@ -176,7 +191,7 @@ async function deleteStaleKeys(): Promise<void> {
       }
     }
   } catch (error) {
-    console.warn('[persistence-bridge] Failed to clean stale keys:', error);
+    console.warn("[persistence-bridge] Failed to clean stale keys:", error);
   }
 }
 
@@ -191,18 +206,18 @@ async function migrateIfNeeded(): Promise<void> {
     if (existingKeys.length > 0) {
       // SQLite already has data — skip migration
       console.log(
-        '[persistence-bridge] SQLite has data, skipping localStorage migration',
+        "[persistence-bridge] SQLite has data, skipping localStorage migration",
       );
       return;
     }
 
     // SQLite is empty — migrate from localStorage
     console.log(
-      '[persistence-bridge] First run detected — migrating localStorage → SQLite',
+      "[persistence-bridge] First run detected — migrating localStorage → SQLite",
     );
     await saveToDatabase();
   } catch (error) {
-    console.warn('[persistence-bridge] Migration check failed:', error);
+    console.warn("[persistence-bridge] Migration check failed:", error);
   }
 }
 
@@ -225,7 +240,7 @@ async function migrateIfNeeded(): Promise<void> {
 export async function initPersistenceBridge(): Promise<void> {
   if (!isElectron()) {
     console.log(
-      '[persistence-bridge] Not running in Electron — using localStorage only',
+      "[persistence-bridge] Not running in Electron — using localStorage only",
     );
     return;
   }
@@ -242,7 +257,7 @@ export async function initPersistenceBridge(): Promise<void> {
   // Electron's IPC invoke returns a Promise; we await it to flush.
   // As a safety net, the 30 s periodic save guards against data loss
   // if beforeunload doesn't fully complete.
-  window.addEventListener('beforeunload', () => {
+  window.addEventListener("beforeunload", () => {
     saveToDatabase();
   });
 
@@ -255,7 +270,7 @@ export async function initPersistenceBridge(): Promise<void> {
   }, AUTO_SAVE_INTERVAL_MS);
 
   console.log(
-    '[persistence-bridge] Initialized — localStorage ↔ SQLite sync active',
+    "[persistence-bridge] Initialized — localStorage ↔ SQLite sync active",
   );
 }
 

--- a/src/platform/desktop/overrides/theme-persistence.ts
+++ b/src/platform/desktop/overrides/theme-persistence.ts
@@ -11,15 +11,16 @@
  * then fires-and-forgets the SQLite write for durability.
  */
 
-export type ThemeMode = 'dark' | 'light' | 'system'
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-const THEME_KEY = 'open3dcalc_theme'
+export type ThemeMode = "dark" | "light" | "system";
 
-const VALID_MODES: readonly ThemeMode[] = ['dark', 'light', 'system']
+const THEME_KEY = "open3dcalc_theme";
 
+const VALID_MODES: readonly ThemeMode[] = ["dark", "light", "system"];
 /** Type guard — narrows a string to ThemeMode. */
 function isThemeMode(value: string): value is ThemeMode {
-  return (VALID_MODES as readonly string[]).includes(value)
+  return (VALID_MODES as readonly string[]).includes(value);
 }
 
 /* ------------------------------------------------------------------ */
@@ -27,15 +28,15 @@ function isThemeMode(value: string): value is ThemeMode {
 /* ------------------------------------------------------------------ */
 
 function isElectron(): boolean {
-  return typeof window !== 'undefined' && !!window.electronAPI?.db
+  return typeof window !== "undefined" && !!window.electronAPI?.db;
 }
 
 /** Fire-and-forget SQLite write via IPC. Errors logged, never thrown. */
 function persistToSQLite(mode: ThemeMode): void {
-  if (!isElectron()) return
+  if (!isElectron()) return;
   window.electronAPI!.db.save(THEME_KEY, mode).catch((err) => {
-    console.warn('[theme-persistence] Failed to persist to SQLite:', err)
-  })
+    console.warn("[theme-persistence] Failed to persist to SQLite:", err);
+  });
 }
 
 /* ------------------------------------------------------------------ */
@@ -54,27 +55,30 @@ export async function loadThemePreference(): Promise<ThemeMode> {
   // 1. Try SQLite (most durable source)
   if (isElectron()) {
     try {
-      const raw = await window.electronAPI!.db.load(THEME_KEY)
+      const raw = await window.electronAPI!.db.load(THEME_KEY);
       if (raw !== null && isThemeMode(raw)) {
         // Sync to localStorage so the value is immediately available
-        localStorage.setItem(THEME_KEY, raw)
-        return raw
+        guardedStorage.setItem(THEME_KEY, raw);
+        return raw;
       }
     } catch (err) {
-      console.warn('[theme-persistence] SQLite load failed, falling back:', err)
+      console.warn(
+        "[theme-persistence] SQLite load failed, falling back:",
+        err,
+      );
     }
   }
 
   // 2. Fallback to localStorage
-  const stored = localStorage.getItem(THEME_KEY)
+  const stored = guardedStorage.getItem(THEME_KEY);
   if (stored !== null && isThemeMode(stored)) {
     // If Electron is available, push to SQLite in background
-    persistToSQLite(stored)
-    return stored
+    persistToSQLite(stored);
+    return stored;
   }
 
   // 3. Default
-  return 'system'
+  return "system";
 }
 
 /**
@@ -86,13 +90,13 @@ export async function loadThemePreference(): Promise<ThemeMode> {
  */
 export async function saveThemePreference(mode: ThemeMode): Promise<void> {
   if (!isThemeMode(mode)) {
-    console.error(`[theme-persistence] Invalid theme mode: "${mode}"`)
-    return
+    console.error(`[theme-persistence] Invalid theme mode: "${mode}"`);
+    return;
   }
 
   // 1. localStorage — immediate availability
-  localStorage.setItem(THEME_KEY, mode)
+  guardedStorage.setItem(THEME_KEY, mode);
 
   // 2. SQLite — durable persistence
-  persistToSQLite(mode)
+  persistToSQLite(mode);
 }

--- a/src/platform/web/App.tsx
+++ b/src/platform/web/App.tsx
@@ -12,6 +12,7 @@ import { CustomerTab } from "@/shared/components/Catalog/CustomerTab";
 import { ProductInventory } from "@/shared/components/Catalog/ProductInventory";
 import { QuoteSection } from "@/shared/components/Calculator/QuoteSection";
 import { restoreAutoSnapshot } from "@/shared/stores/storeBridge";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 import { useHistoryStore } from "@/shared/stores/historyStore";
 import { useCalculatorStore } from "@/shared/stores/calculatorStore";
 import { computeStoreResults } from "@/shared/stores/calculatorStore.compute";
@@ -170,14 +171,14 @@ function App() {
       const existing = historyStore.entries.length;
 
       // Skip if already migrated
-      if (localStorage.getItem("open3dcalc_migration_done_v2")) return;
+      if (guardedStorage.getItem("open3dcalc_migration_done_v2")) return;
 
       // Only migrate if historyStore is empty (prevent duplicates)
       if (existing > 0) return;
 
       // Migrar productStore antigo
       try {
-        const oldProducts = localStorage.getItem("open3dcalc_products");
+        const oldProducts = guardedStorage.getItem("open3dcalc_products");
         if (oldProducts) {
           const parsed = JSON.parse(oldProducts) as unknown;
           if (Array.isArray(parsed)) {
@@ -201,7 +202,7 @@ function App() {
               });
             });
           }
-          localStorage.removeItem("open3dcalc_products");
+          guardedStorage.removeItem("open3dcalc_products");
         }
       } catch (error) {
         console.warn("Failed to migrate open3dcalc_products", error);
@@ -209,7 +210,7 @@ function App() {
 
       // Migrar calculatorStore.history antigo (v1)
       try {
-        const oldHistory = localStorage.getItem("open3dcalc_history_v2");
+        const oldHistory = guardedStorage.getItem("open3dcalc_history_v2");
         if (oldHistory) {
           const parsed = JSON.parse(oldHistory) as unknown;
           if (Array.isArray(parsed)) {
@@ -251,7 +252,7 @@ function App() {
                 snapshot: legacyItem.snapshot || null,
               });
             });
-            localStorage.removeItem("open3dcalc_history_v2");
+            guardedStorage.removeItem("open3dcalc_history_v2");
           }
         }
       } catch (error) {
@@ -295,7 +296,7 @@ function App() {
         targetMarginMode: calc.targetMarginMode,
         enabledSections: calc.enabledSections,
       };
-      localStorage.setItem("open3dcalc_settings_v2", JSON.stringify(data));
+      guardedStorage.setItem("open3dcalc_settings_v2", JSON.stringify(data));
     };
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
@@ -379,7 +380,7 @@ function App() {
   useEffect(() => {
     const timer = setTimeout(() => {
       // Don't start tutorial if onboarding is still pending
-      const onboardingDone = localStorage.getItem("open3dcalc_onboarded");
+      const onboardingDone = guardedStorage.getItem("open3dcalc_onboarded");
       if (!onboardingDone) return;
 
       const store = useTutorialStore.getState();

--- a/src/shared/components/Dashboard/Dashboard.tsx
+++ b/src/shared/components/Dashboard/Dashboard.tsx
@@ -1,11 +1,19 @@
-import { useState, useEffect, useMemo, useRef, useCallback, Suspense, Fragment } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useCalculatorStore } from '@/shared/stores/calculatorStore'
-import { useHistoryStore } from '@/shared/stores/historyStore'
-import { InputGroup } from '@/shared/components/ui/InputGroup'
-import html2canvas from 'html2canvas'
-import { exportExecutivePdf } from '@/shared/lib/pdfExport'
-import type { ExecutiveReportData } from '@/shared/lib/ExecutiveReportDoc'
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+  Suspense,
+  Fragment,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { useCalculatorStore } from "@/shared/stores/calculatorStore";
+import { useHistoryStore } from "@/shared/stores/historyStore";
+import { InputGroup } from "@/shared/components/ui/InputGroup";
+import html2canvas from "html2canvas";
+import { exportExecutivePdf } from "@/shared/lib/pdfExport";
+import type { ExecutiveReportData } from "@/shared/lib/ExecutiveReportDoc";
 import {
   PieChart,
   Pie,
@@ -19,26 +27,35 @@ import {
   CartesianGrid,
   XAxis,
   YAxis,
-} from './RechartsLazy'
-import { useCurrency } from '@/shared/hooks/useCurrency'
+} from "./RechartsLazy";
+import { useCurrency } from "@/shared/hooks/useCurrency";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-const DASHBOARD_KEY = 'open3dcalc_dashboard_v1'
+const DASHBOARD_KEY = "open3dcalc_dashboard_v1";
 
-const COLORS = ['#6366f1', '#ec4899', '#10b981', '#f59e0b', '#3b82f6', '#ef4444', '#14b8a6']
+const COLORS = [
+  "#6366f1",
+  "#ec4899",
+  "#10b981",
+  "#f59e0b",
+  "#3b82f6",
+  "#ef4444",
+  "#14b8a6",
+];
 
 function loadDashboardSettings() {
-  if (typeof window === 'undefined') return {}
+  if (typeof window === "undefined") return {};
   try {
-    const raw = localStorage.getItem(DASHBOARD_KEY)
-    return raw ? JSON.parse(raw) : {}
+    const raw = guardedStorage.getItem(DASHBOARD_KEY);
+    return raw ? JSON.parse(raw) : {};
   } catch {
-    return {}
+    return {};
   }
 }
 
 function saveDashboardSettings(data: Record<string, unknown>) {
   try {
-    localStorage.setItem(DASHBOARD_KEY, JSON.stringify(data))
+    guardedStorage.setItem(DASHBOARD_KEY, JSON.stringify(data));
   } catch {
     // Silently fail if localStorage is unavailable
   }
@@ -48,249 +65,333 @@ function saveDashboardSettings(data: Record<string, unknown>) {
 // Date helpers
 // ---------------------------------------------------------------------------
 const dateStrToEpoch = (dateStr: string): number => {
-  const [year, month, day] = dateStr.split('-').map(Number)
-  return new Date(year, month - 1, day).getTime()
-}
+  const [year, month, day] = dateStr.split("-").map(Number);
+  return new Date(year, month - 1, day).getTime();
+};
 
 const epochToDateStr = (epoch: number | null): string => {
-  if (epoch === null) return ''
-  const d = new Date(epoch)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
+  if (epoch === null) return "";
+  const d = new Date(epoch);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+};
 
 export function Dashboard() {
-  const { t, i18n } = useTranslation()
-  const store = useCalculatorStore()
-  const results = store.results
-  const fixedCosts = store.fixedCosts
-  const { currency, format: formatMoney, symbol: currencySymbol } = useCurrency()
-  const historyEntries = useHistoryStore(s => s.entries)
+  const { t, i18n } = useTranslation();
+  const store = useCalculatorStore();
+  const results = store.results;
+  const fixedCosts = store.fixedCosts;
+  const {
+    currency,
+    format: formatMoney,
+    symbol: currencySymbol,
+  } = useCurrency();
+  const historyEntries = useHistoryStore((s) => s.entries);
 
   // Local date range filter state (independent from history store)
-  const [dashboardDateFrom, setDashboardDateFrom] = useState<number | null>(null)
-  const [dashboardDateTo, setDashboardDateTo] = useState<number | null>(null)
+  const [dashboardDateFrom, setDashboardDateFrom] = useState<number | null>(
+    null,
+  );
+  const [dashboardDateTo, setDashboardDateTo] = useState<number | null>(null);
 
   // Filter entries by date range
   const filteredEntries = useMemo(() => {
-    let result = historyEntries
+    let result = historyEntries;
     if (dashboardDateFrom !== null) {
-      result = result.filter(e => e.timestamp >= dashboardDateFrom)
+      result = result.filter((e) => e.timestamp >= dashboardDateFrom);
     }
     if (dashboardDateTo !== null) {
-      const endOfDay = dashboardDateTo + 86_399_999 // 23:59:59.999
-      result = result.filter(e => e.timestamp <= endOfDay)
+      const endOfDay = dashboardDateTo + 86_399_999; // 23:59:59.999
+      result = result.filter((e) => e.timestamp <= endOfDay);
     }
-    return result
-  }, [historyEntries, dashboardDateFrom, dashboardDateTo])
+    return result;
+  }, [historyEntries, dashboardDateFrom, dashboardDateTo]);
 
   // Load saved values on mount
-  const saved = useMemo(() => loadDashboardSettings(), [])
+  const saved = useMemo(() => loadDashboardSettings(), []);
 
-  const [printsPerMonth, setPrintsPerMonth] = useState(() => (saved.printsPerMonth as number) ?? 30)
-  const [buyPrice, setBuyPrice] = useState(() => (saved.buyPrice as string) ?? '')
-  const [targetSellPrice, setTargetSellPrice] = useState(() => (saved.targetSellPrice as string) ?? '')
-  const [exportingPdf, setExportingPdf] = useState(false)
-  const trendChartRef = useRef<HTMLDivElement>(null)
+  const [printsPerMonth, setPrintsPerMonth] = useState(
+    () => (saved.printsPerMonth as number) ?? 30,
+  );
+  const [buyPrice, setBuyPrice] = useState(
+    () => (saved.buyPrice as string) ?? "",
+  );
+  const [targetSellPrice, setTargetSellPrice] = useState(
+    () => (saved.targetSellPrice as string) ?? "",
+  );
+  const [exportingPdf, setExportingPdf] = useState(false);
+  const trendChartRef = useRef<HTMLDivElement>(null);
 
   // Persist to localStorage on change
   useEffect(() => {
-    saveDashboardSettings({ printsPerMonth, buyPrice, targetSellPrice })
-  }, [printsPerMonth, buyPrice, targetSellPrice])
+    saveDashboardSettings({ printsPerMonth, buyPrice, targetSellPrice });
+  }, [printsPerMonth, buyPrice, targetSellPrice]);
 
   const handleInput = (value: string, setter: (v: number) => void) => {
-    setter(value === '' ? 0 : parseFloat(value) || 0)
-  }
+    setter(value === "" ? 0 : parseFloat(value) || 0);
+  };
 
-  const monthlyProjection = results ? {
-    revenue: results.sellPrice * printsPerMonth,
-    cost: results.totalCost * printsPerMonth,
-    profit: results.profit * printsPerMonth,
-    annualProfit: results.profit * printsPerMonth * 12,
-  } : null
+  const monthlyProjection = results
+    ? {
+        revenue: results.sellPrice * printsPerMonth,
+        cost: results.totalCost * printsPerMonth,
+        profit: results.profit * printsPerMonth,
+        annualProfit: results.profit * printsPerMonth * 12,
+      }
+    : null;
 
   // Break-even calculation
-  const breakEven = results && fixedCosts.enabled && fixedCosts.monthlyCost > 0 ? {
-    variableCostPerUnit: results.totalCost,
-    sellPrice: results.sellPrice,
-    marginPerUnit: results.sellPrice - results.totalCost,
-    monthlyFixedCost: fixedCosts.monthlyCost,
-  } : null
+  const breakEven =
+    results && fixedCosts.enabled && fixedCosts.monthlyCost > 0
+      ? {
+          variableCostPerUnit: results.totalCost,
+          sellPrice: results.sellPrice,
+          marginPerUnit: results.sellPrice - results.totalCost,
+          monthlyFixedCost: fixedCosts.monthlyCost,
+        }
+      : null;
 
-  const breakEvenUnits = breakEven && breakEven.marginPerUnit > 0
-    ? Math.ceil(breakEven.monthlyFixedCost / breakEven.marginPerUnit)
-    : null
+  const breakEvenUnits =
+    breakEven && breakEven.marginPerUnit > 0
+      ? Math.ceil(breakEven.monthlyFixedCost / breakEven.marginPerUnit)
+      : null;
 
-  const breakEvenRevenue = breakEvenUnits !== null && breakEven
-    ? breakEvenUnits * breakEven.sellPrice
-    : null
+  const breakEvenRevenue =
+    breakEvenUnits !== null && breakEven
+      ? breakEvenUnits * breakEven.sellPrice
+      : null;
 
   // Average margin from history (filtered)
   const avgMargin = useMemo(() => {
     const margins = filteredEntries
-      .filter(e => e.sellPrice > 0)
-      .map(e => (e.profit / e.sellPrice) * 100)
-    if (margins.length === 0) return null
-    return margins.reduce((a, b) => a + b, 0) / margins.length
-  }, [filteredEntries])
+      .filter((e) => e.sellPrice > 0)
+      .map((e) => (e.profit / e.sellPrice) * 100);
+    if (margins.length === 0) return null;
+    return margins.reduce((a, b) => a + b, 0) / margins.length;
+  }, [filteredEntries]);
 
   // Profit trend data (filtered)
   const trendData = useMemo(() => {
-    const sorted = [...filteredEntries]
-      .sort((a, b) => a.timestamp - b.timestamp)
-    const locale = i18n.resolvedLanguage || i18n.language
-    return sorted.map(e => ({
+    const sorted = [...filteredEntries].sort(
+      (a, b) => a.timestamp - b.timestamp,
+    );
+    const locale = i18n.resolvedLanguage || i18n.language;
+    return sorted.map((e) => ({
       date: new Date(e.timestamp).toLocaleDateString(locale),
       profit: Math.round(e.profit * 100) / 100,
-    }))
-  }, [filteredEntries, i18n.resolvedLanguage, i18n.language])
+    }));
+  }, [filteredEntries, i18n.resolvedLanguage, i18n.language]);
 
-  const printVsBuy = results && buyPrice ? {
-    printCost: results.totalCost,
-    buyPrice: parseFloat(buyPrice) || 0,
-    cheaper: results.totalCost <= (parseFloat(buyPrice) || 0) ? 'print' as const : 'buy' as const,
-    savings: Math.abs(results.totalCost - (parseFloat(buyPrice) || 0)),
-    savingsPercent: (parseFloat(buyPrice) || 0) > 0 ? (Math.abs(results.totalCost - (parseFloat(buyPrice) || 0)) / (parseFloat(buyPrice) || 0)) * 100 : 0,
-  } : null
+  const printVsBuy =
+    results && buyPrice
+      ? {
+          printCost: results.totalCost,
+          buyPrice: parseFloat(buyPrice) || 0,
+          cheaper:
+            results.totalCost <= (parseFloat(buyPrice) || 0)
+              ? ("print" as const)
+              : ("buy" as const),
+          savings: Math.abs(results.totalCost - (parseFloat(buyPrice) || 0)),
+          savingsPercent:
+            (parseFloat(buyPrice) || 0) > 0
+              ? (Math.abs(results.totalCost - (parseFloat(buyPrice) || 0)) /
+                  (parseFloat(buyPrice) || 0)) *
+                100
+              : 0,
+        }
+      : null;
 
-  const reverseMargin = results && targetSellPrice ? {
-    targetPrice: parseFloat(targetSellPrice) || 0,
-    actualMargin: results.totalCost > 0 && (parseFloat(targetSellPrice) || 0) > 0
-      ? (((parseFloat(targetSellPrice) || 0) - results.totalCost - results.taxAmount - results.marketplaceFee) / (parseFloat(targetSellPrice) || 0)) * 100
-      : 0,
-    profit: (parseFloat(targetSellPrice) || 0) - results.totalCost - results.taxAmount - results.marketplaceFee,
-  } : null
+  const reverseMargin =
+    results && targetSellPrice
+      ? {
+          targetPrice: parseFloat(targetSellPrice) || 0,
+          actualMargin:
+            results.totalCost > 0 && (parseFloat(targetSellPrice) || 0) > 0
+              ? (((parseFloat(targetSellPrice) || 0) -
+                  results.totalCost -
+                  results.taxAmount -
+                  results.marketplaceFee) /
+                  (parseFloat(targetSellPrice) || 0)) *
+                100
+              : 0,
+          profit:
+            (parseFloat(targetSellPrice) || 0) -
+            results.totalCost -
+            results.taxAmount -
+            results.marketplaceFee,
+        }
+      : null;
 
   // ---------------------------------------------------------------------------
   // Top Printers (from filtered history)
   // ---------------------------------------------------------------------------
   const topPrintersData = useMemo(() => {
-    const map = new Map<string, { profit: number; count: number }>()
+    const map = new Map<string, { profit: number; count: number }>();
     for (const e of filteredEntries) {
-      const name = e.snapshot?.selectedPrinterId || (e.type === 'resin' ? 'Resin' : 'FDM')
-      const existing = map.get(name) || { profit: 0, count: 0 }
-      existing.profit += e.profit
-      existing.count++
-      map.set(name, existing)
+      const name =
+        e.snapshot?.selectedPrinterId || (e.type === "resin" ? "Resin" : "FDM");
+      const existing = map.get(name) || { profit: 0, count: 0 };
+      existing.profit += e.profit;
+      existing.count++;
+      map.set(name, existing);
     }
     return Array.from(map.entries())
-      .map(([name, data]) => ({ name: name.charAt(0).toUpperCase() + name.slice(1), ...data }))
+      .map(([name, data]) => ({
+        name: name.charAt(0).toUpperCase() + name.slice(1),
+        ...data,
+      }))
       .sort((a, b) => b.profit - a.profit)
-      .slice(0, 5)
-  }, [filteredEntries])
+      .slice(0, 5);
+  }, [filteredEntries]);
 
   // ---------------------------------------------------------------------------
   // Top Materials (from filtered history)
   // ---------------------------------------------------------------------------
   const topMaterialsData = useMemo(() => {
-    const map = new Map<string, { count: number; totalCost: number }>()
+    const map = new Map<string, { count: number; totalCost: number }>();
     for (const e of filteredEntries) {
-      const type = e.snapshot?.fdmMaterial?.type || e.snapshot?.resinMaterial?.type || e.type
-      const existing = map.get(type) || { count: 0, totalCost: 0 }
-      existing.count++
-      existing.totalCost += e.totalCost
-      map.set(type, existing)
+      const type =
+        e.snapshot?.fdmMaterial?.type ||
+        e.snapshot?.resinMaterial?.type ||
+        e.type;
+      const existing = map.get(type) || { count: 0, totalCost: 0 };
+      existing.count++;
+      existing.totalCost += e.totalCost;
+      map.set(type, existing);
     }
     return Array.from(map.entries())
       .map(([name, data]) => ({ name: name.toUpperCase(), ...data }))
       .sort((a, b) => b.count - a.count)
-      .slice(0, 5)
-  }, [filteredEntries])
+      .slice(0, 5);
+  }, [filteredEntries]);
 
   // ---------------------------------------------------------------------------
   // Period Comparison: current month vs previous month
   // ---------------------------------------------------------------------------
   const periodComparison = useMemo(() => {
-    const now = new Date()
-    const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1).getTime()
-    const prevMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1).getTime()
+    const now = new Date();
+    const currentMonthStart = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      1,
+    ).getTime();
+    const prevMonthStart = new Date(
+      now.getFullYear(),
+      now.getMonth() - 1,
+      1,
+    ).getTime();
 
-    const current = filteredEntries.filter(e => e.timestamp >= currentMonthStart)
-    const previous = filteredEntries.filter(e => e.timestamp >= prevMonthStart && e.timestamp < currentMonthStart)
+    const current = filteredEntries.filter(
+      (e) => e.timestamp >= currentMonthStart,
+    );
+    const previous = filteredEntries.filter(
+      (e) => e.timestamp >= prevMonthStart && e.timestamp < currentMonthStart,
+    );
 
-    const sum = (arr: typeof filteredEntries, key: 'sellPrice' | 'totalCost' | 'profit') =>
-      arr.reduce((s, e) => s + e[key], 0)
+    const sum = (
+      arr: typeof filteredEntries,
+      key: "sellPrice" | "totalCost" | "profit",
+    ) => arr.reduce((s, e) => s + e[key], 0);
 
     const calcChange = (cur: number, prev: number): number | null => {
-      if (prev === 0) return cur > 0 ? 100 : null
-      return parseFloat((((cur - prev) / Math.abs(prev)) * 100).toFixed(1))
-    }
+      if (prev === 0) return cur > 0 ? 100 : null;
+      return parseFloat((((cur - prev) / Math.abs(prev)) * 100).toFixed(1));
+    };
 
     return [
       {
-        key: 'revenue' as const,
-        current: sum(current, 'sellPrice'),
-        previous: sum(previous, 'sellPrice'),
+        key: "revenue" as const,
+        current: sum(current, "sellPrice"),
+        previous: sum(previous, "sellPrice"),
       },
       {
-        key: 'cost' as const,
-        current: sum(current, 'totalCost'),
-        previous: sum(previous, 'totalCost'),
+        key: "cost" as const,
+        current: sum(current, "totalCost"),
+        previous: sum(previous, "totalCost"),
       },
       {
-        key: 'profit' as const,
-        current: sum(current, 'profit'),
-        previous: sum(previous, 'profit'),
+        key: "profit" as const,
+        current: sum(current, "profit"),
+        previous: sum(previous, "profit"),
       },
       {
-        key: 'printCount' as const,
+        key: "printCount" as const,
         current: current.length,
         previous: previous.length,
       },
-    ].map(m => ({
+    ].map((m) => ({
       ...m,
       change: calcChange(m.current, m.previous),
-    }))
-  }, [filteredEntries])
+    }));
+  }, [filteredEntries]);
 
   // ---------------------------------------------------------------------------
   // PDF Export Handler
   // ---------------------------------------------------------------------------
   const handleExportPdf = useCallback(async () => {
-    setExportingPdf(true)
+    setExportingPdf(true);
     try {
       // Capture profit trend chart as base64 image
-      let chartImage: string | undefined
+      let chartImage: string | undefined;
       if (trendChartRef.current) {
         const canvas = await html2canvas(trendChartRef.current, {
           backgroundColor: null,
           scale: 2,
           logging: false,
-        })
-        chartImage = canvas.toDataURL('image/png')
+        });
+        chartImage = canvas.toDataURL("image/png");
       }
 
       // Build period range from filter or fallback to last 90 days
-      const dateFrom = dashboardDateFrom ?? Date.now() - 90 * 24 * 60 * 60 * 1000
-      const dateTo = dashboardDateTo ?? Date.now()
-      const fromStr = epochToDateStr(dateFrom)
-      const toStr = epochToDateStr(dateTo)
+      const dateFrom =
+        dashboardDateFrom ?? Date.now() - 90 * 24 * 60 * 60 * 1000;
+      const dateTo = dashboardDateTo ?? Date.now();
+      const fromStr = epochToDateStr(dateFrom);
+      const toStr = epochToDateStr(dateTo);
 
-      const sorted = [...filteredEntries].sort((a, b) => a.timestamp - b.timestamp)
+      const sorted = [...filteredEntries].sort(
+        (a, b) => a.timestamp - b.timestamp,
+      );
 
-      const totalRevenue = sorted.reduce((s, e) => s + e.sellPrice, 0)
-      const totalCost = sorted.reduce((s, e) => s + e.totalCost, 0)
-      const totalProfit = sorted.reduce((s, e) => s + e.profit, 0)
-      const marginEntries = sorted.filter(e => e.sellPrice > 0)
-      const avgMargin = marginEntries.length > 0
-        ? marginEntries.reduce((s, e) => s + (e.profit / e.sellPrice) * 100, 0) / marginEntries.length
-        : 0
+      const totalRevenue = sorted.reduce((s, e) => s + e.sellPrice, 0);
+      const totalCost = sorted.reduce((s, e) => s + e.totalCost, 0);
+      const totalProfit = sorted.reduce((s, e) => s + e.profit, 0);
+      const marginEntries = sorted.filter((e) => e.sellPrice > 0);
+      const avgMargin =
+        marginEntries.length > 0
+          ? marginEntries.reduce(
+              (s, e) => s + (e.profit / e.sellPrice) * 100,
+              0,
+            ) / marginEntries.length
+          : 0;
 
       // Recompute comparison for the report (use same logic as periodComparison)
       const calcChange = (cur: number, prev: number): number | null => {
-        if (prev === 0) return cur > 0 ? 100 : null
-        return parseFloat((((cur - prev) / Math.abs(prev)) * 100).toFixed(1))
-      }
+        if (prev === 0) return cur > 0 ? 100 : null;
+        return parseFloat((((cur - prev) / Math.abs(prev)) * 100).toFixed(1));
+      };
 
-      const now = new Date()
-      const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1).getTime()
-      const prevMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1).getTime()
-      const current = sorted.filter(e => e.timestamp >= currentMonthStart)
-      const previous = sorted.filter(e => e.timestamp >= prevMonthStart && e.timestamp < currentMonthStart)
+      const now = new Date();
+      const currentMonthStart = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        1,
+      ).getTime();
+      const prevMonthStart = new Date(
+        now.getFullYear(),
+        now.getMonth() - 1,
+        1,
+      ).getTime();
+      const current = sorted.filter((e) => e.timestamp >= currentMonthStart);
+      const previous = sorted.filter(
+        (e) => e.timestamp >= prevMonthStart && e.timestamp < currentMonthStart,
+      );
 
-      const sum = (arr: typeof sorted, key: 'sellPrice' | 'totalCost' | 'profit') =>
-        arr.reduce((s, e) => s + e[key], 0)
+      const sum = (
+        arr: typeof sorted,
+        key: "sellPrice" | "totalCost" | "profit",
+      ) => arr.reduce((s, e) => s + e[key], 0);
 
-      const locale = i18n.resolvedLanguage || i18n.language || 'pt-BR'
+      const locale = i18n.resolvedLanguage || i18n.language || "pt-BR";
       const reportData: ExecutiveReportData = {
         period: { from: fromStr, to: toStr },
         entryCount: sorted.length,
@@ -302,136 +403,196 @@ export function Dashboard() {
         topMaterials: topMaterialsData,
         comparison: {
           revenue: {
-            current: sum(current, 'sellPrice'),
-            previous: sum(previous, 'sellPrice'),
-            change: calcChange(sum(current, 'sellPrice'), sum(previous, 'sellPrice')),
+            current: sum(current, "sellPrice"),
+            previous: sum(previous, "sellPrice"),
+            change: calcChange(
+              sum(current, "sellPrice"),
+              sum(previous, "sellPrice"),
+            ),
           },
           cost: {
-            current: sum(current, 'totalCost'),
-            previous: sum(previous, 'totalCost'),
-            change: calcChange(sum(current, 'totalCost'), sum(previous, 'totalCost')),
+            current: sum(current, "totalCost"),
+            previous: sum(previous, "totalCost"),
+            change: calcChange(
+              sum(current, "totalCost"),
+              sum(previous, "totalCost"),
+            ),
           },
           profit: {
-            current: sum(current, 'profit'),
-            previous: sum(previous, 'profit'),
-            change: calcChange(sum(current, 'profit'), sum(previous, 'profit')),
+            current: sum(current, "profit"),
+            previous: sum(previous, "profit"),
+            change: calcChange(sum(current, "profit"), sum(previous, "profit")),
           },
         },
         chartImage,
         locale,
         currency,
-      }
+      };
 
-      await exportExecutivePdf(reportData)
+      await exportExecutivePdf(reportData);
     } finally {
-      setExportingPdf(false)
+      setExportingPdf(false);
     }
-  }, [filteredEntries, dashboardDateFrom, dashboardDateTo, topPrintersData, topMaterialsData, i18n, currency])
+  }, [
+    filteredEntries,
+    dashboardDateFrom,
+    dashboardDateTo,
+    topPrintersData,
+    topMaterialsData,
+    i18n,
+    currency,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Custom Goal
   // ---------------------------------------------------------------------------
-  const GOAL_KEY = 'open3dcalc_dashboard_goal'
+  const GOAL_KEY = "open3dcalc_dashboard_goal";
   const [goal, setGoal] = useState(() => {
-    if (typeof window === 'undefined') return ''
+    if (typeof window === "undefined") return "";
     try {
-      return localStorage.getItem(GOAL_KEY) || ''
+      return guardedStorage.getItem(GOAL_KEY) || "";
     } catch {
-      return ''
+      return "";
     }
-  })
+  });
 
   useEffect(() => {
     try {
-      localStorage.setItem(GOAL_KEY, goal)
+      guardedStorage.setItem(GOAL_KEY, goal);
     } catch {
       // Silently fail
     }
-  }, [goal])
+  }, [goal]);
 
   const printsNeeded = useMemo(() => {
-    const goalValue = parseFloat(goal)
-    if (!goalValue || goalValue <= 0 || !results) return null
-    if (results.profit <= 0) return { prints: Infinity, negativeMargin: true, goalValue }
-    return { prints: Math.ceil(goalValue / results.profit), negativeMargin: false, goalValue }
-  }, [goal, results])
+    const goalValue = parseFloat(goal);
+    if (!goalValue || goalValue <= 0 || !results) return null;
+    if (results.profit <= 0)
+      return { prints: Infinity, negativeMargin: true, goalValue };
+    return {
+      prints: Math.ceil(goalValue / results.profit),
+      negativeMargin: false,
+      goalValue,
+    };
+  }, [goal, results]);
 
   // ---------------------------------------------------------------------------
   // Low-Margin Alerts
   // ---------------------------------------------------------------------------
   const lowMarginEntries = useMemo(() => {
     return filteredEntries
-      .filter(e => e.sellPrice > 0)
-      .map(e => ({ ...e, margin: (e.profit / e.sellPrice) * 100 }))
-      .filter(e => e.margin < 20)
+      .filter((e) => e.sellPrice > 0)
+      .map((e) => ({ ...e, margin: (e.profit / e.sellPrice) * 100 }))
+      .filter((e) => e.margin < 20)
       .sort((a, b) => a.margin - b.margin)
-      .slice(0, 3)
-  }, [filteredEntries])
+      .slice(0, 3);
+  }, [filteredEntries]);
 
   if (!results) {
     return (
       <div className="space-y-5">
         <div className="surface rounded-xl p-5">
-          <h2 className="text-lg font-bold text-[var(--color-text-primary)]">{t('nav.dashboard')}</h2>
-          <p className="text-xs text-[var(--color-text-muted)] mt-1">{t('calc.noCosts')}</p>
+          <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
+            {t("nav.dashboard")}
+          </h2>
+          <p className="text-xs text-[var(--color-text-muted)] mt-1">
+            {t("calc.noCosts")}
+          </p>
         </div>
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-          {[t('dashboard.totalCost'), t('dashboard.salePrice'), t('dashboard.profit'), t('dashboard.roi')].map(label => (
-            <div key={label} className="surface rounded-xl p-4 text-center hover:-translate-y-0.5 transition-transform">
-              <p className="text-xs text-[var(--color-text-secondary)] mb-1">{label}</p>
-              <p className="text-lg font-extrabold text-[var(--color-text-muted)]">---</p>
+          {[
+            t("dashboard.totalCost"),
+            t("dashboard.salePrice"),
+            t("dashboard.profit"),
+            t("dashboard.roi"),
+          ].map((label) => (
+            <div
+              key={label}
+              className="surface rounded-xl p-4 text-center hover:-translate-y-0.5 transition-transform"
+            >
+              <p className="text-xs text-[var(--color-text-secondary)] mb-1">
+                {label}
+              </p>
+              <p className="text-lg font-extrabold text-[var(--color-text-muted)]">
+                ---
+              </p>
             </div>
           ))}
         </div>
       </div>
-    )
+    );
   }
 
   const chartData = [
-    { name: t('breakdown.material'), value: results.materialCost },
-    { name: t('breakdown.energy'), value: results.energyCost },
-    { name: t('breakdown.depreciation'), value: results.machineCost },
-    { name: t('breakdown.maintenance'), value: results.consumablesCost },
-    { name: t('breakdown.labor'), value: results.laborCost },
-    { name: t('breakdown.packaging'), value: results.totalCost - results.subtotal - results.failureCost > 0 ? results.totalCost - results.subtotal - results.failureCost : 0 },
-    { name: t('breakdown.finishing'), value: results.postProcessingCost },
-  ].filter(d => d.value > 0)
+    { name: t("breakdown.material"), value: results.materialCost },
+    { name: t("breakdown.energy"), value: results.energyCost },
+    { name: t("breakdown.depreciation"), value: results.machineCost },
+    { name: t("breakdown.maintenance"), value: results.consumablesCost },
+    { name: t("breakdown.labor"), value: results.laborCost },
+    {
+      name: t("breakdown.packaging"),
+      value:
+        results.totalCost - results.subtotal - results.failureCost > 0
+          ? results.totalCost - results.subtotal - results.failureCost
+          : 0,
+    },
+    { name: t("breakdown.finishing"), value: results.postProcessingCost },
+  ].filter((d) => d.value > 0);
 
-  const roi = results.totalCost > 0 ? (results.profit / results.totalCost) * 100 : 0
+  const roi =
+    results.totalCost > 0 ? (results.profit / results.totalCost) * 100 : 0;
 
   return (
     <div className="space-y-5">
       {/* Header with Export PDF */}
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-bold text-[var(--color-text-primary)]">{t('nav.dashboard')}</h2>
+        <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
+          {t("nav.dashboard")}
+        </h2>
         <button
           onClick={handleExportPdf}
           disabled={exportingPdf || filteredEntries.length === 0}
           className="px-4 py-2 rounded-lg bg-[var(--color-accent)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
         >
-          {exportingPdf ? t('common.loading') : t('dashboard.exportPdf')}
+          {exportingPdf ? t("common.loading") : t("dashboard.exportPdf")}
         </button>
       </div>
 
       {/* KPI Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <div className="surface rounded-xl p-4 text-center hover:-translate-y-0.5 transition-transform">
-          <p className="text-xs text-[var(--color-text-secondary)] mb-1">{t('dashboard.totalCost')}</p>
-          <p className="text-lg font-extrabold text-pink-400">{formatMoney(results.totalCost)}</p>
+          <p className="text-xs text-[var(--color-text-secondary)] mb-1">
+            {t("dashboard.totalCost")}
+          </p>
+          <p className="text-lg font-extrabold text-pink-400">
+            {formatMoney(results.totalCost)}
+          </p>
         </div>
         <div className="surface rounded-xl p-4 text-center hover:-translate-y-0.5 transition-transform">
-          <p className="text-xs text-[var(--color-text-secondary)] mb-1">{t('dashboard.salePrice')}</p>
-          <p className="text-lg font-extrabold text-[var(--color-success)]">{formatMoney(results.sellPrice)}</p>
+          <p className="text-xs text-[var(--color-text-secondary)] mb-1">
+            {t("dashboard.salePrice")}
+          </p>
+          <p className="text-lg font-extrabold text-[var(--color-success)]">
+            {formatMoney(results.sellPrice)}
+          </p>
         </div>
         <div className="surface rounded-xl p-4 text-center hover:-translate-y-0.5 transition-transform">
-          <p className="text-xs text-[var(--color-text-secondary)] mb-1">{t('dashboard.profit')}</p>
-          <p className={`text-lg font-extrabold ${results.profit >= 0 ? 'text-[var(--color-accent)]' : 'text-[var(--color-danger)]'}`}>
+          <p className="text-xs text-[var(--color-text-secondary)] mb-1">
+            {t("dashboard.profit")}
+          </p>
+          <p
+            className={`text-lg font-extrabold ${results.profit >= 0 ? "text-[var(--color-accent)]" : "text-[var(--color-danger)]"}`}
+          >
             {formatMoney(results.profit)}
           </p>
         </div>
         <div className="surface rounded-xl p-4 text-center hover:-translate-y-0.5 transition-transform">
-          <p className="text-xs text-[var(--color-text-secondary)] mb-1">{t('dashboard.roi')}</p>
-          <p className={`text-lg font-extrabold ${roi >= 0 ? 'text-[var(--color-success)]' : 'text-[var(--color-danger)]'}`}>
+          <p className="text-xs text-[var(--color-text-secondary)] mb-1">
+            {t("dashboard.roi")}
+          </p>
+          <p
+            className={`text-lg font-extrabold ${roi >= 0 ? "text-[var(--color-success)]" : "text-[var(--color-danger)]"}`}
+          >
             {roi.toFixed(0)}%
           </p>
         </div>
@@ -439,45 +600,91 @@ export function Dashboard() {
 
       {/* Date Range Filter */}
       <div className="surface rounded-xl p-4">
-        <p className="text-sm font-semibold text-[var(--color-text-secondary)] mb-3">{t('dashboard.dateFrom')} / {t('dashboard.dateTo')}</p>
+        <p className="text-sm font-semibold text-[var(--color-text-secondary)] mb-3">
+          {t("dashboard.dateFrom")} / {t("dashboard.dateTo")}
+        </p>
         <div className="flex flex-wrap items-end gap-3">
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-[var(--color-text-secondary)]">{t('dashboard.dateFrom')}</label>
-            <input type="date" value={epochToDateStr(dashboardDateFrom)}
-              onChange={e => setDashboardDateFrom(e.target.value ? dateStrToEpoch(e.target.value) : null)}
-              className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] border border-[var(--color-border)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]" />
+            <label className="text-xs text-[var(--color-text-secondary)]">
+              {t("dashboard.dateFrom")}
+            </label>
+            <input
+              type="date"
+              value={epochToDateStr(dashboardDateFrom)}
+              onChange={(e) =>
+                setDashboardDateFrom(
+                  e.target.value ? dateStrToEpoch(e.target.value) : null,
+                )
+              }
+              className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] border border-[var(--color-border)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+            />
           </div>
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-[var(--color-text-secondary)]">{t('dashboard.dateTo')}</label>
-            <input type="date" value={epochToDateStr(dashboardDateTo)}
-              onChange={e => setDashboardDateTo(e.target.value ? dateStrToEpoch(e.target.value) : null)}
-              className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] border border-[var(--color-border)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]" />
+            <label className="text-xs text-[var(--color-text-secondary)]">
+              {t("dashboard.dateTo")}
+            </label>
+            <input
+              type="date"
+              value={epochToDateStr(dashboardDateTo)}
+              onChange={(e) =>
+                setDashboardDateTo(
+                  e.target.value ? dateStrToEpoch(e.target.value) : null,
+                )
+              }
+              className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] border border-[var(--color-border)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+            />
           </div>
           {(dashboardDateFrom !== null || dashboardDateTo !== null) && (
-            <button onClick={() => { setDashboardDateFrom(null); setDashboardDateTo(null) }}
-              className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-tertiary)] text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] border border-[var(--color-border)] transition-colors">
-              {t('dashboard.clearFilters')}
+            <button
+              onClick={() => {
+                setDashboardDateFrom(null);
+                setDashboardDateTo(null);
+              }}
+              className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-tertiary)] text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] border border-[var(--color-border)] transition-colors"
+            >
+              {t("dashboard.clearFilters")}
             </button>
           )}
         </div>
       </div>
 
       {/* Cost Breakdown Chart */}
-      <Suspense fallback={<div className="surface rounded-xl p-4"><p className="text-sm text-[var(--color-text-muted)] text-center py-8">{t('dashboard.loadingCharts')}</p></div>}>
+      <Suspense
+        fallback={
+          <div className="surface rounded-xl p-4">
+            <p className="text-sm text-[var(--color-text-muted)] text-center py-8">
+              {t("dashboard.loadingCharts")}
+            </p>
+          </div>
+        }
+      >
         {chartData.length > 1 && (
           <div className="surface rounded-xl p-4">
-            <p className="text-sm font-semibold text-[var(--color-text-secondary)] mb-3">{t('breakdown.title')}</p>
+            <p className="text-sm font-semibold text-[var(--color-text-secondary)] mb-3">
+              {t("breakdown.title")}
+            </p>
             <div className="flex items-center gap-4">
               <div className="w-40 h-40 flex-shrink-0">
                 <ResponsiveContainer width="100%" height="100%">
                   <PieChart>
-                    <Pie data={chartData} dataKey="value" cx="50%" cy="50%" outerRadius={60} label={false}>
+                    <Pie
+                      data={chartData}
+                      dataKey="value"
+                      cx="50%"
+                      cy="50%"
+                      outerRadius={60}
+                      label={false}
+                    >
                       {chartData.map((_, i) => (
                         <Cell key={i} fill={COLORS[i % COLORS.length]} />
                       ))}
                     </Pie>
                     <Tooltip
-                      contentStyle={{ background: 'var(--color-bg-elevated)', border: '1px solid var(--color-border)', borderRadius: '8px' }}
+                      contentStyle={{
+                        background: "var(--color-bg-elevated)",
+                        border: "1px solid var(--color-border)",
+                        borderRadius: "8px",
+                      }}
                       formatter={(value: unknown) => formatMoney(Number(value))}
                     />
                   </PieChart>
@@ -486,9 +693,16 @@ export function Dashboard() {
               <div className="flex-1 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
                 {chartData.map((d, i) => (
                   <div key={d.name} className="flex items-center gap-2">
-                    <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: COLORS[i % COLORS.length] }} />
-                    <span className="text-[var(--color-text-secondary)]">{d.name}</span>
-                    <span className="text-[var(--color-text-primary)] font-semibold ml-auto">{formatMoney(d.value)}</span>
+                    <span
+                      className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: COLORS[i % COLORS.length] }}
+                    />
+                    <span className="text-[var(--color-text-secondary)]">
+                      {d.name}
+                    </span>
+                    <span className="text-[var(--color-text-primary)] font-semibold ml-auto">
+                      {formatMoney(d.value)}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -499,29 +713,62 @@ export function Dashboard() {
 
       {/* Monthly Projection */}
       <div className="surface rounded-xl p-5">
-        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('calc.monthlyProjection')}</h3>
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+          {t("calc.monthlyProjection")}
+        </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <InputGroup label={t('calc.printsPerMonth')} value={printsPerMonth}
-            onChange={v => handleInput(v, val => setPrintsPerMonth(val > 0 ? val : 1))} type="number" unit="un" />
+          <InputGroup
+            label={t("calc.printsPerMonth")}
+            value={printsPerMonth}
+            onChange={(v) =>
+              handleInput(v, (val) => setPrintsPerMonth(val > 0 ? val : 1))
+            }
+            type="number"
+            unit="un"
+          />
           <div className="grid grid-cols-2 gap-3">
             <div className="surface rounded-xl p-3 text-center">
-              <p className="text-[10px] text-[var(--color-text-muted)]">{t('calc.monthlyRevenue')}</p>
-              <p className="text-sm font-bold text-[var(--color-success)]">{monthlyProjection ? formatMoney(monthlyProjection.revenue) : '---'}</p>
-            </div>
-            <div className="surface rounded-xl p-3 text-center">
-              <p className="text-[10px] text-[var(--color-text-muted)]">{t('calc.monthlyCost')}</p>
-              <p className="text-sm font-bold text-pink-400">{monthlyProjection ? formatMoney(monthlyProjection.cost) : '---'}</p>
-            </div>
-            <div className="surface rounded-xl p-3 text-center">
-              <p className="text-[10px] text-[var(--color-text-muted)]">{t('calc.monthlyProfit')}</p>
-              <p className={`text-sm font-bold ${monthlyProjection && monthlyProjection.profit >= 0 ? 'text-[var(--color-accent)]' : 'text-[var(--color-danger)]'}`}>
-                {monthlyProjection ? formatMoney(monthlyProjection.profit) : '---'}
+              <p className="text-[10px] text-[var(--color-text-muted)]">
+                {t("calc.monthlyRevenue")}
+              </p>
+              <p className="text-sm font-bold text-[var(--color-success)]">
+                {monthlyProjection
+                  ? formatMoney(monthlyProjection.revenue)
+                  : "---"}
               </p>
             </div>
             <div className="surface rounded-xl p-3 text-center">
-              <p className="text-[10px] text-[var(--color-text-muted)]">{t('calc.annualProfit')}</p>
-              <p className={`text-sm font-bold ${monthlyProjection && monthlyProjection.annualProfit >= 0 ? 'text-cyan-400' : 'text-[var(--color-danger)]'}`}>
-                {monthlyProjection ? formatMoney(monthlyProjection.annualProfit) : '---'}
+              <p className="text-[10px] text-[var(--color-text-muted)]">
+                {t("calc.monthlyCost")}
+              </p>
+              <p className="text-sm font-bold text-pink-400">
+                {monthlyProjection
+                  ? formatMoney(monthlyProjection.cost)
+                  : "---"}
+              </p>
+            </div>
+            <div className="surface rounded-xl p-3 text-center">
+              <p className="text-[10px] text-[var(--color-text-muted)]">
+                {t("calc.monthlyProfit")}
+              </p>
+              <p
+                className={`text-sm font-bold ${monthlyProjection && monthlyProjection.profit >= 0 ? "text-[var(--color-accent)]" : "text-[var(--color-danger)]"}`}
+              >
+                {monthlyProjection
+                  ? formatMoney(monthlyProjection.profit)
+                  : "---"}
+              </p>
+            </div>
+            <div className="surface rounded-xl p-3 text-center">
+              <p className="text-[10px] text-[var(--color-text-muted)]">
+                {t("calc.annualProfit")}
+              </p>
+              <p
+                className={`text-sm font-bold ${monthlyProjection && monthlyProjection.annualProfit >= 0 ? "text-cyan-400" : "text-[var(--color-danger)]"}`}
+              >
+                {monthlyProjection
+                  ? formatMoney(monthlyProjection.annualProfit)
+                  : "---"}
               </p>
             </div>
           </div>
@@ -530,21 +777,32 @@ export function Dashboard() {
 
       {/* Break-Even Card */}
       <div className="surface rounded-xl p-5">
-        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('dashboard.breakEven')}</h3>
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+          {t("dashboard.breakEven")}
+        </h3>
         {breakEven ? (
           breakEvenUnits !== null ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="surface rounded-xl p-4 text-center">
-                <p className="text-[10px] text-[var(--color-text-muted)]">{t('dashboard.breakEvenUnits')}</p>
-                <p className="text-lg font-extrabold text-cyan-400">{breakEvenUnits} {t('common.units')}</p>
+                <p className="text-[10px] text-[var(--color-text-muted)]">
+                  {t("dashboard.breakEvenUnits")}
+                </p>
+                <p className="text-lg font-extrabold text-cyan-400">
+                  {breakEvenUnits} {t("common.units")}
+                </p>
                 <p className="text-[10px] text-[var(--color-text-muted)] mt-1">
-                  {formatMoney(breakEven.monthlyFixedCost)} / {formatMoney(breakEven.marginPerUnit)}
+                  {formatMoney(breakEven.monthlyFixedCost)} /{" "}
+                  {formatMoney(breakEven.marginPerUnit)}
                 </p>
               </div>
               <div className="surface rounded-xl p-4 text-center">
-                <p className="text-[10px] text-[var(--color-text-muted)]">{t('dashboard.breakEvenRevenue')}</p>
+                <p className="text-[10px] text-[var(--color-text-muted)]">
+                  {t("dashboard.breakEvenRevenue")}
+                </p>
                 <p className="text-lg font-extrabold text-[var(--color-success)]">
-                  {breakEvenRevenue !== null ? formatMoney(breakEvenRevenue) : '---'}
+                  {breakEvenRevenue !== null
+                    ? formatMoney(breakEvenRevenue)
+                    : "---"}
                 </p>
                 <p className="text-[10px] text-[var(--color-text-muted)] mt-1">
                   {breakEvenUnits} x {formatMoney(breakEven.sellPrice)}
@@ -553,74 +811,117 @@ export function Dashboard() {
             </div>
           ) : (
             <div className="surface rounded-xl p-4 text-center">
-              <p className="text-xs text-[var(--color-danger)]">{t('dashboard.cantBreakEven')}</p>
+              <p className="text-xs text-[var(--color-danger)]">
+                {t("dashboard.cantBreakEven")}
+              </p>
               <p className="text-[10px] text-[var(--color-text-muted)] mt-1">
-                {t('breakdown.material')}: {formatMoney(breakEven.variableCostPerUnit)} / {t('dashboard.salePrice')}: {formatMoney(breakEven.sellPrice)}
+                {t("breakdown.material")}:{" "}
+                {formatMoney(breakEven.variableCostPerUnit)} /{" "}
+                {t("dashboard.salePrice")}: {formatMoney(breakEven.sellPrice)}
               </p>
             </div>
           )
         ) : (
           <p className="text-xs text-[var(--color-text-muted)] text-center py-2">
-            {t('calc.fixedCost.title')} {t('common.noData')}
+            {t("calc.fixedCost.title")} {t("common.noData")}
           </p>
         )}
       </div>
 
       {/* Average Margin Card */}
       <div className="surface rounded-xl p-5">
-        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('dashboard.avgMargin')}</h3>
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+          {t("dashboard.avgMargin")}
+        </h3>
         {avgMargin !== null ? (
           <div className="text-center">
-            <p className={`text-3xl font-black ${avgMargin >= 0 ? 'text-[var(--color-success)]' : 'text-[var(--color-danger)]'}`}>
-              {avgMargin >= 0 ? '+' : ''}{avgMargin.toFixed(1)}%
+            <p
+              className={`text-3xl font-black ${avgMargin >= 0 ? "text-[var(--color-success)]" : "text-[var(--color-danger)]"}`}
+            >
+              {avgMargin >= 0 ? "+" : ""}
+              {avgMargin.toFixed(1)}%
             </p>
             <p className="text-[10px] text-[var(--color-text-muted)] mt-1">
-              {t('calc.history')}: {filteredEntries.length} {t('common.entries')}
+              {t("calc.history")}: {filteredEntries.length}{" "}
+              {t("common.entries")}
             </p>
           </div>
         ) : (
-          <p className="text-xs text-[var(--color-text-muted)] text-center py-2">{t('dashboard.noHistory')}</p>
+          <p className="text-xs text-[var(--color-text-muted)] text-center py-2">
+            {t("dashboard.noHistory")}
+          </p>
         )}
       </div>
 
       {/* Profit Trend Chart */}
-      <Suspense fallback={<div className="surface rounded-xl p-5"><p className="text-sm text-[var(--color-text-muted)] text-center py-16">{t('dashboard.loadingCharts')}</p></div>}>
+      <Suspense
+        fallback={
+          <div className="surface rounded-xl p-5">
+            <p className="text-sm text-[var(--color-text-muted)] text-center py-16">
+              {t("dashboard.loadingCharts")}
+            </p>
+          </div>
+        }
+      >
         <div className="surface rounded-xl p-5">
-          <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('dashboard.trend')}</h3>
+          <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+            {t("dashboard.trend")}
+          </h3>
           {trendData.length > 1 ? (
             <div className="w-full h-56" ref={trendChartRef}>
               <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={trendData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                <AreaChart
+                  data={trendData}
+                  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+                >
                   <defs>
-                    <linearGradient id="profitGradient" x1="0" y1="0" x2="0" y2="1">
+                    <linearGradient
+                      id="profitGradient"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="1"
+                    >
                       <stop offset="5%" stopColor="#818cf8" stopOpacity={0.4} />
-                      <stop offset="95%" stopColor="#818cf8" stopOpacity={0.05} />
+                      <stop
+                        offset="95%"
+                        stopColor="#818cf8"
+                        stopOpacity={0.05}
+                      />
                     </linearGradient>
                   </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="var(--color-border)"
+                  />
                   <XAxis
                     dataKey="date"
-                    tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+                    tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
                     axisLine={false}
                     tickLine={false}
                     interval="preserveStartEnd"
                   />
                   <YAxis
-                    tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+                    tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
                     axisLine={false}
                     tickLine={false}
-                    tickFormatter={(v: number) => new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language, { notation: 'compact', maximumFractionDigits: 1 }).format(v)}
+                    tickFormatter={(v: number) =>
+                      new Intl.NumberFormat(
+                        i18n.resolvedLanguage || i18n.language,
+                        { notation: "compact", maximumFractionDigits: 1 },
+                      ).format(v)
+                    }
                     width={50}
                   />
                   <Tooltip
                     contentStyle={{
-                      background: 'var(--color-bg-elevated)',
-                      border: '1px solid var(--color-border)',
-                      borderRadius: '8px',
-                      fontSize: '12px',
+                      background: "var(--color-bg-elevated)",
+                      border: "1px solid var(--color-border)",
+                      borderRadius: "8px",
+                      fontSize: "12px",
                     }}
                     formatter={(value: unknown) => formatMoney(Number(value))}
-                    labelStyle={{ color: 'var(--color-text-secondary)' }}
+                    labelStyle={{ color: "var(--color-text-secondary)" }}
                   />
                   <Area
                     type="monotone"
@@ -628,36 +929,57 @@ export function Dashboard() {
                     stroke="#818cf8"
                     strokeWidth={2}
                     fill="url(#profitGradient)"
-                    dot={{ fill: '#818cf8', r: 3, strokeWidth: 0 }}
-                    activeDot={{ r: 5, fill: '#a5b4fc', strokeWidth: 0 }}
+                    dot={{ fill: "#818cf8", r: 3, strokeWidth: 0 }}
+                    activeDot={{ r: 5, fill: "#a5b4fc", strokeWidth: 0 }}
                   />
                 </AreaChart>
               </ResponsiveContainer>
             </div>
           ) : (
-            <p className="text-xs text-[var(--color-text-muted)] text-center py-8">{t('dashboard.noHistory')}</p>
+            <p className="text-xs text-[var(--color-text-muted)] text-center py-8">
+              {t("dashboard.noHistory")}
+            </p>
           )}
         </div>
       </Suspense>
 
       {/* Target Margin Mode */}
       <div className="surface rounded-xl p-5">
-        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('calc.targetMarginMode')}</h3>
-        <p className="text-xs text-[var(--color-text-muted)] mb-3">{t('calc.targetMarginDesc')}</p>
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+          {t("calc.targetMarginMode")}
+        </h3>
+        <p className="text-xs text-[var(--color-text-muted)] mb-3">
+          {t("calc.targetMarginDesc")}
+        </p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <InputGroup label={t('calc.sellPriceTarget')} value={targetSellPrice}
-            onChange={v => setTargetSellPrice(v)} type="number" prefix={currencySymbol} />
+          <InputGroup
+            label={t("calc.sellPriceTarget")}
+            value={targetSellPrice}
+            onChange={(v) => setTargetSellPrice(v)}
+            type="number"
+            prefix={currencySymbol}
+          />
           <div className="grid grid-cols-2 gap-3">
             <div className="surface rounded-xl p-3 text-center">
-              <p className="text-[10px] text-[var(--color-text-muted)]">{t('calc.actualMargin')}</p>
-              <p className={`text-sm font-bold ${reverseMargin && reverseMargin.actualMargin >= 0 ? 'text-[var(--color-success)]' : 'text-[var(--color-danger)]'}`}>
-                {reverseMargin ? `${reverseMargin.actualMargin.toFixed(1)}%` : '---'}
+              <p className="text-[10px] text-[var(--color-text-muted)]">
+                {t("calc.actualMargin")}
+              </p>
+              <p
+                className={`text-sm font-bold ${reverseMargin && reverseMargin.actualMargin >= 0 ? "text-[var(--color-success)]" : "text-[var(--color-danger)]"}`}
+              >
+                {reverseMargin
+                  ? `${reverseMargin.actualMargin.toFixed(1)}%`
+                  : "---"}
               </p>
             </div>
             <div className="surface rounded-xl p-3 text-center">
-              <p className="text-[10px] text-[var(--color-text-muted)]">Lucro</p>
-              <p className={`text-sm font-bold ${reverseMargin && reverseMargin.profit >= 0 ? 'text-[var(--color-accent)]' : 'text-[var(--color-danger)]'}`}>
-                {reverseMargin ? formatMoney(reverseMargin.profit) : '---'}
+              <p className="text-[10px] text-[var(--color-text-muted)]">
+                Lucro
+              </p>
+              <p
+                className={`text-sm font-bold ${reverseMargin && reverseMargin.profit >= 0 ? "text-[var(--color-accent)]" : "text-[var(--color-danger)]"}`}
+              >
+                {reverseMargin ? formatMoney(reverseMargin.profit) : "---"}
               </p>
             </div>
           </div>
@@ -666,22 +988,36 @@ export function Dashboard() {
 
       {/* Print vs Buy */}
       <div className="surface rounded-xl p-5">
-        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('calc.printVsBuy')}</h3>
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+          {t("calc.printVsBuy")}
+        </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <InputGroup label={t('calc.buyPrice')} value={buyPrice}
-            onChange={v => setBuyPrice(v)} type="number" prefix={currencySymbol} />
+          <InputGroup
+            label={t("calc.buyPrice")}
+            value={buyPrice}
+            onChange={(v) => setBuyPrice(v)}
+            type="number"
+            prefix={currencySymbol}
+          />
           {printVsBuy && (
             <div className="grid grid-cols-2 gap-3">
               <div className="surface rounded-xl p-3 text-center">
-                <p className="text-[10px] text-[var(--color-text-muted)]">{t('calc.cheaper')}</p>
+                <p className="text-[10px] text-[var(--color-text-muted)]">
+                  {t("calc.cheaper")}
+                </p>
                 <p className="text-sm font-bold text-cyan-400">
-                  {printVsBuy.cheaper === 'print' ? t('calc.printCheaper') : t('calc.buyCheaper')}
+                  {printVsBuy.cheaper === "print"
+                    ? t("calc.printCheaper")
+                    : t("calc.buyCheaper")}
                 </p>
               </div>
               <div className="surface rounded-xl p-3 text-center">
-                <p className="text-[10px] text-[var(--color-text-muted)]">{t('calc.savings')}</p>
+                <p className="text-[10px] text-[var(--color-text-muted)]">
+                  {t("calc.savings")}
+                </p>
                 <p className="text-sm font-bold text-[var(--color-success)]">
-                  {formatMoney(printVsBuy.savings)} ({printVsBuy.savingsPercent.toFixed(0)}%)
+                  {formatMoney(printVsBuy.savings)} (
+                  {printVsBuy.savingsPercent.toFixed(0)}%)
                 </p>
               </div>
             </div>
@@ -690,120 +1026,198 @@ export function Dashboard() {
       </div>
 
       {/* Top Printers Chart */}
-      <Suspense fallback={<div className="surface rounded-xl p-5"><p className="text-sm text-[var(--color-text-muted)] text-center py-8">{t('dashboard.loadingCharts')}</p></div>}>
+      <Suspense
+        fallback={
+          <div className="surface rounded-xl p-5">
+            <p className="text-sm text-[var(--color-text-muted)] text-center py-8">
+              {t("dashboard.loadingCharts")}
+            </p>
+          </div>
+        }
+      >
         <div className="surface rounded-xl p-5">
-          <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('dashboard.topPrinters')}</h3>
+          <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+            {t("dashboard.topPrinters")}
+          </h3>
           {topPrintersData.length > 0 ? (
             <div className="w-full h-52">
               <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={topPrintersData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                <BarChart
+                  data={topPrintersData}
+                  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+                >
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="var(--color-border)"
+                  />
                   <XAxis
                     dataKey="name"
-                    tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+                    tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
                     axisLine={false}
                     tickLine={false}
                   />
                   <YAxis
-                    tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+                    tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
                     axisLine={false}
                     tickLine={false}
-                    tickFormatter={(v: number) => new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language, { notation: 'compact', maximumFractionDigits: 0 }).format(v)}
+                    tickFormatter={(v: number) =>
+                      new Intl.NumberFormat(
+                        i18n.resolvedLanguage || i18n.language,
+                        { notation: "compact", maximumFractionDigits: 0 },
+                      ).format(v)
+                    }
                     width={50}
                   />
                   <Tooltip
-                    contentStyle={{ background: 'var(--color-bg-elevated)', border: '1px solid var(--color-border)', borderRadius: '8px', fontSize: '12px' }}
+                    contentStyle={{
+                      background: "var(--color-bg-elevated)",
+                      border: "1px solid var(--color-border)",
+                      borderRadius: "8px",
+                      fontSize: "12px",
+                    }}
                     formatter={(value: unknown) => formatMoney(Number(value))}
-                    labelStyle={{ color: 'var(--color-text-secondary)' }}
+                    labelStyle={{ color: "var(--color-text-secondary)" }}
                   />
                   <Bar dataKey="profit" fill="#6366f1" radius={[4, 4, 0, 0]} />
                 </BarChart>
               </ResponsiveContainer>
             </div>
           ) : (
-            <p className="text-xs text-[var(--color-text-muted)] text-center py-8">{t('common.noData')}</p>
+            <p className="text-xs text-[var(--color-text-muted)] text-center py-8">
+              {t("common.noData")}
+            </p>
           )}
         </div>
       </Suspense>
 
       {/* Top Materials Chart */}
-      <Suspense fallback={<div className="surface rounded-xl p-5"><p className="text-sm text-[var(--color-text-muted)] text-center py-8">{t('dashboard.loadingCharts')}</p></div>}>
+      <Suspense
+        fallback={
+          <div className="surface rounded-xl p-5">
+            <p className="text-sm text-[var(--color-text-muted)] text-center py-8">
+              {t("dashboard.loadingCharts")}
+            </p>
+          </div>
+        }
+      >
         <div className="surface rounded-xl p-5">
-          <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('dashboard.topMaterials')}</h3>
+          <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+            {t("dashboard.topMaterials")}
+          </h3>
           {topMaterialsData.length > 0 ? (
             <div className="w-full h-52">
               <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={topMaterialsData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                <BarChart
+                  data={topMaterialsData}
+                  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+                >
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="var(--color-border)"
+                  />
                   <XAxis
                     dataKey="name"
-                    tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+                    tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
                     axisLine={false}
                     tickLine={false}
                   />
                   <YAxis
-                    tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+                    tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
                     axisLine={false}
                     tickLine={false}
-                    tickFormatter={(v: number) => new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language, { notation: 'compact', maximumFractionDigits: 0 }).format(v)}
+                    tickFormatter={(v: number) =>
+                      new Intl.NumberFormat(
+                        i18n.resolvedLanguage || i18n.language,
+                        { notation: "compact", maximumFractionDigits: 0 },
+                      ).format(v)
+                    }
                     width={40}
                     allowDecimals={false}
                   />
                   <Tooltip
-                    contentStyle={{ background: 'var(--color-bg-elevated)', border: '1px solid var(--color-border)', borderRadius: '8px', fontSize: '12px' }}
+                    contentStyle={{
+                      background: "var(--color-bg-elevated)",
+                      border: "1px solid var(--color-border)",
+                      borderRadius: "8px",
+                      fontSize: "12px",
+                    }}
                     formatter={(value: unknown) => `${value}`}
-                    labelStyle={{ color: 'var(--color-text-secondary)' }}
+                    labelStyle={{ color: "var(--color-text-secondary)" }}
                   />
                   <Bar dataKey="count" fill="#10b981" radius={[4, 4, 0, 0]} />
                 </BarChart>
               </ResponsiveContainer>
             </div>
           ) : (
-            <p className="text-xs text-[var(--color-text-muted)] text-center py-8">{t('common.noData')}</p>
+            <p className="text-xs text-[var(--color-text-muted)] text-center py-8">
+              {t("common.noData")}
+            </p>
           )}
         </div>
       </Suspense>
 
       {/* Period Comparison */}
       <div className="surface rounded-xl p-5">
-        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('dashboard.periodComparison')}</h3>
-        {periodComparison.some(m => m.current > 0 || m.previous > 0) ? (
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+          {t("dashboard.periodComparison")}
+        </h3>
+        {periodComparison.some((m) => m.current > 0 || m.previous > 0) ? (
           <div className="grid grid-cols-2 gap-3">
             {/* Header row */}
             <div className="text-[10px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider" />
-            <div className="text-[10px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider text-right">{t('dashboard.currentMonth')}</div>
-            <div className="text-[10px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider text-right">{t('dashboard.previousMonth')}</div>
-            <div className="text-[10px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider text-right">{t('dashboard.change')}</div>
-            {periodComparison.map(m => (
+            <div className="text-[10px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider text-right">
+              {t("dashboard.currentMonth")}
+            </div>
+            <div className="text-[10px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider text-right">
+              {t("dashboard.previousMonth")}
+            </div>
+            <div className="text-[10px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider text-right">
+              {t("dashboard.change")}
+            </div>
+            {periodComparison.map((m) => (
               <Fragment key={m.key}>
-                <div className="text-xs text-[var(--color-text-secondary)] font-medium">{t(`dashboard.${m.key}`)}</div>
+                <div className="text-xs text-[var(--color-text-secondary)] font-medium">
+                  {t(`dashboard.${m.key}`)}
+                </div>
                 <div className="text-xs text-[var(--color-text-primary)] font-semibold text-right">
-                  {m.key === 'printCount' ? m.current : formatMoney(m.current)}
+                  {m.key === "printCount" ? m.current : formatMoney(m.current)}
                 </div>
                 <div className="text-xs text-[var(--color-text-muted)] text-right">
-                  {m.key === 'printCount' ? m.previous : formatMoney(m.previous)}
+                  {m.key === "printCount"
+                    ? m.previous
+                    : formatMoney(m.previous)}
                 </div>
-                <div className={`text-xs font-bold text-right ${m.change !== null ? (m.change >= 0 ? 'text-[var(--color-success)]' : 'text-[var(--color-danger)]') : 'text-[var(--color-text-muted)]'}`}>
-                  {m.change !== null ? `${m.change >= 0 ? '+' : ''}${m.change}%` : '---'}
+                <div
+                  className={`text-xs font-bold text-right ${m.change !== null ? (m.change >= 0 ? "text-[var(--color-success)]" : "text-[var(--color-danger)]") : "text-[var(--color-text-muted)]"}`}
+                >
+                  {m.change !== null
+                    ? `${m.change >= 0 ? "+" : ""}${m.change}%`
+                    : "---"}
                 </div>
               </Fragment>
             ))}
           </div>
         ) : (
-          <p className="text-xs text-[var(--color-text-muted)] text-center py-4">{t('common.noData')}</p>
+          <p className="text-xs text-[var(--color-text-muted)] text-center py-4">
+            {t("common.noData")}
+          </p>
         )}
       </div>
 
       {/* Custom Goal */}
       <div className="surface rounded-xl p-5">
-        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">{t('dashboard.customGoal')}</h3>
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">
+          {t("dashboard.customGoal")}
+        </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-[var(--color-text-secondary)]">{t('dashboard.goalInput')}</label>
+            <label className="text-xs text-[var(--color-text-secondary)]">
+              {t("dashboard.goalInput")}
+            </label>
             <input
               type="number"
               value={goal}
-              onChange={e => setGoal(e.target.value)}
+              onChange={(e) => setGoal(e.target.value)}
               placeholder="0"
               className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
             />
@@ -811,14 +1225,21 @@ export function Dashboard() {
           <div className="flex flex-col justify-center gap-1">
             {printsNeeded ? (
               printsNeeded.negativeMargin ? (
-                <p className="text-xs text-[var(--color-danger)]">{t('dashboard.goalWarning')}</p>
+                <p className="text-xs text-[var(--color-danger)]">
+                  {t("dashboard.goalWarning")}
+                </p>
               ) : (
                 <p className="text-xs text-[var(--color-text-secondary)]">
-                  {t('dashboard.printsNeeded', { count: printsNeeded.prints, value: formatMoney(printsNeeded.goalValue) })}
+                  {t("dashboard.printsNeeded", {
+                    count: printsNeeded.prints,
+                    value: formatMoney(printsNeeded.goalValue),
+                  })}
                 </p>
               )
             ) : (
-              <p className="text-xs text-[var(--color-text-muted)]">{t('calc.noCosts')}</p>
+              <p className="text-xs text-[var(--color-text-muted)]">
+                {t("calc.noCosts")}
+              </p>
             )}
           </div>
         </div>
@@ -827,20 +1248,29 @@ export function Dashboard() {
       {/* Low-Margin Alerts */}
       {lowMarginEntries.length > 0 && (
         <div className="surface rounded-xl p-5 border border-amber-500/30">
-          <h3 className="text-sm font-bold text-amber-400 mb-2">{t('dashboard.lowMarginAlerts')}</h3>
+          <h3 className="text-sm font-bold text-amber-400 mb-2">
+            {t("dashboard.lowMarginAlerts")}
+          </h3>
           <p className="text-xs text-[var(--color-text-secondary)] mb-3">
-            {t('dashboard.lowMarginCount', { count: lowMarginEntries.length })}
+            {t("dashboard.lowMarginCount", { count: lowMarginEntries.length })}
           </p>
           <div className="space-y-1">
-            {lowMarginEntries.map(e => (
-              <div key={e.id} className="flex items-center justify-between py-1 px-2 rounded-lg bg-amber-500/5">
-                <span className="text-xs text-[var(--color-text-primary)] truncate mr-2">{e.name}</span>
-                <span className="text-xs font-semibold text-amber-400 shrink-0">{e.margin.toFixed(1)}%</span>
+            {lowMarginEntries.map((e) => (
+              <div
+                key={e.id}
+                className="flex items-center justify-between py-1 px-2 rounded-lg bg-amber-500/5"
+              >
+                <span className="text-xs text-[var(--color-text-primary)] truncate mr-2">
+                  {e.name}
+                </span>
+                <span className="text-xs font-semibold text-amber-400 shrink-0">
+                  {e.margin.toFixed(1)}%
+                </span>
               </div>
             ))}
           </div>
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/src/shared/components/ui/OnboardingModal.tsx
+++ b/src/shared/components/ui/OnboardingModal.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { X, ChevronRight, ArrowLeft, Play } from "lucide-react";
 import { useReducedMotion } from "@/shared/hooks/useReducedMotion";
 import { useTutorialStore } from "@/shared/stores/tutorialStore";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
 const ONBOARDING_KEY = "open3dcalc_onboarded";
 
@@ -31,7 +32,7 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
   const prefersReduced = useReducedMotion();
   const [[slideIndex, direction], setSlideState] = useState([0, 0]);
   const [visible, setVisible] = useState(
-    () => !localStorage.getItem(ONBOARDING_KEY),
+    () => !guardedStorage.getItem(ONBOARDING_KEY),
   );
 
   const totalSlides = 3;
@@ -61,13 +62,13 @@ export function OnboardingModal({ onComplete }: OnboardingModalProps) {
 
   const handleStartTutorial = useCallback(() => {
     startTutorial();
-    localStorage.setItem(ONBOARDING_KEY, "true");
+    guardedStorage.setItem(ONBOARDING_KEY, "true");
     setVisible(false);
     onComplete?.();
   }, [startTutorial, onComplete]);
 
   const dismiss = useCallback(() => {
-    localStorage.setItem(ONBOARDING_KEY, "true");
+    guardedStorage.setItem(ONBOARDING_KEY, "true");
     setVisible(false);
     onComplete?.();
   }, [onComplete]);

--- a/src/shared/components/ui/QuickStartBanner.tsx
+++ b/src/shared/components/ui/QuickStartBanner.tsx
@@ -1,20 +1,23 @@
-import { Zap, RotateCcw, X } from 'lucide-react'
-import { useCalculatorStore } from '@/shared/stores/calculatorStore'
-import { useState } from 'react'
+import { Zap, RotateCcw, X } from "lucide-react";
+import { useCalculatorStore } from "@/shared/stores/calculatorStore";
+import { useState } from "react";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-const BANNER_KEY = 'open3dcalc_quickstart_dismissed'
+const BANNER_KEY = "open3dcalc_quickstart_dismissed";
 
 export function QuickStartBanner() {
-  const setQuickStart = useCalculatorStore((s) => s.setQuickStart)
-  const resetCalculator = useCalculatorStore((s) => s.resetCalculator)
-  const [dismissed, setDismissed] = useState(() => localStorage.getItem(BANNER_KEY) === 'true')
+  const setQuickStart = useCalculatorStore((s) => s.setQuickStart);
+  const resetCalculator = useCalculatorStore((s) => s.resetCalculator);
+  const [dismissed, setDismissed] = useState(
+    () => guardedStorage.getItem(BANNER_KEY) === "true",
+  );
 
   const dismiss = () => {
-    setDismissed(true)
-    localStorage.setItem(BANNER_KEY, 'true')
-  }
+    setDismissed(true);
+    guardedStorage.setItem(BANNER_KEY, "true");
+  };
 
-  if (dismissed) return null
+  if (dismissed) return null;
 
   return (
     <div className="surface rounded-xl p-3 sm:p-4 border border-[var(--color-accent)]/20 bg-gradient-to-r from-[var(--color-accent)]/5 to-transparent relative">
@@ -32,7 +35,8 @@ export function QuickStartBanner() {
             Quer ver como funciona?
           </p>
           <p className="text-[10px] sm:text-xs text-[var(--color-text-secondary)] mt-0.5 leading-relaxed">
-            Preencha a calculadora com valores realistas para um exemplo de peça 3D
+            Preencha a calculadora com valores realistas para um exemplo de peça
+            3D
           </p>
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 shrink-0">
@@ -55,5 +59,5 @@ export function QuickStartBanner() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/shared/hooks/useTheme.ts
+++ b/src/shared/hooks/useTheme.ts
@@ -1,40 +1,43 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from "react";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-export type Theme = 'light' | 'dark'
+export type Theme = "light" | "dark";
 
-const STORAGE_KEY = 'open3dcalc_theme'
+const STORAGE_KEY = "open3dcalc_theme";
 
 function getSystemPreference(): Theme {
-  if (typeof window === 'undefined') return 'dark'
-  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
 }
 
 function getStoredTheme(): Theme | null {
-  if (typeof window === 'undefined') return null
+  if (typeof window === "undefined") return null;
   try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored === 'light' || stored === 'dark') return stored
+    const stored = guardedStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
   } catch {
     // localStorage unavailable
   }
-  return null
+  return null;
 }
 
 function applyTheme(theme: Theme) {
-  const root = document.documentElement
-  if (theme === 'dark') {
-    root.classList.add('dark')
-    root.classList.remove('light')
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.classList.add("dark");
+    root.classList.remove("light");
   } else {
-    root.classList.add('light')
-    root.classList.remove('dark')
+    root.classList.add("light");
+    root.classList.remove("dark");
   }
-  root.setAttribute('color-scheme', theme)
+  root.setAttribute("color-scheme", theme);
 }
 
 function persistTheme(theme: Theme) {
   try {
-    localStorage.setItem(STORAGE_KEY, theme)
+    guardedStorage.setItem(STORAGE_KEY, theme);
   } catch {
     // localStorage unavailable
   }
@@ -45,10 +48,10 @@ function persistTheme(theme: Theme) {
  * Call this in main.tsx before createRoot().render().
  */
 export function initTheme(): Theme {
-  const stored = getStoredTheme()
-  const theme = stored ?? getSystemPreference()
-  applyTheme(theme)
-  return theme
+  const stored = getStoredTheme();
+  const theme = stored ?? getSystemPreference();
+  applyTheme(theme);
+  return theme;
 }
 
 /**
@@ -57,36 +60,36 @@ export function initTheme(): Theme {
  */
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = getStoredTheme()
-    return stored ?? getSystemPreference()
-  })
+    const stored = getStoredTheme();
+    return stored ?? getSystemPreference();
+  });
 
   // Listen for system preference changes
   useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: light)')
+    const mq = window.matchMedia("(prefers-color-scheme: light)");
     const handler = (e: MediaQueryListEvent) => {
-      const stored = getStoredTheme()
+      const stored = getStoredTheme();
       // Only auto-switch if user hasn't explicitly chosen a theme
       if (!stored) {
-        const newTheme = e.matches ? 'light' : 'dark'
-        setThemeState(newTheme)
-        applyTheme(newTheme)
+        const newTheme = e.matches ? "light" : "dark";
+        setThemeState(newTheme);
+        applyTheme(newTheme);
       }
-    }
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
 
   const setTheme = useCallback((newTheme: Theme) => {
-    setThemeState(newTheme)
-    applyTheme(newTheme)
-    persistTheme(newTheme)
-  }, [])
+    setThemeState(newTheme);
+    applyTheme(newTheme);
+    persistTheme(newTheme);
+  }, []);
 
   const toggleTheme = useCallback(() => {
-    const next = theme === 'dark' ? 'light' : 'dark'
-    setTheme(next)
-  }, [theme, setTheme])
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+  }, [theme, setTheme]);
 
-  return { theme, setTheme, toggleTheme }
+  return { theme, setTheme, toggleTheme };
 }

--- a/src/shared/lib/__tests__/dataManifest.test.ts
+++ b/src/shared/lib/__tests__/dataManifest.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect } from "vitest";
+import manifestFixture from "../../../../docs/privacy/SPEC-01-manifest-fixture.json";
+import manifestSchema from "../../../../docs/privacy/SPEC-01-manifest.schema.json";
+import {
+  loadManifest,
+  validateManifestEntry,
+  isKnownKey,
+  getEntry,
+  findOrphanKeys,
+  getPolicyVersion,
+  getShippedPolicyVersion,
+  ManifestError,
+  SURFACES,
+  PLATFORMS,
+  PERSISTENCE_MODES,
+  SYNC_MODES,
+  EXPORT_MODES,
+  ERASURE_MODES,
+  DATA_CLASSES,
+  LEGAL_BASES,
+  RETENTION_POLICIES,
+  type ManifestDocument,
+} from "@/shared/lib/dataManifest";
+
+// ---------------------------------------------------------------------------
+// Helpers (synthetic data only — never real PII)
+// ---------------------------------------------------------------------------
+
+function validEntry(overrides = {}) {
+  return {
+    key: "synthetic_test_key",
+    surface: "localStorage",
+    platforms: ["web"],
+    class: "user_preference",
+    pii: false,
+    persistence: "plaintext_allowed",
+    sync: "opt_in",
+    export: "user_export",
+    erasure: "erase_on_delete_all",
+    retention: { policy: "user_controlled", max_days: 0 },
+    purpose: "Synthetic fixture for contract tests.",
+    legal_basis: "not_personal_data",
+    owner: "hermes",
+    version: "1.0",
+    ...overrides,
+  };
+}
+
+function docWith(entries: unknown[]): ManifestDocument {
+  return {
+    manifest_version: "1.0",
+    policy_version: "1.0",
+    keys: entries,
+  } as ManifestDocument;
+}
+
+// ---------------------------------------------------------------------------
+// SPEC-01 §keys + TEST-MATRIX 1.1 — fixture validates against the schema
+// ---------------------------------------------------------------------------
+
+describe("dataManifest loader (SPEC-01)", () => {
+  it("TEST-MATRIX 1.1: loads the schema fixture document without errors", () => {
+    const manifest = loadManifest(manifestFixture as ManifestDocument);
+    expect(manifest.size).toBeGreaterThan(0);
+    expect(isKnownKey(manifest, "open3dcalc_consent_v1")).toBe(true);
+  });
+
+  it("SPEC-01: exposes the full policy record per key", () => {
+    const manifest = loadManifest(manifestFixture as ManifestDocument);
+    const entry = getEntry(manifest, "open3dcalc_consent_v1");
+    expect(entry).toMatchObject({
+      key: "open3dcalc_consent_v1",
+      surface: "localStorage",
+      class: "consent_record",
+      pii: false,
+      persistence: "plaintext_allowed",
+      sync: "never",
+      export: "never",
+      erasure: "erase_on_delete_all",
+      owner: "hermes",
+      version: "1.0",
+    });
+    expect(entry?.platforms).toEqual(["electron", "web", "pwa"]);
+  });
+
+  it("SPEC-01: loader enum sets match the normative schema $defs (no drift)", () => {
+    const defs = (
+      manifestSchema as unknown as { $defs: Record<string, { enum: string[] }> }
+    ).$defs;
+    expect([...SURFACES].sort()).toEqual([...defs.surface.enum].sort());
+    expect([...PLATFORMS].sort()).toEqual([...defs.platform.enum].sort());
+    expect([...PERSISTENCE_MODES].sort()).toEqual(
+      [...defs.persistenceMode.enum].sort(),
+    );
+    expect([...SYNC_MODES].sort()).toEqual([...defs.syncMode.enum].sort());
+    expect([...EXPORT_MODES].sort()).toEqual([...defs.exportMode.enum].sort());
+    expect([...ERASURE_MODES].sort()).toEqual(
+      [...defs.erasureMode.enum].sort(),
+    );
+    expect([...DATA_CLASSES].sort()).toEqual([
+      "cache",
+      "consent_record",
+      "derived_analytics",
+      "diagnostic",
+      "ephemeral_key",
+      "onboarding_flag",
+      "snapshot",
+      "ui_state",
+      "user_content",
+      "user_preference",
+    ]);
+    expect([...LEGAL_BASES].sort()).toEqual([
+      "consent",
+      "contract_performance",
+      "legitimate_interest",
+      "not_personal_data",
+    ]);
+    expect([...RETENTION_POLICIES].sort()).toEqual([
+      "fixed",
+      "session_only",
+      "user_controlled",
+    ]);
+  });
+
+  it("SPEC-01: accepts every entry of the shipped fixture as valid", () => {
+    const doc = manifestFixture as ManifestDocument;
+    for (const entry of doc.keys) {
+      expect(() => validateManifestEntry(entry)).not.toThrow();
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // TEST-MATRIX 1.2 — plaintext_allowed + pii:true is rejected
+  // -----------------------------------------------------------------------
+
+  it("TEST-MATRIX 1.2: REJECTS plaintext_allowed with pii:true", () => {
+    expect(() =>
+      validateManifestEntry(
+        validEntry({ pii: true, persistence: "plaintext_allowed" }),
+      ),
+    ).toThrow(ManifestError);
+    expect(() => loadManifest(docWith([validEntry({ pii: true })]))).toThrow(
+      ManifestError,
+    );
+  });
+
+  it("TEST-MATRIX 1.3: REJECTS legal_basis not_personal_data with pii:true", () => {
+    expect(() =>
+      validateManifestEntry(
+        validEntry({
+          pii: true,
+          legal_basis: "not_personal_data",
+          persistence: "encrypted_at_rest",
+        }),
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  it("TEST-MATRIX 1.4: REJECTS onboarding_flag with sync:opt_in or export:user_export", () => {
+    expect(() =>
+      validateManifestEntry(
+        validEntry({ class: "onboarding_flag", sync: "opt_in" }),
+      ),
+    ).toThrow(ManifestError);
+    expect(() =>
+      validateManifestEntry(
+        validEntry({ class: "onboarding_flag", export: "user_export" }),
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  it("TEST-MATRIX 1.5: REJECTS consent_record with export != never", () => {
+    expect(() =>
+      validateManifestEntry(
+        validEntry({
+          class: "consent_record",
+          export: "user_export",
+          sync: "never",
+        }),
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  it("TEST-MATRIX 1.6: REJECTS snapshot with sync != never or plaintext_allowed", () => {
+    expect(() =>
+      validateManifestEntry(
+        validEntry({
+          class: "snapshot",
+          pii: true,
+          persistence: "encrypted_at_rest",
+          sync: "opt_in",
+          export: "never",
+          legal_basis: "consent",
+        }),
+      ),
+    ).toThrow(ManifestError);
+    expect(() =>
+      validateManifestEntry(
+        validEntry({
+          class: "snapshot",
+          pii: true,
+          persistence: "plaintext_allowed",
+          sync: "never",
+          export: "never",
+          legal_basis: "consent",
+        }),
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  it("TEST-MATRIX 1.7: REJECTS ephemeral_key with persistence != memory_only", () => {
+    expect(() =>
+      validateManifestEntry(
+        validEntry({
+          class: "ephemeral_key",
+          persistence: "encrypted_at_rest",
+          sync: "never",
+          export: "never",
+        }),
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  it("TEST-MATRIX 1.8: REJECTS diagnostic with export:user_export", () => {
+    expect(() =>
+      validateManifestEntry(
+        validEntry({
+          class: "diagnostic",
+          export: "user_export",
+          sync: "never",
+        }),
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  it("TEST-MATRIX 1.9: REJECTS unknown persistence/sync/export/erasure values", () => {
+    for (const field of ["persistence", "sync", "export", "erasure"] as const) {
+      expect(() =>
+        validateManifestEntry(validEntry({ [field]: "bogus_value" })),
+      ).toThrow(ManifestError);
+    }
+    expect(() =>
+      validateManifestEntry(validEntry({ surface: "floppy_disk" })),
+    ).toThrow(ManifestError);
+  });
+
+  it("TEST-MATRIX 1.10: REJECTS missing fields, extra fields, and empty platforms", () => {
+    const entry = validEntry() as Record<string, unknown>;
+    delete entry.purpose;
+    expect(() => validateManifestEntry(entry)).toThrow(ManifestError);
+    expect(() => validateManifestEntry(validEntry({ extra_field: 1 }))).toThrow(
+      ManifestError,
+    );
+    expect(() => validateManifestEntry(validEntry({ platforms: [] }))).toThrow(
+      ManifestError,
+    );
+  });
+
+  it("TEST-MATRIX 1.11: REJECTS duplicate keys across entries", () => {
+    const first = validEntry({ key: "dup_key" });
+    const second = validEntry({ key: "dup_key" });
+    expect(() => loadManifest(docWith([first, second]))).toThrow(ManifestError);
+  });
+
+  // -----------------------------------------------------------------------
+  // S1 wiring: unknown-key deny + orphan enumeration
+  // -----------------------------------------------------------------------
+
+  it("S1: unknown keys are NOT known (default-deny)", () => {
+    const manifest = loadManifest(manifestFixture as ManifestDocument);
+    expect(isKnownKey(manifest, "open3dcalc_no_such_key")).toBe(false);
+    expect(getEntry(manifest, "open3dcalc_no_such_key")).toBeUndefined();
+  });
+
+  it("S1: every runtime storage key written by the app is registered", () => {
+    // Mirrors the key constants in stores, platform overrides, and migration
+    // logic (persistence-bridge LOCALSTORAGE_KEYS + dataSync KEYS). If a new
+    // key is introduced without a manifest entry, this test fails — and the
+    // gate throws in dev at runtime (fail-closed, SPEC-01 default-deny).
+    const manifest = loadManifest(manifestFixture as ManifestDocument);
+    const runtimeKeys = [
+      "open3dcalc_settings_v2",
+      "open3dcalc_sections",
+      "open3dcalc_catalog_v1",
+      "open3dcalc_consent_v1",
+      "open3dcalc_customers_v1",
+      "open3dcalc_filaments",
+      "open3dcalc_history_v2",
+      "open3dcalc_products",
+      "open3dcalc_quotes_v1",
+      "open3dcalc_tutorial_v1",
+      "open3dcalc_theme",
+      "open3dcalc_dashboard_v1",
+      "open3dcalc_dashboard_goal",
+      "open3dcalc_onboarded",
+      "open3dcalc_migration_done_v2",
+      "open3dcalc_quickstart_dismissed",
+      "i18nextLng",
+    ];
+    expect(findOrphanKeys(manifest, runtimeKeys)).toEqual([]);
+  });
+
+  it("S1: enumerates orphan keys (in code, absent from the manifest)", () => {
+    const manifest = loadManifest(manifestFixture as ManifestDocument);
+    const orphans = findOrphanKeys(manifest, [
+      "open3dcalc_consent_v1",
+      "open3dcalc_no_such_key_yet",
+    ]);
+    expect(orphans).toEqual(["open3dcalc_no_such_key_yet"]);
+  });
+
+  // -----------------------------------------------------------------------
+  // S1: loader edge branches (fail-closed on every malformed input shape)
+  // -----------------------------------------------------------------------
+
+  it("S1: rejects malformed documents (non-object, bad versions, extra/empty keys)", () => {
+    expect(() => loadManifest(null)).toThrow(ManifestError);
+    expect(() => loadManifest("nope")).toThrow(ManifestError);
+    expect(() => loadManifest({})).toThrow(ManifestError);
+    expect(() => loadManifest(docWith([]))).toThrow(ManifestError);
+    expect(() =>
+      loadManifest({ ...docWith([validEntry()]), manifest_version: "x" }),
+    ).toThrow(ManifestError);
+    expect(() =>
+      loadManifest({ ...docWith([validEntry()]), policy_version: "v1" }),
+    ).toThrow(ManifestError);
+    expect(() =>
+      loadManifest({ ...docWith([validEntry()]), unexpected: true }),
+    ).toThrow(ManifestError);
+  });
+
+  it("S1: getPolicyVersion returns the document policy version", () => {
+    expect(getPolicyVersion(docWith([validEntry()]))).toBe("1.0");
+    expect(getShippedPolicyVersion()).toBe(
+      (manifestFixture as ManifestDocument).policy_version,
+    );
+    expect(() => getPolicyVersion(null)).toThrow(ManifestError);
+    expect(() => getPolicyVersion({ policy_version: "bad" })).toThrow(
+      ManifestError,
+    );
+  });
+
+  it("S1: rejects malformed retention objects and duplicate platforms", () => {
+    expect(() =>
+      validateManifestEntry(validEntry({ retention: null })),
+    ).toThrow(ManifestError);
+    expect(() =>
+      validateManifestEntry(
+        validEntry({ retention: { policy: "fixed", max_days: -1 } }),
+      ),
+    ).toThrow(ManifestError);
+    expect(() =>
+      validateManifestEntry(
+        validEntry({ retention: { policy: "fixed", max_days: 1.5 } }),
+      ),
+    ).toThrow(ManifestError);
+    expect(() =>
+      validateManifestEntry(
+        validEntry({
+          retention: { policy: "fixed", max_days: 1, extra: true },
+        }),
+      ),
+    ).toThrow(ManifestError);
+    expect(() =>
+      validateManifestEntry(validEntry({ platforms: ["web", "web"] })),
+    ).toThrow(ManifestError);
+    expect(() =>
+      validateManifestEntry(validEntry({ platforms: "web" })),
+    ).toThrow(ManifestError);
+  });
+
+  it("S1: rejects empty key/purpose/owner and malformed version", () => {
+    expect(() => validateManifestEntry(validEntry({ key: "" }))).toThrow(
+      ManifestError,
+    );
+    expect(() => validateManifestEntry(validEntry({ purpose: "" }))).toThrow(
+      ManifestError,
+    );
+    expect(() => validateManifestEntry(validEntry({ owner: "" }))).toThrow(
+      ManifestError,
+    );
+    expect(() => validateManifestEntry(validEntry({ version: "1" }))).toThrow(
+      ManifestError,
+    );
+    expect(() => validateManifestEntry(validEntry({ key: 42 }))).toThrow(
+      ManifestError,
+    );
+  });
+});

--- a/src/shared/lib/__tests__/manifestGate.test.ts
+++ b/src/shared/lib/__tests__/manifestGate.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  checkKey,
+  isKeyAllowed,
+  resetManifestForTests,
+  ManifestError,
+  MANIFEST_POLICY_VERSION,
+} from "@/shared/lib/manifestGate";
+import manifestFixture from "../../../../docs/privacy/SPEC-01-manifest-fixture.json";
+import type { ManifestDocument } from "@/shared/lib/dataManifest";
+
+// ---------------------------------------------------------------------------
+// S1 wiring: unknown-key deny is an explicit dev error and never leaks the
+// key material; production falls back to a safe deny (no crash).
+// ---------------------------------------------------------------------------
+
+describe("manifestGate (S1 unknown-key deny)", () => {
+  const OLD_ENV = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    resetManifestForTests(manifestFixture as ManifestDocument);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    resetManifestForTests(null);
+    vi.restoreAllMocks();
+    process.env.NODE_ENV = OLD_ENV;
+  });
+
+  it("S1: allows known manifest keys with their full policy record", () => {
+    const decision = checkKey("open3dcalc_consent_v1");
+    expect(decision.allowed).toBe(true);
+    expect(decision.entry?.key).toBe("open3dcalc_consent_v1");
+    expect(decision.entry?.pii).toBe(false);
+    expect(MANIFEST_POLICY_VERSION).toMatch(/^\d+\.\d+$/);
+  });
+
+  it("S1: denies unknown keys with an explicit error in dev (no key material in logs)", () => {
+    process.env.NODE_ENV = "development";
+    expect(() => checkKey("open3dcalc_no_such_key")).toThrow(ManifestError);
+    expect(() => checkKey("open3dcalc_no_such_key")).toThrow(
+      /unknown storage key/,
+    );
+    // Logs carry only the key NAME (metadata), never stored values.
+    expect(console.warn).toHaveBeenCalled();
+    const logged = vi
+      .mocked(console.warn)
+      .mock.calls.map((args) => String(args[0]))
+      .join(" ");
+    expect(logged).toContain("open3dcalc_no_such_key");
+  });
+
+  it("S1: never crashes production — unknown keys fall back to a safe deny", () => {
+    process.env.NODE_ENV = "production";
+    const decision = checkKey("open3dcalc_no_such_key");
+    expect(decision.allowed).toBe(false);
+    expect(decision.entry).toBeUndefined();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("S1: denies everything when the manifest fails to load (fail-closed)", () => {
+    resetManifestForTests(null);
+    process.env.NODE_ENV = "production";
+    const decision = checkKey("open3dcalc_consent_v1");
+    expect(decision.allowed).toBe(false);
+  });
+
+  it("S1: isKeyAllowed never throws and rejects unknown keys in dev and prod", () => {
+    process.env.NODE_ENV = "development";
+    expect(isKeyAllowed("open3dcalc_consent_v1")).toBe(true);
+    expect(isKeyAllowed("open3dcalc_rogue")).toBe(false);
+    process.env.NODE_ENV = "production";
+    expect(isKeyAllowed("open3dcalc_consent_v1")).toBe(true);
+    expect(isKeyAllowed("open3dcalc_rogue")).toBe(false);
+    // Fail-closed: unreadable manifest denies even known keys, never throws.
+    resetManifestForTests(null);
+    expect(isKeyAllowed("open3dcalc_consent_v1")).toBe(false);
+  });
+
+  it("S1: reset without a document clears the cache and policy version", () => {
+    process.env.NODE_ENV = "production";
+    resetManifestForTests(manifestFixture as ManifestDocument);
+    expect(MANIFEST_POLICY_VERSION).toBe(
+      (manifestFixture as ManifestDocument).policy_version,
+    );
+    resetManifestForTests(undefined);
+    // Cache cleared (not failed): the next lookup lazily reloads the shipped
+    // manifest, so the policy version is restored by ensureLoaded().
+    const decision = checkKey("open3dcalc_consent_v1");
+    expect(decision.allowed).toBe(true);
+  });
+});

--- a/src/shared/lib/__tests__/manifestStorage.test.ts
+++ b/src/shared/lib/__tests__/manifestStorage.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { manifestStorage, guardedStorage } from "@/shared/lib/manifestStorage";
+import {
+  resetManifestForTests,
+  ManifestError,
+} from "@/shared/lib/manifestGate";
+import manifestFixture from "../../../../docs/privacy/SPEC-01-manifest-fixture.json";
+import type { ManifestDocument } from "@/shared/lib/dataManifest";
+
+// ---------------------------------------------------------------------------
+// S1 wiring: the gated storage wrappers are drop-in for their raw
+// counterparts on manifest-known keys, and deny unknown keys without ever
+// logging values (TEST-MATRIX 3.2 — key NAMES only).
+// ---------------------------------------------------------------------------
+
+describe("guardedStorage (S1)", () => {
+  const OLD_ENV = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    resetManifestForTests(manifestFixture as ManifestDocument);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    resetManifestForTests(null);
+    vi.restoreAllMocks();
+    process.env.NODE_ENV = OLD_ENV;
+    window.localStorage.clear();
+  });
+
+  it("passes known keys through to localStorage untouched", () => {
+    guardedStorage.setItem("open3dcalc_settings_v2", '{"activeTab":"fdm"}');
+    expect(window.localStorage.getItem("open3dcalc_settings_v2")).toBe(
+      '{"activeTab":"fdm"}',
+    );
+    expect(guardedStorage.getItem("open3dcalc_settings_v2")).toBe(
+      '{"activeTab":"fdm"}',
+    );
+    guardedStorage.removeItem("open3dcalc_settings_v2");
+    expect(window.localStorage.getItem("open3dcalc_settings_v2")).toBeNull();
+  });
+
+  it("denies unknown keys with ManifestError in dev", () => {
+    process.env.NODE_ENV = "development";
+    expect(() => guardedStorage.setItem("open3dcalc_rogue", "x")).toThrow(
+      ManifestError,
+    );
+    expect(() => guardedStorage.getItem("open3dcalc_rogue")).toThrow(
+      ManifestError,
+    );
+    expect(window.localStorage.getItem("open3dcalc_rogue")).toBeNull();
+  });
+
+  it("deny-safes unknown keys in production (no crash, no write)", () => {
+    process.env.NODE_ENV = "production";
+    expect(() => guardedStorage.setItem("open3dcalc_rogue", "x")).not.toThrow();
+    expect(window.localStorage.getItem("open3dcalc_rogue")).toBeNull();
+    expect(guardedStorage.getItem("open3dcalc_rogue")).toBeNull();
+  });
+
+  it("never logs stored values — key NAMES only (TEST-MATRIX 3.2)", () => {
+    const sensitiveValue = "João da Silva <joao@example.com>";
+    guardedStorage.setItem("open3dcalc_customers_v1", sensitiveValue);
+    const logged = vi
+      .mocked(console.warn)
+      .mock.calls.map((args) => String(args[0]))
+      .join(" ");
+    expect(logged).not.toContain("João da Silva");
+    expect(logged).not.toContain("joao@example.com");
+  });
+});
+
+describe("manifestStorage (S1 zustand persist wrapper)", () => {
+  const OLD_ENV = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    resetManifestForTests(manifestFixture as ManifestDocument);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    resetManifestForTests(null);
+    vi.restoreAllMocks();
+    process.env.NODE_ENV = OLD_ENV;
+    window.localStorage.clear();
+  });
+
+  it("returns a PersistStorage that round-trips a known key", () => {
+    const storage = manifestStorage();
+    expect(storage).toBeDefined();
+    storage!.setItem("open3dcalc_history_v2", { state: { v: 1 }, version: 1 });
+    expect(storage!.getItem("open3dcalc_history_v2")).toEqual({
+      state: { v: 1 },
+      version: 1,
+    });
+    storage!.removeItem("open3dcalc_history_v2");
+    expect(storage!.getItem("open3dcalc_history_v2")).toBeNull();
+  });
+
+  it("is JSON-based like the zustand default (persist wrapper shape kept)", () => {
+    const storage = manifestStorage<{ a: number }>();
+    storage!.setItem("open3dcalc_products", { state: { a: 1 }, version: 1 });
+    expect(window.localStorage.getItem("open3dcalc_products")).toBe(
+      '{"state":{"a":1},"version":1}',
+    );
+  });
+
+  it("denies unknown keys with ManifestError in dev (fail-closed)", () => {
+    process.env.NODE_ENV = "development";
+    const storage = manifestStorage();
+    expect(() =>
+      storage!.setItem("open3dcalc_rogue", { state: {}, version: 1 }),
+    ).toThrow(ManifestError);
+  });
+
+  it("degrades to a no-op storage when localStorage is unavailable (SSR)", () => {
+    const original = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get: () => undefined,
+    });
+    try {
+      const storage = manifestStorage();
+      expect(() =>
+        storage!.setItem("open3dcalc_settings_v2", { state: {}, version: 1 }),
+      ).not.toThrow();
+      expect(storage!.getItem("open3dcalc_settings_v2")).toBeNull();
+      expect(guardedStorage.getItem("open3dcalc_settings_v2")).toBeNull();
+      expect(() =>
+        guardedStorage.setItem("open3dcalc_settings_v2", "x"),
+      ).not.toThrow();
+    } finally {
+      if (original) Object.defineProperty(window, "localStorage", original);
+    }
+  });
+});

--- a/src/shared/lib/dataManifest.ts
+++ b/src/shared/lib/dataManifest.ts
@@ -1,0 +1,437 @@
+/**
+ * SPEC-01 data manifest loader (D1.1 S1).
+ *
+ * Single source of truth for storage-key policy: each key maps to its
+ * surface, platforms, class, pii flag, and the independent persistence /
+ * sync / export / erasure / retention policies.
+ *
+ * Cross-cutting constraints enforced here (TEST-MATRIX §1):
+ *  - plaintext_allowed is valid ONLY for pii:false keys (1.2)
+ *  - legal_basis not_personal_data is valid ONLY for pii:false keys (1.3)
+ *  - onboarding_flag: pii:false, sync:never, export:never (1.4)
+ *  - consent_record: pii:false, sync:never, export:never,
+ *    erasure:erase_on_delete_all (1.5)
+ *  - snapshot: never plaintext, never synced/exported (1.6)
+ *  - ephemeral_key: memory_only, never synced/exported (1.7)
+ *  - diagnostic: never user_export (1.8)
+ *  - unknown enum values, missing/extra fields, empty platforms (1.9–1.10)
+ *  - duplicate keys (1.11, uniqueness enforced by the loader)
+ *
+ * No real PII is ever handled here — keys are metadata only.
+ */
+
+import manifestFixture from "../../../docs/privacy/SPEC-01-manifest-fixture.json";
+
+/* ------------------------------------------------------------------ */
+/*  Normative vocabularies (mirror SPEC-01 schema $defs)               */
+/* ------------------------------------------------------------------ */
+
+export const SURFACES = [
+  "localStorage",
+  "sqlite_storage_table",
+  "sqlite_domain_tables",
+  "indexeddb",
+  "opfs",
+  "cache_api",
+  "appdata_files",
+  "logs",
+  "temp_staging",
+  "snapshots",
+  "memory",
+] as const;
+export type Surface = (typeof SURFACES)[number];
+
+export const PLATFORMS = ["electron", "web", "pwa"] as const;
+export type Platform = (typeof PLATFORMS)[number];
+
+export const PERSISTENCE_MODES = [
+  "none",
+  "memory_only",
+  "encrypted_at_rest",
+  "plaintext_allowed",
+] as const;
+export type PersistenceMode = (typeof PERSISTENCE_MODES)[number];
+
+export const SYNC_MODES = ["never", "opt_in"] as const;
+export type SyncMode = (typeof SYNC_MODES)[number];
+
+export const EXPORT_MODES = [
+  "never",
+  "user_export",
+  "diagnostic_only",
+] as const;
+export type ExportMode = (typeof EXPORT_MODES)[number];
+
+export const ERASURE_MODES = [
+  "erase_on_delete_all",
+  "retain_anonymized",
+] as const;
+export type ErasureMode = (typeof ERASURE_MODES)[number];
+
+export const DATA_CLASSES = [
+  "user_content",
+  "user_preference",
+  "ui_state",
+  "onboarding_flag",
+  "consent_record",
+  "cache",
+  "derived_analytics",
+  "diagnostic",
+  "snapshot",
+  "ephemeral_key",
+] as const;
+export type DataClass = (typeof DATA_CLASSES)[number];
+
+export const LEGAL_BASES = [
+  "consent",
+  "legitimate_interest",
+  "contract_performance",
+  "not_personal_data",
+] as const;
+export type LegalBasis = (typeof LEGAL_BASES)[number];
+
+export const RETENTION_POLICIES = [
+  "user_controlled",
+  "session_only",
+  "fixed",
+] as const;
+export type RetentionPolicy = (typeof RETENTION_POLICIES)[number];
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface ManifestRetention {
+  policy: RetentionPolicy;
+  max_days: number;
+}
+
+export interface ManifestEntry {
+  key: string;
+  surface: Surface;
+  platforms: Platform[];
+  class: DataClass;
+  pii: boolean;
+  persistence: PersistenceMode;
+  sync: SyncMode;
+  export: ExportMode;
+  erasure: ErasureMode;
+  retention: ManifestRetention;
+  purpose: string;
+  legal_basis: LegalBasis;
+  owner: string;
+  version: string;
+}
+
+export interface ManifestDocument {
+  manifest_version: string;
+  policy_version: string;
+  keys: ManifestEntry[];
+}
+
+/** Lookup index: key → entry (single source of truth at runtime). */
+export type ManifestIndex = ReadonlyMap<string, ManifestEntry>;
+
+export class ManifestError extends Error {
+  constructor(message: string) {
+    super(`[dataManifest] ${message}`);
+    this.name = "ManifestError";
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Validation (SPEC-01 §keys, TEST-MATRIX 1.2–1.11)                   */
+/* ------------------------------------------------------------------ */
+
+const REQUIRED_FIELDS: (keyof ManifestEntry)[] = [
+  "key",
+  "surface",
+  "platforms",
+  "class",
+  "pii",
+  "persistence",
+  "sync",
+  "export",
+  "erasure",
+  "retention",
+  "purpose",
+  "legal_basis",
+  "owner",
+  "version",
+];
+
+const VERSION_PATTERN = /^\d+\.\d+$/;
+
+function isOneOf<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): value is T {
+  return (
+    typeof value === "string" && (allowed as readonly string[]).includes(value)
+  );
+}
+
+function fieldError(key: string, detail: string): ManifestError {
+  return new ManifestError(`invalid entry "${key}": ${detail}`);
+}
+
+/**
+ * Validate a single manifest entry against SPEC-01.
+ * Throws ManifestError on the first violation found.
+ */
+export function validateManifestEntry(
+  entry: unknown,
+): asserts entry is ManifestEntry {
+  if (typeof entry !== "object" || entry === null) {
+    throw new ManifestError("entry must be an object");
+  }
+  const record = entry as Record<string, unknown>;
+  const label =
+    typeof record.key === "string" && record.key ? record.key : "<missing key>";
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in record))
+      throw fieldError(label, `missing required field "${field}"`);
+  }
+  for (const field of Object.keys(record)) {
+    if (!REQUIRED_FIELDS.includes(field as keyof ManifestEntry)) {
+      throw fieldError(label, `unknown field "${field}"`);
+    }
+  }
+
+  if (typeof record.key !== "string" || record.key.length === 0) {
+    throw fieldError(label, "key must be a non-empty string");
+  }
+  if (!isOneOf(record.surface, SURFACES)) {
+    throw fieldError(label, `unknown surface "${String(record.surface)}"`);
+  }
+  if (
+    !Array.isArray(record.platforms) ||
+    record.platforms.length === 0 ||
+    !record.platforms.every((p) => isOneOf(p, PLATFORMS)) ||
+    new Set(record.platforms).size !== record.platforms.length
+  ) {
+    throw fieldError(
+      label,
+      "platforms must be a non-empty array of unique platforms",
+    );
+  }
+  if (!isOneOf(record.class, DATA_CLASSES)) {
+    throw fieldError(label, `unknown class "${String(record.class)}"`);
+  }
+  if (typeof record.pii !== "boolean")
+    throw fieldError(label, "pii must be a boolean");
+  if (!isOneOf(record.persistence, PERSISTENCE_MODES)) {
+    throw fieldError(
+      label,
+      `unknown persistence "${String(record.persistence)}"`,
+    );
+  }
+  if (!isOneOf(record.sync, SYNC_MODES)) {
+    throw fieldError(label, `unknown sync "${String(record.sync)}"`);
+  }
+  if (!isOneOf(record.export, EXPORT_MODES)) {
+    throw fieldError(label, `unknown export "${String(record.export)}"`);
+  }
+  if (!isOneOf(record.erasure, ERASURE_MODES)) {
+    throw fieldError(label, `unknown erasure "${String(record.erasure)}"`);
+  }
+
+  const retention = record.retention as ManifestRetention | null;
+  if (
+    typeof retention !== "object" ||
+    retention === null ||
+    !isOneOf(retention.policy, RETENTION_POLICIES) ||
+    !Number.isInteger(retention.max_days) ||
+    retention.max_days < 0 ||
+    Object.keys(retention).length !== 2
+  ) {
+    throw fieldError(label, "retention must be { policy, max_days>=0 }");
+  }
+
+  if (typeof record.purpose !== "string" || record.purpose.length === 0) {
+    throw fieldError(label, "purpose must be a non-empty string");
+  }
+  if (!isOneOf(record.legal_basis, LEGAL_BASES)) {
+    throw fieldError(
+      label,
+      `unknown legal_basis "${String(record.legal_basis)}"`,
+    );
+  }
+  if (typeof record.owner !== "string" || record.owner.length === 0) {
+    throw fieldError(label, "owner must be a non-empty string");
+  }
+  if (
+    typeof record.version !== "string" ||
+    !VERSION_PATTERN.test(record.version)
+  ) {
+    throw fieldError(label, 'version must match "N.M"');
+  }
+
+  const typed = record as unknown as ManifestEntry;
+
+  // TEST-MATRIX 1.2: plaintext PII is never valid.
+  if (typed.persistence === "plaintext_allowed" && typed.pii) {
+    throw fieldError(
+      label,
+      "plaintext_allowed is valid only for pii:false keys",
+    );
+  }
+  // TEST-MATRIX 1.3.
+  if (typed.legal_basis === "not_personal_data" && typed.pii) {
+    throw fieldError(
+      label,
+      "not_personal_data is valid only for pii:false keys",
+    );
+  }
+  // TEST-MATRIX 1.4.
+  if (typed.class === "onboarding_flag") {
+    if (typed.pii)
+      throw fieldError(label, "onboarding_flag must have pii:false");
+    if (typed.sync !== "never")
+      throw fieldError(label, "onboarding_flag must have sync:never");
+    if (typed.export !== "never") {
+      throw fieldError(label, "onboarding_flag must have export:never");
+    }
+  }
+  // TEST-MATRIX 1.5.
+  if (typed.class === "consent_record") {
+    if (typed.pii)
+      throw fieldError(label, "consent_record must have pii:false");
+    if (typed.sync !== "never")
+      throw fieldError(label, "consent_record must have sync:never");
+    if (typed.export !== "never") {
+      throw fieldError(label, "consent_record must have export:never");
+    }
+    if (typed.erasure !== "erase_on_delete_all") {
+      throw fieldError(
+        label,
+        "consent_record must have erasure:erase_on_delete_all",
+      );
+    }
+  }
+  // TEST-MATRIX 1.6.
+  if (typed.class === "snapshot") {
+    if (typed.persistence === "plaintext_allowed") {
+      throw fieldError(label, "snapshot must never be plaintext_allowed");
+    }
+    if (typed.sync !== "never")
+      throw fieldError(label, "snapshot must have sync:never");
+    if (typed.export !== "never")
+      throw fieldError(label, "snapshot must have export:never");
+  }
+  // TEST-MATRIX 1.7.
+  if (typed.class === "ephemeral_key") {
+    if (typed.persistence !== "memory_only") {
+      throw fieldError(
+        label,
+        "ephemeral_key must have persistence:memory_only",
+      );
+    }
+    if (typed.sync !== "never")
+      throw fieldError(label, "ephemeral_key must have sync:never");
+    if (typed.export !== "never")
+      throw fieldError(label, "ephemeral_key must have export:never");
+  }
+  // TEST-MATRIX 1.8.
+  if (typed.class === "diagnostic" && typed.export === "user_export") {
+    throw fieldError(label, "diagnostic must never use export:user_export");
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Loader                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Load and validate a manifest document into an index.
+ * TEST-MATRIX 1.11: duplicate keys are rejected (fail-closed).
+ */
+export function loadManifest(doc: unknown): ManifestIndex {
+  if (typeof doc !== "object" || doc === null) {
+    throw new ManifestError("manifest document must be an object");
+  }
+  const record = doc as Record<string, unknown>;
+  if (
+    typeof record.manifest_version !== "string" ||
+    !VERSION_PATTERN.test(record.manifest_version)
+  ) {
+    throw new ManifestError('manifest_version must match "N.M"');
+  }
+  if (
+    typeof record.policy_version !== "string" ||
+    !VERSION_PATTERN.test(record.policy_version)
+  ) {
+    throw new ManifestError('policy_version must match "N.M"');
+  }
+  const extra = Object.keys(record).filter(
+    (k) => !["manifest_version", "policy_version", "keys"].includes(k),
+  );
+  if (extra.length > 0) {
+    throw new ManifestError(`unknown top-level field(s): ${extra.join(", ")}`);
+  }
+  if (!Array.isArray(record.keys) || record.keys.length === 0) {
+    throw new ManifestError("keys must be a non-empty array");
+  }
+
+  const index = new Map<string, ManifestEntry>();
+  for (const raw of record.keys) {
+    validateManifestEntry(raw);
+    const entry = raw as ManifestEntry;
+    if (index.has(entry.key)) {
+      throw new ManifestError(`duplicate key "${entry.key}"`);
+    }
+    index.set(entry.key, entry);
+  }
+  return index;
+}
+
+/** The shipped SPEC-01 fixture as a validated runtime index. */
+export function loadShippedManifest(): ManifestIndex {
+  return loadManifest(manifestFixture as ManifestDocument);
+}
+
+/** Document-level policy version (binds SPEC-04 receipts). */
+export function getPolicyVersion(doc: unknown): string {
+  if (typeof doc !== "object" || doc === null) {
+    throw new ManifestError("manifest document must be an object");
+  }
+  const version = (doc as Record<string, unknown>).policy_version;
+  if (typeof version !== "string" || !VERSION_PATTERN.test(version)) {
+    throw new ManifestError('policy_version must match "N.M"');
+  }
+  return version;
+}
+
+/** Policy version of the shipped fixture. */
+export function getShippedPolicyVersion(): string {
+  return getPolicyVersion(manifestFixture as ManifestDocument);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Queries                                                            */
+/* ------------------------------------------------------------------ */
+
+/** SPEC-01 default-deny: unknown keys are simply absent from the index. */
+export function isKnownKey(manifest: ManifestIndex, key: string): boolean {
+  return manifest.has(key);
+}
+
+export function getEntry(
+  manifest: ManifestIndex,
+  key: string,
+): ManifestEntry | undefined {
+  return manifest.get(key);
+}
+
+/**
+ * Enumerate orphan keys: storage keys observed in code that have no
+ * manifest entry. Orphans are candidates for manifest registration —
+ * they are NOT auto-allowed (default-deny still applies).
+ */
+export function findOrphanKeys(
+  manifest: ManifestIndex,
+  observedKeys: string[],
+): string[] {
+  return observedKeys.filter((key) => !manifest.has(key));
+}

--- a/src/shared/lib/dataSync.ts
+++ b/src/shared/lib/dataSync.ts
@@ -15,6 +15,8 @@
  * Zero external dependencies — browser-native Web Crypto only.
  */
 
+import { guardedStorage } from "@/shared/lib/manifestStorage";
+
 export const SYNC_FORMAT = "open3dcalc-export" as const;
 export const SYNC_VERSION = "1.0" as const;
 /** Kept in sync with package.json version. */
@@ -120,7 +122,7 @@ function base64ToBytes(b64: string): Uint8Array {
 function getRaw(key: string): string | null {
   if (typeof window === "undefined") return null;
   try {
-    return localStorage.getItem(key);
+    return guardedStorage.getItem(key);
   } catch {
     return null;
   }
@@ -187,7 +189,7 @@ function writeJSON(key: string, value: unknown): void {
     try {
       const parsed = JSON.parse(raw);
       if (isPersistWrapper(parsed)) {
-        localStorage.setItem(
+        guardedStorage.setItem(
           key,
           JSON.stringify({ state: value, version: parsed.version }),
         );
@@ -197,13 +199,13 @@ function writeJSON(key: string, value: unknown): void {
       /* ignore malformed value */
     }
   }
-  localStorage.setItem(key, JSON.stringify(value));
+  guardedStorage.setItem(key, JSON.stringify(value));
 }
 
 /** Patch a persist-wrapped key, keeping its other state fields and version. */
 function writePersistState(key: string, patch: Record<string, unknown>): void {
   const { state, version } = readPersistState(key);
-  localStorage.setItem(
+  guardedStorage.setItem(
     key,
     JSON.stringify({ state: { ...state, ...patch }, version }),
   );
@@ -593,7 +595,10 @@ export function applySyncData(
     if (mode === "replace") {
       writePersistState(KEYS.products, { products: incomingProducts });
     } else {
-      const { merged, conflicts: c } = mergeById(localProducts, incomingProducts);
+      const { merged, conflicts: c } = mergeById(
+        localProducts,
+        incomingProducts,
+      );
       writePersistState(KEYS.products, { products: merged });
       if (c > 0) conflicts.push("products");
     }
@@ -601,7 +606,7 @@ export function applySyncData(
   }
 
   if (data.theme !== "" || mode === "replace") {
-    localStorage.setItem(KEYS.theme, data.theme);
+    guardedStorage.setItem(KEYS.theme, data.theme);
     imported.push("theme");
   }
 
@@ -609,7 +614,7 @@ export function applySyncData(
     const { goal, ...dashboardV1 } = data.dashboard;
     writeJSON(KEYS.dashboard, dashboardV1);
     if (typeof goal === "string" && goal !== "") {
-      localStorage.setItem(KEYS.dashboardGoal, goal);
+      guardedStorage.setItem(KEYS.dashboardGoal, goal);
     }
     imported.push("dashboard");
   }

--- a/src/shared/lib/manifestGate.ts
+++ b/src/shared/lib/manifestGate.ts
@@ -1,0 +1,119 @@
+/**
+ * SPEC-01 manifest gate (D1.1 S1).
+ *
+ * Narrow choke point between stores and storage: every persisted key is
+ * checked against the manifest index before use. Unknown keys are denied:
+ * an explicit ManifestError in development, a safe deny (no throw — never
+ * crash production) otherwise. Logs carry the key NAME only, never values.
+ *
+ * Fail-closed: if the manifest cannot be loaded, every key is denied.
+ * Rollback (OWNERS-RUNBOOK §7): flipping the gate off returns stores to
+ * direct-key behavior; the manifest file itself is inert (read-only doc).
+ */
+
+import {
+  getShippedPolicyVersion,
+  loadManifest,
+  loadShippedManifest,
+  type ManifestDocument,
+  type ManifestEntry,
+  type ManifestIndex,
+  ManifestError,
+} from "./dataManifest";
+
+export { ManifestError };
+
+/** Policy version of the loaded manifest (binds SPEC-04 receipts). */
+export let MANIFEST_POLICY_VERSION = "0.0";
+
+let cachedIndex: ManifestIndex | null = null;
+let loadFailed = false;
+
+/**
+ * Log a gate event with key NAME metadata only. Values are NEVER logged,
+ * so PII cannot leak through this path (TEST-MATRIX 3.2).
+ */
+function logGateEvent(message: string): void {
+  console.warn(`[manifestGate] ${message}`);
+}
+
+function isDev(): boolean {
+  return process.env.NODE_ENV !== "production";
+}
+
+function ensureLoaded(): ManifestIndex | null {
+  if (cachedIndex || loadFailed) return cachedIndex;
+  try {
+    cachedIndex = loadShippedManifest();
+    MANIFEST_POLICY_VERSION = getShippedPolicyVersion();
+  } catch {
+    // Fail-closed: manifest unreadable ⇒ deny everything, log once.
+    loadFailed = true;
+    cachedIndex = null;
+    logGateEvent("manifest load failed; all keys denied");
+  }
+  return cachedIndex;
+}
+
+/** Test-only: inject a manifest document into the gate. */
+function injectForTests(doc: ManifestDocument): void {
+  cachedIndex = loadManifest(doc);
+  loadFailed = false;
+  MANIFEST_POLICY_VERSION =
+    typeof doc.policy_version === "string"
+      ? doc.policy_version
+      : MANIFEST_POLICY_VERSION;
+}
+
+export interface GateDecision {
+  allowed: boolean;
+  entry?: ManifestEntry;
+}
+
+/**
+ * Check a storage key against the manifest. Unknown keys are denied:
+ * throws ManifestError outside production, returns { allowed:false }
+ * in production (safe fallback — never crashes the app).
+ */
+export function checkKey(key: string): GateDecision {
+  const index = ensureLoaded();
+  const entry = index?.get(key);
+  if (entry) return { allowed: true, entry };
+  logGateEvent(`denied unknown storage key "${key}"`);
+  if (isDev()) {
+    throw new ManifestError(
+      `unknown storage key "${key}" — register it in docs/privacy/SPEC-01-manifest-fixture.json`,
+    );
+  }
+  return { allowed: false };
+}
+
+/**
+ * Non-throwing variant for bulk paths that must not let one unknown key
+ * abort the whole operation (e.g. the desktop persistence-bridge backup
+ * loop): returns false for unknown/failed-load keys, logging the key NAME.
+ */
+export function isKeyAllowed(key: string): boolean {
+  const index = ensureLoaded();
+  if (index?.has(key)) return true;
+  logGateEvent(`denied unknown storage key "${key}"`);
+  return false;
+}
+
+/** Test-only reset: inject a document, or null to simulate load failure. */
+export function resetManifestForTests(
+  doc: ManifestDocument | null | undefined,
+): void {
+  if (doc === undefined) {
+    cachedIndex = null;
+    loadFailed = false;
+    MANIFEST_POLICY_VERSION = "0.0";
+    return;
+  }
+  if (doc === null) {
+    cachedIndex = null;
+    loadFailed = true;
+    return;
+  }
+  injectForTests(doc);
+}

--- a/src/shared/lib/manifestStorage.ts
+++ b/src/shared/lib/manifestStorage.ts
@@ -1,0 +1,91 @@
+/**
+ * SPEC-01 gated storage wiring (D1.1 S1).
+ *
+ * Two narrow choke points that connect the manifest loader to the stores
+ * WITHOUT changing store behavior:
+ *
+ * 1. `manifestStorage()` — a zustand `StateStorage` wrapper around
+ *    `localStorage` that runs `checkKey(name)` before every get/set/remove.
+ *    Drop-in for the default `persist` storage: same sync semantics, same
+ *    JSON handling (delegated to zustand's `createJSONStorage`).
+ *
+ * 2. `guardedStorage` — a `localStorage`-shaped object for the handful of
+ *    stores that call `localStorage` directly. Same API, gate-checked.
+ *
+ * Gate semantics (see manifestGate): known keys pass through untouched;
+ * unknown keys throw in dev and deny-safely in production. Values are never
+ * logged — only key names (TEST-MATRIX 3.2).
+ */
+
+import {
+  createJSONStorage,
+  type PersistStorage,
+  type StateStorage,
+} from "zustand/middleware";
+import { checkKey } from "./manifestGate";
+
+function rawStorage(): StateStorage {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return {
+      getItem: () => null,
+      setItem: () => undefined,
+      removeItem: () => undefined,
+    };
+  }
+  return window.localStorage;
+}
+
+function gatedStateStorage(): StateStorage {
+  const backing = rawStorage();
+  return {
+    getItem: (name) => {
+      // Deny = no-op: dev throws inside checkKey; production returns
+      // allowed:false and we never touch the backing store.
+      if (!checkKey(name).allowed) return null;
+      return backing.getItem(name);
+    },
+    setItem: (name, value) => {
+      if (!checkKey(name).allowed) return;
+      backing.setItem(name, value);
+    },
+    removeItem: (name) => {
+      if (!checkKey(name).allowed) return;
+      backing.removeItem(name);
+    },
+  };
+}
+
+/**
+ * Drop-in zustand persist storage with manifest key-checking.
+ * Identical to zustand's default (`createJSONStorage(() => localStorage)`)
+ * except every key is validated against SPEC-01 first.
+ */
+export function manifestStorage<S>(): PersistStorage<S, unknown> | undefined {
+  return createJSONStorage<S>(() => gatedStateStorage());
+}
+
+/**
+ * `localStorage`-shaped facade with per-key manifest checks, for stores
+ * that touch `localStorage` directly. API-compatible for get/set/remove.
+ * Like `rawStorage()`, an unavailable backing store degrades to no-ops
+ * (reads return null) — storage failure never crashes the app.
+ */
+export const guardedStorage = {
+  getItem(key: string): string | null {
+    const backing = rawStorage();
+    if (!checkKey(key).allowed) return null;
+    // rawStorage() is always the synchronous window.localStorage (or the
+    // no-op stub), so the Promise variant of StateStorage never occurs.
+    return backing.getItem(key) as string | null;
+  },
+  setItem(key: string, value: string): void {
+    const backing = rawStorage();
+    if (!checkKey(key).allowed) return;
+    backing.setItem(key, value);
+  },
+  removeItem(key: string): void {
+    const backing = rawStorage();
+    if (!checkKey(key).allowed) return;
+    backing.removeItem(key);
+  },
+};

--- a/src/shared/stores/calculatorStore.helpers.ts
+++ b/src/shared/stores/calculatorStore.helpers.ts
@@ -1,48 +1,65 @@
-import type { CalcLevel, CalculatorState } from './calculatorStore.types'
+import type { CalcLevel, CalculatorState } from "./calculatorStore.types";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-let autoSaveTimer: ReturnType<typeof setTimeout> | null = null
+let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
 export function debouncedAutoSave(getState: () => CalculatorState) {
-  if (autoSaveTimer) clearTimeout(autoSaveTimer)
+  if (autoSaveTimer) clearTimeout(autoSaveTimer);
   autoSaveTimer = setTimeout(() => {
-    const s = getState()
+    const s = getState();
     const data = {
       activeTab: s.activeTab,
-      fdmMaterial: s.fdmMaterial, fdmPrintParams: s.fdmPrintParams,
-      fdmMachine: s.fdmMachine, fdmHardware: s.fdmHardware, fdmFinishing: s.fdmFinishing,
-      fdmLabor: s.fdmLabor, fdmExtras: s.fdmExtras, fdmSales: s.fdmSales,
-      fdmOps: s.fdmOps, fdmSoft: s.fdmSoft,
-      resinMaterial: s.resinMaterial, resinPrintParams: s.resinPrintParams,
-      resinPostProcess: s.resinPostProcess, resinMachine: s.resinMachine,
-      resinHardware: s.resinHardware, resinLabor: s.resinLabor,
-      resinExtras: s.resinExtras, resinSales: s.resinSales,
-      resinOps: s.resinOps, resinSoft: s.resinSoft,
+      fdmMaterial: s.fdmMaterial,
+      fdmPrintParams: s.fdmPrintParams,
+      fdmMachine: s.fdmMachine,
+      fdmHardware: s.fdmHardware,
+      fdmFinishing: s.fdmFinishing,
+      fdmLabor: s.fdmLabor,
+      fdmExtras: s.fdmExtras,
+      fdmSales: s.fdmSales,
+      fdmOps: s.fdmOps,
+      fdmSoft: s.fdmSoft,
+      resinMaterial: s.resinMaterial,
+      resinPrintParams: s.resinPrintParams,
+      resinPostProcess: s.resinPostProcess,
+      resinMachine: s.resinMachine,
+      resinHardware: s.resinHardware,
+      resinLabor: s.resinLabor,
+      resinExtras: s.resinExtras,
+      resinSales: s.resinSales,
+      resinOps: s.resinOps,
+      resinSoft: s.resinSoft,
       selectedPrinterId: s.selectedPrinter.id,
       selectedMarketplaceId: s.selectedMarketplace.id,
       fdmAmsEnabled: s.fdmAmsEnabled,
       fdmAmsSlots: s.fdmAmsSlots,
       fixedCosts: s.fixedCosts,
-      productName: s.productName, quantity: s.quantity,
-      infillPercent: s.infillPercent, targetMarginMode: s.targetMarginMode,
+      productName: s.productName,
+      quantity: s.quantity,
+      infillPercent: s.infillPercent,
+      targetMarginMode: s.targetMarginMode,
       enabledSections: s.enabledSections,
-      calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
-    }
-    localStorage.setItem('open3dcalc_settings_v2', JSON.stringify(data))
-  }, 800)
+      calcLevel: s.calcLevel,
+      hiddenFields: s.hiddenFields,
+    };
+    guardedStorage.setItem("open3dcalc_settings_v2", JSON.stringify(data));
+  }, 800);
 }
 
-export const loadStr = <T,>(key: string, def: T): T => {
-  if (typeof window === 'undefined') return def
+export const loadStr = <T>(key: string, def: T): T => {
+  if (typeof window === "undefined") return def;
   try {
-    const saved = localStorage.getItem('open3dcalc_settings_v2')
-    if (!saved) return def
-    const parsed = JSON.parse(saved)
-    return parsed[key] !== undefined ? parsed[key] : def
-  } catch { return def }
-}
+    const saved = guardedStorage.getItem("open3dcalc_settings_v2");
+    if (!saved) return def;
+    const parsed = JSON.parse(saved);
+    return parsed[key] !== undefined ? parsed[key] : def;
+  } catch {
+    return def;
+  }
+};
 
 export function migrateQuickMode(quickMode: boolean | undefined): CalcLevel {
-  if (quickMode === true) return 'basic'
-  if (quickMode === false) return 'advanced'
-  return 'basic'
+  if (quickMode === true) return "basic";
+  if (quickMode === false) return "advanced";
+  return "basic";
 }

--- a/src/shared/stores/calculatorStore.ts
+++ b/src/shared/stores/calculatorStore.ts
@@ -1,32 +1,59 @@
-import { create } from 'zustand'
-import { marketplaces } from '@/shared/lib/marketplace'
-import { printers } from '@/shared/lib/printers'
-import { useCatalogStore } from '@/shared/stores/catalogStore'
-import { useFilamentInventory } from '@/shared/stores/filamentInventory'
-import { useHistoryStore } from '@/shared/stores/historyStore'
-import type { CalculatorState, ComputeStoreInput } from './calculatorStore.types'
-import type { CalcLevel } from './calculatorStore.types'
-import type { CurrencySetting } from '@/shared/lib/currency'
-import type { CalculationSnapshot } from '@/shared/types'
+import { create } from "zustand";
+import { marketplaces } from "@/shared/lib/marketplace";
+import { printers } from "@/shared/lib/printers";
+import { useCatalogStore } from "@/shared/stores/catalogStore";
+import { useFilamentInventory } from "@/shared/stores/filamentInventory";
+import { useHistoryStore } from "@/shared/stores/historyStore";
+import type {
+  CalculatorState,
+  ComputeStoreInput,
+} from "./calculatorStore.types";
+import type { CalcLevel } from "./calculatorStore.types";
+import type { CurrencySetting } from "@/shared/lib/currency";
+import type { CalculationSnapshot } from "@/shared/types";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 import {
-  DEFAULT_FDM_MATERIAL, DEFAULT_FDM_PARAMS, DEFAULT_FDM_MACHINE,
-  DEFAULT_FDM_HARDWARE, DEFAULT_FDM_FINISHING, DEFAULT_LABOR,
-  DEFAULT_EXTRAS, DEFAULT_OPS, DEFAULT_SOFT, DEFAULT_SALES,
-  DEFAULT_RESIN_MATERIAL, DEFAULT_RESIN_PARAMS, DEFAULT_RESIN_PP,
-  DEFAULT_RESIN_MACHINE, DEFAULT_RESIN_HARDWARE, DEFAULT_RESIN_LABOR,
-  DEFAULT_RESIN_OPS, DEFAULT_RESIN_SOFT, DEFAULT_RESIN_EXTRAS,
-  DEFAULT_RESIN_SALES, DEFAULT_FIXED_COSTS, DEFAULT_AMS_SLOTS,
+  DEFAULT_FDM_MATERIAL,
+  DEFAULT_FDM_PARAMS,
+  DEFAULT_FDM_MACHINE,
+  DEFAULT_FDM_HARDWARE,
+  DEFAULT_FDM_FINISHING,
+  DEFAULT_LABOR,
+  DEFAULT_EXTRAS,
+  DEFAULT_OPS,
+  DEFAULT_SOFT,
+  DEFAULT_SALES,
+  DEFAULT_RESIN_MATERIAL,
+  DEFAULT_RESIN_PARAMS,
+  DEFAULT_RESIN_PP,
+  DEFAULT_RESIN_MACHINE,
+  DEFAULT_RESIN_HARDWARE,
+  DEFAULT_RESIN_LABOR,
+  DEFAULT_RESIN_OPS,
+  DEFAULT_RESIN_SOFT,
+  DEFAULT_RESIN_EXTRAS,
+  DEFAULT_RESIN_SALES,
+  DEFAULT_FIXED_COSTS,
+  DEFAULT_AMS_SLOTS,
   DEFAULT_VOLUME_DISCOUNTS,
-} from './calculatorStore.defaults'
-import { debouncedAutoSave, loadStr, migrateQuickMode } from './calculatorStore.helpers'
-import { computeStoreResults } from './calculatorStore.compute'
+} from "./calculatorStore.defaults";
+import {
+  debouncedAutoSave,
+  loadStr,
+  migrateQuickMode,
+} from "./calculatorStore.helpers";
+import { computeStoreResults } from "./calculatorStore.compute";
 
-type PrinterProfile = (typeof printers)[number]
+type PrinterProfile = (typeof printers)[number];
 
 // Re-exports — used by section components, Calculator.tsx, tests, etc.
-export type { CalculatorState, CalcLevel, ComputeStoreInput } from './calculatorStore.types'
+export type {
+  CalculatorState,
+  CalcLevel,
+  ComputeStoreInput,
+} from "./calculatorStore.types";
 
-const UNDO_LIMIT = 20
+const UNDO_LIMIT = 20;
 
 /** Extracts data-only fields from CalculatorState into a JSON-safe snapshot. */
 function captureSnapshot(s: CalculatorState): string {
@@ -65,76 +92,104 @@ function captureSnapshot(s: CalculatorState): string {
     targetMarginMode: s.targetMarginMode,
     enabledSections: s.enabledSections,
     currency: s.currency,
-  })
+  });
 }
 
 export const useCalculatorStore = create<CalculatorState>((set, get) => {
   const setWithCompute = (
-    update: Partial<CalculatorState> | ((state: CalculatorState) => Partial<CalculatorState>),
+    update:
+      | Partial<CalculatorState>
+      | ((state: CalculatorState) => Partial<CalculatorState>),
     options?: { undoable?: boolean },
   ) => {
-    const undoable = options?.undoable ?? true
+    const undoable = options?.undoable ?? true;
     set((state) => {
       const history = undoable
         ? [...(state.history || []), captureSnapshot(state)].slice(-UNDO_LIMIT)
-        : state.history || []
-      const nextState = typeof update === 'function' ? update(state) : update
-      const merged = { ...state, ...nextState }
-      const results = computeStoreResults(merged)
-      return { ...nextState, results, history }
-    })
-    debouncedAutoSave(get)
-  }
+        : state.history || [];
+      const nextState = typeof update === "function" ? update(state) : update;
+      const merged = { ...state, ...nextState };
+      const results = computeStoreResults(merged);
+      return { ...nextState, results, history };
+    });
+    debouncedAutoSave(get);
+  };
 
   const initialValues = {
-    activeTab: 'fdm' as const,
-    fdmMaterial: { ...DEFAULT_FDM_MATERIAL, ...loadStr('fdmMaterial', {}) },
-    fdmPrintParams: { ...DEFAULT_FDM_PARAMS, ...loadStr('fdmPrintParams', {}) },
-    fdmMachine: { ...DEFAULT_FDM_MACHINE, ...loadStr('fdmMachine', {}) },
-    fdmHardware: { ...DEFAULT_FDM_HARDWARE, ...loadStr('fdmHardware', {}) },
-    fdmFinishing: { ...DEFAULT_FDM_FINISHING, ...loadStr('fdmFinishing', {}) },
-    fdmLabor: { ...DEFAULT_LABOR, ...loadStr('fdmLabor', {}) },
-    fdmExtras: { ...DEFAULT_EXTRAS, ...loadStr('fdmExtras', {}) },
-    fdmSales: { ...DEFAULT_SALES, ...loadStr('fdmSales', {}) },
-    fdmOps: { ...DEFAULT_OPS, ...loadStr('fdmOps', {}) },
-    fdmSoft: { ...DEFAULT_SOFT, ...loadStr('fdmSoft', {}) },
+    activeTab: "fdm" as const,
+    fdmMaterial: { ...DEFAULT_FDM_MATERIAL, ...loadStr("fdmMaterial", {}) },
+    fdmPrintParams: { ...DEFAULT_FDM_PARAMS, ...loadStr("fdmPrintParams", {}) },
+    fdmMachine: { ...DEFAULT_FDM_MACHINE, ...loadStr("fdmMachine", {}) },
+    fdmHardware: { ...DEFAULT_FDM_HARDWARE, ...loadStr("fdmHardware", {}) },
+    fdmFinishing: { ...DEFAULT_FDM_FINISHING, ...loadStr("fdmFinishing", {}) },
+    fdmLabor: { ...DEFAULT_LABOR, ...loadStr("fdmLabor", {}) },
+    fdmExtras: { ...DEFAULT_EXTRAS, ...loadStr("fdmExtras", {}) },
+    fdmSales: { ...DEFAULT_SALES, ...loadStr("fdmSales", {}) },
+    fdmOps: { ...DEFAULT_OPS, ...loadStr("fdmOps", {}) },
+    fdmSoft: { ...DEFAULT_SOFT, ...loadStr("fdmSoft", {}) },
 
-    resinMaterial: { ...DEFAULT_RESIN_MATERIAL, ...loadStr('resinMaterial', {}) },
-    resinPrintParams: { ...DEFAULT_RESIN_PARAMS, ...loadStr('resinPrintParams', {}) },
-    resinPostProcess: { ...DEFAULT_RESIN_PP, ...loadStr('resinPostProcess', {}) },
-    resinMachine: { ...DEFAULT_RESIN_MACHINE, ...loadStr('resinMachine', {}) },
-    resinHardware: { ...DEFAULT_RESIN_HARDWARE, ...loadStr('resinHardware', {}) },
-    resinLabor: { ...DEFAULT_RESIN_LABOR, ...loadStr('resinLabor', {}) },
-    resinExtras: { ...DEFAULT_RESIN_EXTRAS, ...loadStr('resinExtras', {}) },
-    resinSales: { ...DEFAULT_RESIN_SALES, ...loadStr('resinSales', {}) },
-    resinOps: { ...DEFAULT_RESIN_OPS, ...loadStr('resinOps', {}) },
-    resinSoft: { ...DEFAULT_RESIN_SOFT, ...loadStr('resinSoft', {}) },
+    resinMaterial: {
+      ...DEFAULT_RESIN_MATERIAL,
+      ...loadStr("resinMaterial", {}),
+    },
+    resinPrintParams: {
+      ...DEFAULT_RESIN_PARAMS,
+      ...loadStr("resinPrintParams", {}),
+    },
+    resinPostProcess: {
+      ...DEFAULT_RESIN_PP,
+      ...loadStr("resinPostProcess", {}),
+    },
+    resinMachine: { ...DEFAULT_RESIN_MACHINE, ...loadStr("resinMachine", {}) },
+    resinHardware: {
+      ...DEFAULT_RESIN_HARDWARE,
+      ...loadStr("resinHardware", {}),
+    },
+    resinLabor: { ...DEFAULT_RESIN_LABOR, ...loadStr("resinLabor", {}) },
+    resinExtras: { ...DEFAULT_RESIN_EXTRAS, ...loadStr("resinExtras", {}) },
+    resinSales: { ...DEFAULT_RESIN_SALES, ...loadStr("resinSales", {}) },
+    resinOps: { ...DEFAULT_RESIN_OPS, ...loadStr("resinOps", {}) },
+    resinSoft: { ...DEFAULT_RESIN_SOFT, ...loadStr("resinSoft", {}) },
 
     selectedPrinter: printers[0],
     selectedMarketplace: marketplaces[0],
-    fixedCosts: { ...DEFAULT_FIXED_COSTS, ...loadStr('fixedCosts', {}) },
+    fixedCosts: { ...DEFAULT_FIXED_COSTS, ...loadStr("fixedCosts", {}) },
 
     fdmAmsEnabled: false,
-    fdmAmsSlots: DEFAULT_AMS_SLOTS.map(s => ({ ...s })),
+    fdmAmsSlots: DEFAULT_AMS_SLOTS.map((s) => ({ ...s })),
 
-    productName: '',
-    calcLevel: loadStr<CalcLevel>('calcLevel', migrateQuickMode(loadStr<boolean | undefined>('quickMode', undefined))),
-    hiddenFields: loadStr<string[]>('hiddenFields', []),
-    quantity: loadStr('quantity', 1),
-    infillPercent: loadStr('infillPercent', 20),
+    productName: "",
+    calcLevel: loadStr<CalcLevel>(
+      "calcLevel",
+      migrateQuickMode(loadStr<boolean | undefined>("quickMode", undefined)),
+    ),
+    hiddenFields: loadStr<string[]>("hiddenFields", []),
+    quantity: loadStr("quantity", 1),
+    infillPercent: loadStr("infillPercent", 20),
     targetMarginMode: false,
-    currency: loadStr<CurrencySetting>('currency', 'auto'),
-    enabledSections: loadStr('enabledSections', {
-      material: true, energy: true, machine: true, hardware: true,
-      consumables: true, labor: true, software: true, failure: true,
-      extras: true, postProcessing: true, packaging: true, shipping: true,
+    currency: loadStr<CurrencySetting>("currency", "auto"),
+    enabledSections: loadStr("enabledSections", {
+      material: true,
+      energy: true,
+      machine: true,
+      hardware: true,
+      consumables: true,
+      labor: true,
+      software: true,
+      failure: true,
+      extras: true,
+      postProcessing: true,
+      packaging: true,
+      shipping: true,
     }),
     selectedSpoolId: null,
     lastDeductedInfo: null,
     history: [],
-  }
+  };
 
-  const initialResults = computeStoreResults(initialValues as ComputeStoreInput)
+  const initialResults = computeStoreResults(
+    initialValues as ComputeStoreInput,
+  );
 
   return {
     ...initialValues,
@@ -165,26 +220,31 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
     setResinSoft: (v) => setWithCompute({ resinSoft: v }),
 
     setSelectedPrinter: (selectedPrinter) => {
-      const hasAms = (selectedPrinter.maxFilaments ?? 1) > 1
-      const wasAmsEnabled = get().fdmAmsEnabled
-      const state = get()
+      const hasAms = (selectedPrinter.maxFilaments ?? 1) > 1;
+      const wasAmsEnabled = get().fdmAmsEnabled;
+      const state = get();
       setWithCompute({
         selectedPrinter,
         fdmAmsEnabled: hasAms && wasAmsEnabled,
-        fdmPrintParams: { ...state.fdmPrintParams, printerPowerWatts: selectedPrinter.power },
-      })
+        fdmPrintParams: {
+          ...state.fdmPrintParams,
+          printerPowerWatts: selectedPrinter.power,
+        },
+      });
     },
-    setSelectedMarketplace: (selectedMarketplace) => setWithCompute({ selectedMarketplace }),
+    setSelectedMarketplace: (selectedMarketplace) =>
+      setWithCompute({ selectedMarketplace }),
 
-    setFixedCostsField: (field, value) => setWithCompute((state) => ({
-      fixedCosts: { ...state.fixedCosts, [field]: value as never },
-    })),
+    setFixedCostsField: (field, value) =>
+      setWithCompute((state) => ({
+        fixedCosts: { ...state.fixedCosts, [field]: value as never },
+      })),
 
     setFdmAmsEnabled: (fdmAmsEnabled) => setWithCompute({ fdmAmsEnabled }),
     setFdmAmsSlot: (index, slot) => {
-      const slots = [...get().fdmAmsSlots]
-      slots[index] = slot
-      setWithCompute({ fdmAmsSlots: slots })
+      const slots = [...get().fdmAmsSlots];
+      slots[index] = slot;
+      setWithCompute({ fdmAmsSlots: slots });
     },
 
     setCurrency: (currency) => set({ currency }),
@@ -192,89 +252,165 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
     setLastDeductedInfo: (info) => set({ lastDeductedInfo: info }),
 
     undo: () => {
-      const s = get()
-      const hist = s.history || []
-      if (hist.length === 0) return
-      const snapshot = hist[hist.length - 1]
+      const s = get();
+      const hist = s.history || [];
+      if (hist.length === 0) return;
+      const snapshot = hist[hist.length - 1];
       try {
-        const data = JSON.parse(snapshot) as Record<string, unknown>
+        const data = JSON.parse(snapshot) as Record<string, unknown>;
         set((state) => {
-          const merged = { ...state, ...data }
-          const results = computeStoreResults(merged)
-          return { ...merged, results, history: state.history.slice(0, -1) }
-        })
+          const merged = { ...state, ...data };
+          const results = computeStoreResults(merged);
+          return { ...merged, results, history: state.history.slice(0, -1) };
+        });
       } catch {
         // Corrupted snapshot — just remove it
-        set((state) => ({ history: state.history.slice(0, -1) }))
+        set((state) => ({ history: state.history.slice(0, -1) }));
       }
     },
 
     setProductName: (productName) => setWithCompute({ productName }),
     setCalcLevel: (calcLevel) => setWithCompute({ calcLevel }),
-    toggleField: (fieldId) => setWithCompute((state) => {
-      const hidden = state.hiddenFields.includes(fieldId)
-        ? state.hiddenFields.filter((id) => id !== fieldId)
-        : [...state.hiddenFields, fieldId]
-      return { hiddenFields: hidden }
-    }),
+    toggleField: (fieldId) =>
+      setWithCompute((state) => {
+        const hidden = state.hiddenFields.includes(fieldId)
+          ? state.hiddenFields.filter((id) => id !== fieldId)
+          : [...state.hiddenFields, fieldId];
+        return { hiddenFields: hidden };
+      }),
     setQuantity: (quantity) => setWithCompute({ quantity }),
     setInfillPercent: (infillPercent) => setWithCompute({ infillPercent }),
-    setTargetMarginMode: (targetMarginMode) => setWithCompute({ targetMarginMode }),
+    setTargetMarginMode: (targetMarginMode) =>
+      setWithCompute({ targetMarginMode }),
     toggleSection: (section) => {
       setWithCompute((state) => {
-        const next = { ...state.enabledSections, [section]: !state.enabledSections[section] }
-        localStorage.setItem('open3dcalc_sections', JSON.stringify(next))
-        return { enabledSections: next }
-      })
+        const next = {
+          ...state.enabledSections,
+          [section]: !state.enabledSections[section],
+        };
+        guardedStorage.setItem("open3dcalc_sections", JSON.stringify(next));
+        return { enabledSections: next };
+      });
     },
 
     setQuickStart: () => {
-      const rand = (min: number, max: number) => Math.round(Math.random() * (max - min) + min)
-      const pick = <T,>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
+      const rand = (min: number, max: number) =>
+        Math.round(Math.random() * (max - min) + min);
+      const pick = <T>(arr: T[]): T =>
+        arr[Math.floor(Math.random() * arr.length)];
 
-      const names = ['Vaso Decorativo', 'Suporte de Celular', 'Porta Canetas', 'Chaveiro Personalizado', 'Mascote Impressão 3D', 'Suporte para Fones', 'Organizador de Mesa', 'Mini Vaso', 'Porta Cartão', 'Ícone Decorativo', 'Suporte de Caneca', 'Caixa Organizadora']
-      const types = ['PLA', 'PETG', 'ABS', 'PLA+']
-      const type = pick(types)
-      const costPerKg = type === 'PLA' ? rand(65, 110) : type === 'PETG' ? rand(85, 140) : type === 'ABS' ? rand(80, 130) : rand(70, 120)
-      const weightUsed = rand(80, 350)
-      const purgeWeight = Math.random() > 0.5 ? rand(10, 30) : 0
-      const printTime = rand(2, 8)
-      const power = pick([150, 180, 200, 250, 300, 350])
-      const energyCost = parseFloat((rand(50, 110) / 100).toFixed(2))
-      const margin = pick([30, 40, 50, 60, 80])
-      const machineCost = pick([800, 1200, 1800, 2000, 2500, 3500, 5000])
-      const hourlyRate = pick([20, 25, 30, 35, 50])
-      const packaging = rand(2, 10)
-      const shipping = Math.random() > 0.4 ? rand(10, 30) : 0
-      const setupTime = rand(10, 30)
-      const postTime = rand(10, 25)
-      const failureValue = pick([5, 8, 10, 12, 15, 20])
-      const nozzleCost = pick([15, 20, 25, 35, 50])
-      const nozzleLife = pick([3, 5, 8, 10])
-      const bedCost = parseFloat((rand(10, 50) / 100).toFixed(2))
-      const hoursMonth = pick([50, 80, 100, 120, 150])
-      const depMonths = pick([24, 36, 48])
-      const infill = pick([10, 15, 20, 25, 30, 50])
-      const density = type === 'PLA' ? 1.24 : type === 'PETG' ? 1.27 : type === 'ABS' ? 1.04 : 1.24
-      const spoolEff = pick([95, 96, 97, 98, 99])
+      const names = [
+        "Vaso Decorativo",
+        "Suporte de Celular",
+        "Porta Canetas",
+        "Chaveiro Personalizado",
+        "Mascote Impressão 3D",
+        "Suporte para Fones",
+        "Organizador de Mesa",
+        "Mini Vaso",
+        "Porta Cartão",
+        "Ícone Decorativo",
+        "Suporte de Caneca",
+        "Caixa Organizadora",
+      ];
+      const types = ["PLA", "PETG", "ABS", "PLA+"];
+      const type = pick(types);
+      const costPerKg =
+        type === "PLA"
+          ? rand(65, 110)
+          : type === "PETG"
+            ? rand(85, 140)
+            : type === "ABS"
+              ? rand(80, 130)
+              : rand(70, 120);
+      const weightUsed = rand(80, 350);
+      const purgeWeight = Math.random() > 0.5 ? rand(10, 30) : 0;
+      const printTime = rand(2, 8);
+      const power = pick([150, 180, 200, 250, 300, 350]);
+      const energyCost = parseFloat((rand(50, 110) / 100).toFixed(2));
+      const margin = pick([30, 40, 50, 60, 80]);
+      const machineCost = pick([800, 1200, 1800, 2000, 2500, 3500, 5000]);
+      const hourlyRate = pick([20, 25, 30, 35, 50]);
+      const packaging = rand(2, 10);
+      const shipping = Math.random() > 0.4 ? rand(10, 30) : 0;
+      const setupTime = rand(10, 30);
+      const postTime = rand(10, 25);
+      const failureValue = pick([5, 8, 10, 12, 15, 20]);
+      const nozzleCost = pick([15, 20, 25, 35, 50]);
+      const nozzleLife = pick([3, 5, 8, 10]);
+      const bedCost = parseFloat((rand(10, 50) / 100).toFixed(2));
+      const hoursMonth = pick([50, 80, 100, 120, 150]);
+      const depMonths = pick([24, 36, 48]);
+      const infill = pick([10, 15, 20, 25, 30, 50]);
+      const density =
+        type === "PLA"
+          ? 1.24
+          : type === "PETG"
+            ? 1.27
+            : type === "ABS"
+              ? 1.04
+              : 1.24;
+      const spoolEff = pick([95, 96, 97, 98, 99]);
 
       setWithCompute({
-        activeTab: 'fdm',
-        fdmMaterial: { type, weightUsed, purgeWeight, costPerKg, density, spoolEfficiency: spoolEff },
-        fdmPrintParams: { printTimeHours: printTime, printerPowerWatts: power, energyCostPerKwh: energyCost, failureMode: 'percent', failureValue, riskMultiplier: 1, heatUpTimeMinutes: 5, heatUpPowerPercent: 150 },
-        fdmMachine: { enabled: true, machineCost, depreciationMonths: depMonths, hoursPerMonth: hoursMonth, maintenanceEnabled: false, maintenanceCost: 0 },
-        fdmHardware: { enabled: true, nozzleEnabled: true, nozzleCost, nozzleLifespanKg: nozzleLife, bedEnabled: true, bedAdhesionCost: bedCost },
+        activeTab: "fdm",
+        fdmMaterial: {
+          type,
+          weightUsed,
+          purgeWeight,
+          costPerKg,
+          density,
+          spoolEfficiency: spoolEff,
+        },
+        fdmPrintParams: {
+          printTimeHours: printTime,
+          printerPowerWatts: power,
+          energyCostPerKwh: energyCost,
+          failureMode: "percent",
+          failureValue,
+          riskMultiplier: 1,
+          heatUpTimeMinutes: 5,
+          heatUpPowerPercent: 150,
+        },
+        fdmMachine: {
+          enabled: true,
+          machineCost,
+          depreciationMonths: depMonths,
+          hoursPerMonth: hoursMonth,
+          maintenanceEnabled: false,
+          maintenanceCost: 0,
+        },
+        fdmHardware: {
+          enabled: true,
+          nozzleEnabled: true,
+          nozzleCost,
+          nozzleLifespanKg: nozzleLife,
+          bedEnabled: true,
+          bedAdhesionCost: bedCost,
+        },
         fdmFinishing: { enabled: false, suppliesCost: 5 },
-        fdmLabor: { enabled: true, setupTimeMinutes: setupTime, postProcessingTimeMinutes: postTime, hourlyRate },
+        fdmLabor: {
+          enabled: true,
+          setupTimeMinutes: setupTime,
+          postProcessingTimeMinutes: postTime,
+          hourlyRate,
+        },
         fdmExtras: { extrasCost: 0 },
-        fdmSales: { packagingCost: packaging, shippingCost: shipping, taxPercent: 0, marketplaceFeePercent: 0, profitMarginPercent: margin, volumeDiscounts: DEFAULT_VOLUME_DISCOUNTS },
+        fdmSales: {
+          packagingCost: packaging,
+          shippingCost: shipping,
+          taxPercent: 0,
+          marketplaceFeePercent: 0,
+          profitMarginPercent: margin,
+          volumeDiscounts: DEFAULT_VOLUME_DISCOUNTS,
+        },
         fdmOps: { enabled: false, ppeCostPerPrint: 0, carbonIntensity: 100 },
         fdmSoft: { enabled: false, slicerMonthlyCost: 0, modelFileCost: 0 },
         quantity: 1,
         productName: pick(names),
         infillPercent: infill,
         targetMarginMode: false,
-      })
+      });
     },
 
     resetCalculator: () => {
@@ -300,28 +436,30 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
         resinOps: { ...DEFAULT_RESIN_OPS },
         resinSoft: { ...DEFAULT_RESIN_SOFT },
         fixedCosts: { ...DEFAULT_FIXED_COSTS },
-        productName: '',
+        productName: "",
         quantity: 1,
         infillPercent: 20,
         targetMarginMode: false,
         fdmAmsEnabled: false,
-        fdmAmsSlots: DEFAULT_AMS_SLOTS.map(s => ({ ...s })),
+        fdmAmsSlots: DEFAULT_AMS_SLOTS.map((s) => ({ ...s })),
         selectedPrinter: printers[0],
         selectedMarketplace: marketplaces[0],
         selectedSpoolId: null,
         lastDeductedInfo: null,
-      })
+      });
     },
 
     addToHistory: () => {
-      const s = get()
-      const r = s.results
-      if (!r) return
-      const name = s.productName.trim() || (s.activeTab === 'fdm'
-        ? `${s.fdmMaterial.type} - ${s.fdmMaterial.weightUsed}g`
-        : `${s.resinMaterial.type} - ${s.resinMaterial.volumeUsedMl}ml`)
-      const now = Date.now()
-      const id = `hist_${now}_${Math.random().toString(36).slice(2, 7)}`
+      const s = get();
+      const r = s.results;
+      if (!r) return;
+      const name =
+        s.productName.trim() ||
+        (s.activeTab === "fdm"
+          ? `${s.fdmMaterial.type} - ${s.fdmMaterial.weightUsed}g`
+          : `${s.resinMaterial.type} - ${s.resinMaterial.volumeUsedMl}ml`);
+      const now = Date.now();
+      const id = `hist_${now}_${Math.random().toString(36).slice(2, 7)}`;
 
       const snapshot: CalculationSnapshot = {
         id,
@@ -359,7 +497,7 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
         targetMarginMode: s.targetMarginMode,
         enabledSections: s.enabledSections,
         results: r,
-      }
+      };
 
       useHistoryStore.getState().addEntry({
         id,
@@ -372,12 +510,23 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
         profit: r.profit,
         result: r,
         snapshot,
-      })
+      });
 
       // Auto-deduct filament from inventory
-      if (s.activeTab === 'fdm' && s.selectedSpoolId !== null && r.unitWeight > 0) {
-        useFilamentInventory.getState().deductWeight(s.selectedSpoolId, r.unitWeight)
-        set({ lastDeductedInfo: { spoolId: s.selectedSpoolId, weight: r.unitWeight } })
+      if (
+        s.activeTab === "fdm" &&
+        s.selectedSpoolId !== null &&
+        r.unitWeight > 0
+      ) {
+        useFilamentInventory
+          .getState()
+          .deductWeight(s.selectedSpoolId, r.unitWeight);
+        set({
+          lastDeductedInfo: {
+            spoolId: s.selectedSpoolId,
+            weight: r.unitWeight,
+          },
+        });
       }
     },
 
@@ -385,7 +534,8 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
       setWithCompute({
         activeTab: snapshot.type,
         fdmAmsEnabled: snapshot.fdmAmsEnabled ?? false,
-        fdmAmsSlots: snapshot.fdmAmsSlots ?? DEFAULT_AMS_SLOTS.map(s => ({ ...s })),
+        fdmAmsSlots:
+          snapshot.fdmAmsSlots ?? DEFAULT_AMS_SLOTS.map((s) => ({ ...s })),
         fixedCosts: snapshot.fixedCosts ?? { ...DEFAULT_FIXED_COSTS },
         fdmMaterial: snapshot.fdmMaterial,
         fdmPrintParams: snapshot.fdmPrintParams,
@@ -412,37 +562,53 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => {
         infillPercent: snapshot.infillPercent,
         targetMarginMode: snapshot.targetMarginMode,
         enabledSections: snapshot.enabledSections,
-      })
+      });
     },
 
     saveSettings: () => {
-      const s = get()
+      const s = get();
       const data = {
-        fdmMaterial: s.fdmMaterial, fdmPrintParams: s.fdmPrintParams,
-        fdmMachine: s.fdmMachine, fdmHardware: s.fdmHardware, fdmFinishing: s.fdmFinishing,
-        fdmLabor: s.fdmLabor, fdmExtras: s.fdmExtras, fdmSales: s.fdmSales,
-        fdmOps: s.fdmOps, fdmSoft: s.fdmSoft,
-        resinMaterial: s.resinMaterial, resinPrintParams: s.resinPrintParams,
-        resinPostProcess: s.resinPostProcess, resinMachine: s.resinMachine,
-        resinHardware: s.resinHardware, resinLabor: s.resinLabor,
-        resinExtras: s.resinExtras, resinSales: s.resinSales,
-        resinOps: s.resinOps, resinSoft: s.resinSoft,
+        fdmMaterial: s.fdmMaterial,
+        fdmPrintParams: s.fdmPrintParams,
+        fdmMachine: s.fdmMachine,
+        fdmHardware: s.fdmHardware,
+        fdmFinishing: s.fdmFinishing,
+        fdmLabor: s.fdmLabor,
+        fdmExtras: s.fdmExtras,
+        fdmSales: s.fdmSales,
+        fdmOps: s.fdmOps,
+        fdmSoft: s.fdmSoft,
+        resinMaterial: s.resinMaterial,
+        resinPrintParams: s.resinPrintParams,
+        resinPostProcess: s.resinPostProcess,
+        resinMachine: s.resinMachine,
+        resinHardware: s.resinHardware,
+        resinLabor: s.resinLabor,
+        resinExtras: s.resinExtras,
+        resinSales: s.resinSales,
+        resinOps: s.resinOps,
+        resinSoft: s.resinSoft,
         fdmAmsEnabled: s.fdmAmsEnabled,
         fdmAmsSlots: s.fdmAmsSlots,
         fixedCosts: s.fixedCosts,
-        quantity: s.quantity, infillPercent: s.infillPercent,
+        quantity: s.quantity,
+        infillPercent: s.infillPercent,
         currency: s.currency,
-        calcLevel: s.calcLevel, hiddenFields: s.hiddenFields,
-      }
-      localStorage.setItem('open3dcalc_settings_v2', JSON.stringify(data))
+        calcLevel: s.calcLevel,
+        hiddenFields: s.hiddenFields,
+      };
+      guardedStorage.setItem("open3dcalc_settings_v2", JSON.stringify(data));
     },
-  }
-})
+  };
+});
 
 // Sync default selections with catalog overrides when available.
-if (typeof window !== 'undefined') {
-  const catalog = useCatalogStore.getState()
-  const state = useCalculatorStore.getState()
-  const printer = catalog.printers.find(p => p.id === state.selectedPrinter.id)
-  if (printer) useCalculatorStore.setState({ selectedPrinter: printer as PrinterProfile })
+if (typeof window !== "undefined") {
+  const catalog = useCatalogStore.getState();
+  const state = useCalculatorStore.getState();
+  const printer = catalog.printers.find(
+    (p) => p.id === state.selectedPrinter.id,
+  );
+  if (printer)
+    useCalculatorStore.setState({ selectedPrinter: printer as PrinterProfile });
 }

--- a/src/shared/stores/catalogStore.ts
+++ b/src/shared/stores/catalogStore.ts
@@ -1,121 +1,160 @@
-import { create } from 'zustand'
-import type { Material, PrinterProfile, Marketplace } from '@/shared/types'
-import { fdmMaterials, resinMaterials } from '@/shared/lib/materials'
-import { printers } from '@/shared/lib/printers'
-import { marketplaces } from '@/shared/lib/marketplace'
+import { create } from "zustand";
+import type { Material, PrinterProfile, Marketplace } from "@/shared/types";
+import { fdmMaterials, resinMaterials } from "@/shared/lib/materials";
+import { printers } from "@/shared/lib/printers";
+import { marketplaces } from "@/shared/lib/marketplace";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-const STORAGE_KEY = 'open3dcalc_catalog_v1'
+const STORAGE_KEY = "open3dcalc_catalog_v1";
 
-type CatalogPrinter = PrinterProfile & { custom?: boolean }
-type CatalogMaterial = Material & { custom?: boolean }
-type CatalogMarketplace = Marketplace & { custom?: boolean }
+type CatalogPrinter = PrinterProfile & { custom?: boolean };
+type CatalogMaterial = Material & { custom?: boolean };
+type CatalogMarketplace = Marketplace & { custom?: boolean };
 
 interface CatalogState {
-  printers: CatalogPrinter[]
-  materials: CatalogMaterial[]
-  marketplaces: CatalogMarketplace[]
-  load: () => void
-  save: () => void
-  addPrinter: (printer: CatalogPrinter) => void
-  updatePrinter: (id: string, patch: Partial<CatalogPrinter>) => void
-  removePrinter: (id: string) => void
-  addMaterial: (material: CatalogMaterial) => void
-  updateMaterial: (id: string, patch: Partial<CatalogMaterial>) => void
-  removeMaterial: (id: string) => void
-  addMarketplace: (marketplace: CatalogMarketplace) => void
-  updateMarketplace: (id: string, patch: Partial<CatalogMarketplace>) => void
-  removeMarketplace: (id: string) => void
+  printers: CatalogPrinter[];
+  materials: CatalogMaterial[];
+  marketplaces: CatalogMarketplace[];
+  load: () => void;
+  save: () => void;
+  addPrinter: (printer: CatalogPrinter) => void;
+  updatePrinter: (id: string, patch: Partial<CatalogPrinter>) => void;
+  removePrinter: (id: string) => void;
+  addMaterial: (material: CatalogMaterial) => void;
+  updateMaterial: (id: string, patch: Partial<CatalogMaterial>) => void;
+  removeMaterial: (id: string) => void;
+  addMarketplace: (marketplace: CatalogMarketplace) => void;
+  updateMarketplace: (id: string, patch: Partial<CatalogMarketplace>) => void;
+  removeMarketplace: (id: string) => void;
 }
 
 const cloneDefaults = () => ({
-  printers: printers.map(p => ({ ...p })),
-  materials: [...fdmMaterials, ...resinMaterials].map(m => ({ ...m })),
-  marketplaces: marketplaces.map(m => ({ ...m })),
-})
+  printers: printers.map((p) => ({ ...p })),
+  materials: [...fdmMaterials, ...resinMaterials].map((m) => ({ ...m })),
+  marketplaces: marketplaces.map((m) => ({ ...m })),
+});
 
 const loadFromStorage = (): Partial<ReturnType<typeof cloneDefaults>> => {
-  if (typeof window === 'undefined') return {}
+  if (typeof window === "undefined") return {};
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+    return JSON.parse(guardedStorage.getItem(STORAGE_KEY) || "{}");
   } catch {
-    return {}
+    return {};
   }
-}
+};
 
 const persist = (state: ReturnType<typeof cloneDefaults>) => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-}
+  guardedStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};
 
 export const useCatalogStore = create<CatalogState>((set, get) => {
-  const defaults = cloneDefaults()
-  const saved = loadFromStorage()
+  const defaults = cloneDefaults();
+  const saved = loadFromStorage();
 
   const initial = {
     printers: (saved.printers ?? defaults.printers) as CatalogPrinter[],
     materials: (saved.materials ?? defaults.materials) as CatalogMaterial[],
-    marketplaces: (saved.marketplaces ?? defaults.marketplaces) as CatalogMarketplace[],
-  }
+    marketplaces: (saved.marketplaces ??
+      defaults.marketplaces) as CatalogMarketplace[],
+  };
 
   return {
     ...initial,
 
     load: () => {
-      const next = loadFromStorage()
+      const next = loadFromStorage();
       set({
         printers: (next.printers ?? defaults.printers) as CatalogPrinter[],
         materials: (next.materials ?? defaults.materials) as CatalogMaterial[],
-        marketplaces: (next.marketplaces ?? defaults.marketplaces) as CatalogMarketplace[],
-      })
+        marketplaces: (next.marketplaces ??
+          defaults.marketplaces) as CatalogMarketplace[],
+      });
     },
 
     save: () => persist(get()),
 
-    addPrinter: (printer) => set(state => {
-      const next = { ...state, printers: [...state.printers, printer] }
-      persist(next)
-      return next
-    }),
-    updatePrinter: (id, patch) => set(state => {
-      const next = { ...state, printers: state.printers.map(p => p.id === id ? { ...p, ...patch } : p) }
-      persist(next)
-      return next
-    }),
-    removePrinter: (id) => set(state => {
-      const next = { ...state, printers: state.printers.filter(p => p.id !== id) }
-      persist(next)
-      return next
-    }),
+    addPrinter: (printer) =>
+      set((state) => {
+        const next = { ...state, printers: [...state.printers, printer] };
+        persist(next);
+        return next;
+      }),
+    updatePrinter: (id, patch) =>
+      set((state) => {
+        const next = {
+          ...state,
+          printers: state.printers.map((p) =>
+            p.id === id ? { ...p, ...patch } : p,
+          ),
+        };
+        persist(next);
+        return next;
+      }),
+    removePrinter: (id) =>
+      set((state) => {
+        const next = {
+          ...state,
+          printers: state.printers.filter((p) => p.id !== id),
+        };
+        persist(next);
+        return next;
+      }),
 
-    addMaterial: (material) => set(state => {
-      const next = { ...state, materials: [...state.materials, material] }
-      persist(next)
-      return next
-    }),
-    updateMaterial: (id, patch) => set(state => {
-      const next = { ...state, materials: state.materials.map(m => m.id === id ? { ...m, ...patch } : m) }
-      persist(next)
-      return next
-    }),
-    removeMaterial: (id) => set(state => {
-      const next = { ...state, materials: state.materials.filter(m => m.id !== id) }
-      persist(next)
-      return next
-    }),
+    addMaterial: (material) =>
+      set((state) => {
+        const next = { ...state, materials: [...state.materials, material] };
+        persist(next);
+        return next;
+      }),
+    updateMaterial: (id, patch) =>
+      set((state) => {
+        const next = {
+          ...state,
+          materials: state.materials.map((m) =>
+            m.id === id ? { ...m, ...patch } : m,
+          ),
+        };
+        persist(next);
+        return next;
+      }),
+    removeMaterial: (id) =>
+      set((state) => {
+        const next = {
+          ...state,
+          materials: state.materials.filter((m) => m.id !== id),
+        };
+        persist(next);
+        return next;
+      }),
 
-    addMarketplace: (marketplace) => set(state => {
-      const next = { ...state, marketplaces: [...state.marketplaces, marketplace] }
-      persist(next)
-      return next
-    }),
-    updateMarketplace: (id, patch) => set(state => {
-      const next = { ...state, marketplaces: state.marketplaces.map(m => m.id === id ? { ...m, ...patch } : m) }
-      persist(next)
-      return next
-    }),
-    removeMarketplace: (id) => set(state => {
-      const next = { ...state, marketplaces: state.marketplaces.filter(m => m.id !== id) }
-      persist(next)
-      return next
-    }),
-  }
-})
+    addMarketplace: (marketplace) =>
+      set((state) => {
+        const next = {
+          ...state,
+          marketplaces: [...state.marketplaces, marketplace],
+        };
+        persist(next);
+        return next;
+      }),
+    updateMarketplace: (id, patch) =>
+      set((state) => {
+        const next = {
+          ...state,
+          marketplaces: state.marketplaces.map((m) =>
+            m.id === id ? { ...m, ...patch } : m,
+          ),
+        };
+        persist(next);
+        return next;
+      }),
+    removeMarketplace: (id) =>
+      set((state) => {
+        const next = {
+          ...state,
+          marketplaces: state.marketplaces.filter((m) => m.id !== id),
+        };
+        persist(next);
+        return next;
+      }),
+  };
+});

--- a/src/shared/stores/consentStore.ts
+++ b/src/shared/stores/consentStore.ts
@@ -1,15 +1,16 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { manifestStorage } from "@/shared/lib/manifestStorage";
 
 interface ConsentStore {
-  privacyBannerDismissed: boolean
-  consentGiven: boolean
-  consentDate: number | null
+  privacyBannerDismissed: boolean;
+  consentGiven: boolean;
+  consentDate: number | null;
 
-  dismissBanner(): void
-  giveConsent(): void
-  resetConsent(): void
-  needsConsent(): boolean
+  dismissBanner(): void;
+  giveConsent(): void;
+  resetConsent(): void;
+  needsConsent(): boolean;
 }
 
 export const useConsentStore = create<ConsentStore>()(
@@ -19,8 +20,7 @@ export const useConsentStore = create<ConsentStore>()(
       consentGiven: false,
       consentDate: null,
 
-      dismissBanner: () =>
-        set({ privacyBannerDismissed: true }),
+      dismissBanner: () => set({ privacyBannerDismissed: true }),
 
       giveConsent: () =>
         set({
@@ -39,8 +39,9 @@ export const useConsentStore = create<ConsentStore>()(
       needsConsent: () => !get().consentGiven,
     }),
     {
-      name: 'open3dcalc_consent_v1',
+      name: "open3dcalc_consent_v1",
       version: 1,
+      storage: manifestStorage(),
     },
   ),
-)
+);

--- a/src/shared/stores/customerStore.ts
+++ b/src/shared/stores/customerStore.ts
@@ -1,49 +1,50 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import type { Customer, CustomerFormData } from '@/shared/types'
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { manifestStorage } from "@/shared/lib/manifestStorage";
+import type { Customer, CustomerFormData } from "@/shared/types";
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function generateId(): string {
-  return `cust_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+  return `cust_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
 }
 
 interface CustomerStore {
-  customers: Customer[]
-  searchQuery: string
+  customers: Customer[];
+  searchQuery: string;
 
-  addCustomer: (data: CustomerFormData) => string
-  updateCustomer: (id: string, data: Partial<CustomerFormData>) => void
-  removeCustomer: (id: string) => void
+  addCustomer: (data: CustomerFormData) => string;
+  updateCustomer: (id: string, data: Partial<CustomerFormData>) => void;
+  removeCustomer: (id: string) => void;
 
-  getCustomer: (id: string) => Customer | undefined
-  searchCustomers: (query: string) => Customer[]
-  getAllCustomers: () => Customer[]
+  getCustomer: (id: string) => Customer | undefined;
+  searchCustomers: (query: string) => Customer[];
+  getAllCustomers: () => Customer[];
 
-  incrementQuoteCount: (id: string) => void
-  exportCustomers: () => string
-  importCustomers: (json: string) => { imported: number; skipped: number }
+  incrementQuoteCount: (id: string) => void;
+  exportCustomers: () => string;
+  importCustomers: (json: string) => { imported: number; skipped: number };
 
-  setSearchQuery: (query: string) => void
+  setSearchQuery: (query: string) => void;
 }
 
 export const useCustomerStore = create<CustomerStore>()(
   persist(
     (set, get) => ({
       customers: [],
-      searchQuery: '',
+      searchQuery: "",
 
       addCustomer: (data) => {
-        const name = data.name.trim()
+        const name = data.name.trim();
         if (name.length < 2) {
-          throw new Error('Name must be at least 2 characters')
+          throw new Error("Name must be at least 2 characters");
         }
         if (data.email && !EMAIL_REGEX.test(data.email)) {
-          throw new Error('Invalid email format')
+          throw new Error("Invalid email format");
         }
 
-        const now = Date.now()
-        const id = generateId()
+        const now = Date.now();
+        const id = generateId();
         const customer: Customer = {
           id,
           name,
@@ -55,9 +56,9 @@ export const useCustomerStore = create<CustomerStore>()(
           createdAt: now,
           updatedAt: now,
           quoteCount: 0,
-        }
-        set((state) => ({ customers: [...state.customers, customer] }))
-        return id
+        };
+        set((state) => ({ customers: [...state.customers, customer] }));
+        return id;
       },
 
       updateCustomer: (id, data) => {
@@ -67,16 +68,26 @@ export const useCustomerStore = create<CustomerStore>()(
               ? {
                   ...c,
                   ...(data.name !== undefined ? { name: data.name } : {}),
-                  ...(data.company !== undefined ? { company: data.company || undefined } : {}),
-                  ...(data.email !== undefined ? { email: data.email || undefined } : {}),
-                  ...(data.phone !== undefined ? { phone: data.phone || undefined } : {}),
-                  ...(data.address !== undefined ? { address: data.address || undefined } : {}),
-                  ...(data.notes !== undefined ? { notes: data.notes || undefined } : {}),
+                  ...(data.company !== undefined
+                    ? { company: data.company || undefined }
+                    : {}),
+                  ...(data.email !== undefined
+                    ? { email: data.email || undefined }
+                    : {}),
+                  ...(data.phone !== undefined
+                    ? { phone: data.phone || undefined }
+                    : {}),
+                  ...(data.address !== undefined
+                    ? { address: data.address || undefined }
+                    : {}),
+                  ...(data.notes !== undefined
+                    ? { notes: data.notes || undefined }
+                    : {}),
                   updatedAt: Date.now(),
                 }
               : c,
           ),
-        }))
+        }));
       },
 
       removeCustomer: (id) =>
@@ -87,15 +98,15 @@ export const useCustomerStore = create<CustomerStore>()(
       getCustomer: (id) => get().customers.find((c) => c.id === id),
 
       searchCustomers: (query) => {
-        const { customers } = get()
-        if (!query) return [...customers]
-        const q = query.toLowerCase()
+        const { customers } = get();
+        if (!query) return [...customers];
+        const q = query.toLowerCase();
         return customers.filter(
           (c) =>
             c.name.toLowerCase().includes(q) ||
             (c.company && c.company.toLowerCase().includes(q)) ||
             (c.email && c.email.toLowerCase().includes(q)),
-        )
+        );
       },
 
       getAllCustomers: () => [...get().customers],
@@ -105,75 +116,88 @@ export const useCustomerStore = create<CustomerStore>()(
           customers: state.customers.map((c) =>
             c.id === id ? { ...c, quoteCount: c.quoteCount + 1 } : c,
           ),
-        }))
+        }));
       },
 
       exportCustomers: () => {
         return JSON.stringify(
           {
             customers: get().customers,
-            version: '1.0',
+            version: "1.0",
             exportedAt: new Date().toISOString(),
           },
           null,
           2,
-        )
+        );
       },
 
       importCustomers: (json) => {
         try {
-          const data = JSON.parse(json)
-          const incoming = Array.isArray(data.customers) ? data.customers : []
-          let imported = 0
-          let skipped = 0
+          const data = JSON.parse(json);
+          const incoming = Array.isArray(data.customers) ? data.customers : [];
+          let imported = 0;
+          let skipped = 0;
 
           set((state) => {
-            const existingIds = new Set(state.customers.map((c) => c.id))
-            const newCustomers = incoming.flatMap((entry: unknown) => {
-              const e = entry as Partial<Customer>
-              if (!e || typeof e !== 'object' || !e.name || typeof e.name !== 'string' || e.name.trim().length < 2) {
-                skipped++
-                return []
-              }
-              const now = Date.now()
-              const normalized: Customer = {
-                id: typeof e.id === 'string' && e.id.trim()
-                  ? e.id
-                  : generateId(),
-                name: e.name.trim(),
-                company: e.company || undefined,
-                email: e.email || undefined,
-                phone: e.phone || undefined,
-                address: e.address || undefined,
-                notes: e.notes || undefined,
-                createdAt: typeof e.createdAt === 'number' ? e.createdAt : now,
-                updatedAt: typeof e.updatedAt === 'number' ? e.updatedAt : now,
-                quoteCount: typeof e.quoteCount === 'number' ? e.quoteCount : 0,
-              }
-              return [normalized]
-            }).filter((c: Customer) => {
-              if (existingIds.has(c.id)) {
-                skipped++
-                return false
-              }
-              existingIds.add(c.id)
-              imported++
-              return true
-            })
-            return { customers: [...state.customers, ...newCustomers] }
-          })
+            const existingIds = new Set(state.customers.map((c) => c.id));
+            const newCustomers = incoming
+              .flatMap((entry: unknown) => {
+                const e = entry as Partial<Customer>;
+                if (
+                  !e ||
+                  typeof e !== "object" ||
+                  !e.name ||
+                  typeof e.name !== "string" ||
+                  e.name.trim().length < 2
+                ) {
+                  skipped++;
+                  return [];
+                }
+                const now = Date.now();
+                const normalized: Customer = {
+                  id:
+                    typeof e.id === "string" && e.id.trim()
+                      ? e.id
+                      : generateId(),
+                  name: e.name.trim(),
+                  company: e.company || undefined,
+                  email: e.email || undefined,
+                  phone: e.phone || undefined,
+                  address: e.address || undefined,
+                  notes: e.notes || undefined,
+                  createdAt:
+                    typeof e.createdAt === "number" ? e.createdAt : now,
+                  updatedAt:
+                    typeof e.updatedAt === "number" ? e.updatedAt : now,
+                  quoteCount:
+                    typeof e.quoteCount === "number" ? e.quoteCount : 0,
+                };
+                return [normalized];
+              })
+              .filter((c: Customer) => {
+                if (existingIds.has(c.id)) {
+                  skipped++;
+                  return false;
+                }
+                existingIds.add(c.id);
+                imported++;
+                return true;
+              });
+            return { customers: [...state.customers, ...newCustomers] };
+          });
 
-          return { imported, skipped }
+          return { imported, skipped };
         } catch {
-          return { imported: 0, skipped: 0 }
+          return { imported: 0, skipped: 0 };
         }
       },
 
       setSearchQuery: (query) => set({ searchQuery: query }),
     }),
     {
-      name: 'open3dcalc_customers_v1',
+      name: "open3dcalc_customers_v1",
       version: 1,
+      storage: manifestStorage(),
     },
   ),
-)
+);

--- a/src/shared/stores/filamentInventory.ts
+++ b/src/shared/stores/filamentInventory.ts
@@ -1,102 +1,113 @@
-import { create } from 'zustand'
+import { create } from "zustand";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-export type SpoolStatus = 'in_stock' | 'on_the_way' | 'empty'
+export type SpoolStatus = "in_stock" | "on_the_way" | "empty";
 
 export interface FilamentSpool {
-  id: string
-  brand: string
-  material: string
-  color: string
-  colorHex: string
-  weightGrams: number
-  originalWeightGrams: number
-  costPerKg: number
-  diameterMm: number
-  dateAdded: number
-  notes: string
-  status: SpoolStatus
-  purchaseStore: string
+  id: string;
+  brand: string;
+  material: string;
+  color: string;
+  colorHex: string;
+  weightGrams: number;
+  originalWeightGrams: number;
+  costPerKg: number;
+  diameterMm: number;
+  dateAdded: number;
+  notes: string;
+  status: SpoolStatus;
+  purchaseStore: string;
 }
 
 interface FilamentInventoryState {
-  spools: FilamentSpool[]
-  addSpool: (spool: Omit<FilamentSpool, 'id' | 'dateAdded'>) => void
-  removeSpool: (id: string) => void
-  updateSpool: (id: string, updates: Partial<FilamentSpool>) => void
-  deductWeight: (id: string, grams: number) => void
-  getTotalWeight: () => number
-  getSpoolsByMaterial: (material: string) => FilamentSpool[]
-  getLowStockSpools: (thresholdGrams: number) => FilamentSpool[]
+  spools: FilamentSpool[];
+  addSpool: (spool: Omit<FilamentSpool, "id" | "dateAdded">) => void;
+  removeSpool: (id: string) => void;
+  updateSpool: (id: string, updates: Partial<FilamentSpool>) => void;
+  deductWeight: (id: string, grams: number) => void;
+  getTotalWeight: () => number;
+  getSpoolsByMaterial: (material: string) => FilamentSpool[];
+  getLowStockSpools: (thresholdGrams: number) => FilamentSpool[];
 }
 
 const migrateSpool = (s: Record<string, unknown>): FilamentSpool => ({
   id: s.id as string,
-  brand: (s.brand as string) || '',
-  material: (s.material as string) || 'PLA',
-  color: (s.color as string) || '',
-  colorHex: (s.colorHex as string) || '',
+  brand: (s.brand as string) || "",
+  material: (s.material as string) || "PLA",
+  color: (s.color as string) || "",
+  colorHex: (s.colorHex as string) || "",
   weightGrams: (s.weightGrams as number) || 0,
   originalWeightGrams: (s.originalWeightGrams as number) || 1000,
   costPerKg: (s.costPerKg as number) || 0,
   diameterMm: (s.diameterMm as number) || 1.75,
   dateAdded: (s.dateAdded as number) || Date.now(),
-  notes: (s.notes as string) || '',
-  status: (s.status as SpoolStatus) || 'in_stock',
-  purchaseStore: (s.purchaseStore as string) || '',
-})
+  notes: (s.notes as string) || "",
+  status: (s.status as SpoolStatus) || "in_stock",
+  purchaseStore: (s.purchaseStore as string) || "",
+});
 
 const loadSpools = (): FilamentSpool[] => {
-  if (typeof window === 'undefined') return []
+  if (typeof window === "undefined") return [];
   try {
-    const saved = localStorage.getItem('open3dcalc_filaments')
-    const raw = saved ? JSON.parse(saved) : []
-    return (raw as Record<string, unknown>[]).map(migrateSpool)
-  } catch { return [] }
-}
+    const saved = guardedStorage.getItem("open3dcalc_filaments");
+    const raw = saved ? JSON.parse(saved) : [];
+    return (raw as Record<string, unknown>[]).map(migrateSpool);
+  } catch {
+    return [];
+  }
+};
 
-export const useFilamentInventory = create<FilamentInventoryState>((set, get) => ({
-  spools: loadSpools(),
+export const useFilamentInventory = create<FilamentInventoryState>(
+  (set, get) => ({
+    spools: loadSpools(),
 
-  addSpool: (spool) => {
-    const newSpool: FilamentSpool = {
-      ...spool,
-      id: Date.now().toString(36) + Math.random().toString(36).slice(2, 7),
-      dateAdded: Date.now(),
-    }
-    const spools = [...get().spools, newSpool]
-    localStorage.setItem('open3dcalc_filaments', JSON.stringify(spools))
-    set({ spools })
-  },
+    addSpool: (spool) => {
+      const newSpool: FilamentSpool = {
+        ...spool,
+        id: Date.now().toString(36) + Math.random().toString(36).slice(2, 7),
+        dateAdded: Date.now(),
+      };
+      const spools = [...get().spools, newSpool];
+      guardedStorage.setItem("open3dcalc_filaments", JSON.stringify(spools));
+      set({ spools });
+    },
 
-  removeSpool: (id) => {
-    const spools = get().spools.filter(s => s.id !== id)
-    localStorage.setItem('open3dcalc_filaments', JSON.stringify(spools))
-    set({ spools })
-  },
+    removeSpool: (id) => {
+      const spools = get().spools.filter((s) => s.id !== id);
+      guardedStorage.setItem("open3dcalc_filaments", JSON.stringify(spools));
+      set({ spools });
+    },
 
-  updateSpool: (id, updates) => {
-    const spools = get().spools.map(s => s.id === id ? { ...s, ...updates } : s)
-    localStorage.setItem('open3dcalc_filaments', JSON.stringify(spools))
-    set({ spools })
-  },
+    updateSpool: (id, updates) => {
+      const spools = get().spools.map((s) =>
+        s.id === id ? { ...s, ...updates } : s,
+      );
+      guardedStorage.setItem("open3dcalc_filaments", JSON.stringify(spools));
+      set({ spools });
+    },
 
-  deductWeight: (id, grams) => {
-    const spools = get().spools.map(s =>
-      s.id === id ? { ...s, weightGrams: Math.max(0, s.weightGrams - grams) } : s
-    )
-    localStorage.setItem('open3dcalc_filaments', JSON.stringify(spools))
-    set({ spools })
-  },
+    deductWeight: (id, grams) => {
+      const spools = get().spools.map((s) =>
+        s.id === id
+          ? { ...s, weightGrams: Math.max(0, s.weightGrams - grams) }
+          : s,
+      );
+      guardedStorage.setItem("open3dcalc_filaments", JSON.stringify(spools));
+      set({ spools });
+    },
 
-  getTotalWeight: () => {
-    return get().spools.reduce((sum, s) => sum + s.weightGrams, 0)
-  },
+    getTotalWeight: () => {
+      return get().spools.reduce((sum, s) => sum + s.weightGrams, 0);
+    },
 
-  getSpoolsByMaterial: (material) => {
-    return get().spools.filter(s => s.material.toLowerCase() === material.toLowerCase())
-  },
+    getSpoolsByMaterial: (material) => {
+      return get().spools.filter(
+        (s) => s.material.toLowerCase() === material.toLowerCase(),
+      );
+    },
 
-  getLowStockSpools: (thresholdGrams) => {
-    return get().spools.filter(s => s.weightGrams < thresholdGrams)
-  },
-}))
+    getLowStockSpools: (thresholdGrams) => {
+      return get().spools.filter((s) => s.weightGrams < thresholdGrams);
+    },
+  }),
+);

--- a/src/shared/stores/historyStore.ts
+++ b/src/shared/stores/historyStore.ts
@@ -1,57 +1,65 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import type { HistoryEntry } from '@/shared/types'
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { manifestStorage } from "@/shared/lib/manifestStorage";
+import type { HistoryEntry } from "@/shared/types";
 
 interface HistoryStore {
-  entries: HistoryEntry[]
-  search: string
-  sortBy: 'date' | 'price' | 'profit' | 'name'
-  sortOrder: 'asc' | 'desc'
-  filterType: 'all' | 'fdm' | 'resin'
-  dateFrom: number | null
-  dateTo: number | null
+  entries: HistoryEntry[];
+  search: string;
+  sortBy: "date" | "price" | "profit" | "name";
+  sortOrder: "asc" | "desc";
+  filterType: "all" | "fdm" | "resin";
+  dateFrom: number | null;
+  dateTo: number | null;
 
   addEntry: (
-    entry: Omit<HistoryEntry, 'id' | 'timestamp'> & Partial<Pick<HistoryEntry, 'id' | 'timestamp'>>,
-  ) => string
-  removeEntry: (id: string) => void
-  clearHistory: () => void
-  getEntry: (id: string) => HistoryEntry | undefined
+    entry: Omit<HistoryEntry, "id" | "timestamp"> &
+      Partial<Pick<HistoryEntry, "id" | "timestamp">>,
+  ) => string;
+  removeEntry: (id: string) => void;
+  clearHistory: () => void;
+  getEntry: (id: string) => HistoryEntry | undefined;
 
-  setSearch: (search: string) => void
-  setSortBy: (sortBy: HistoryStore['sortBy']) => void
-  setSortOrder: (order: 'asc' | 'desc') => void
-  setFilterType: (type: 'all' | 'fdm' | 'resin') => void
-  setDateFrom: (date: number | null) => void
-  setDateTo: (date: number | null) => void
+  setSearch: (search: string) => void;
+  setSortBy: (sortBy: HistoryStore["sortBy"]) => void;
+  setSortOrder: (order: "asc" | "desc") => void;
+  setFilterType: (type: "all" | "fdm" | "resin") => void;
+  setDateFrom: (date: number | null) => void;
+  setDateTo: (date: number | null) => void;
 
-  getFilteredEntries: () => HistoryEntry[]
-  getTopPrinters: (limit?: number) => Array<{ name: string; profit: number; count: number }>
-  getTopMaterials: (limit?: number) => Array<{ name: string; count: number; totalCost: number }>
-  exportJson: () => string
-  importJson: (json: string) => { imported: number; skipped: number }
+  getFilteredEntries: () => HistoryEntry[];
+  getTopPrinters: (
+    limit?: number,
+  ) => Array<{ name: string; profit: number; count: number }>;
+  getTopMaterials: (
+    limit?: number,
+  ) => Array<{ name: string; count: number; totalCost: number }>;
+  exportJson: () => string;
+  importJson: (json: string) => { imported: number; skipped: number };
 }
 
 export const useHistoryStore = create<HistoryStore>()(
   persist(
     (set, get) => ({
       entries: [],
-      search: '',
-      sortBy: 'date',
-      sortOrder: 'desc',
-      filterType: 'all',
+      search: "",
+      sortBy: "date",
+      sortOrder: "desc",
+      filterType: "all",
       dateFrom: null,
       dateTo: null,
 
       addEntry: (entry) => {
-        const id = entry.id || `hist_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+        const id =
+          entry.id ||
+          `hist_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
         const newEntry: HistoryEntry = {
           ...entry,
           id,
           timestamp: entry.timestamp ?? Date.now(),
-        }
-        set((state) => ({ entries: [newEntry, ...state.entries] }))
-        return id
+        };
+        set((state) => ({ entries: [newEntry, ...state.entries] }));
+        return id;
       },
 
       removeEntry: (id) =>
@@ -71,144 +79,165 @@ export const useHistoryStore = create<HistoryStore>()(
       setDateTo: (dateTo) => set({ dateTo }),
 
       getFilteredEntries: () => {
-        const { entries, search, filterType, sortBy, sortOrder, dateFrom, dateTo } = get()
-        let filtered = [...entries]
+        const {
+          entries,
+          search,
+          filterType,
+          sortBy,
+          sortOrder,
+          dateFrom,
+          dateTo,
+        } = get();
+        let filtered = [...entries];
 
-        if (filterType !== 'all') {
-          filtered = filtered.filter((e) => e.type === filterType)
+        if (filterType !== "all") {
+          filtered = filtered.filter((e) => e.type === filterType);
         }
         if (search) {
-          const q = search.toLowerCase()
+          const q = search.toLowerCase();
           filtered = filtered.filter(
             (e) =>
               e.name.toLowerCase().includes(q) ||
               e.summary.toLowerCase().includes(q),
-          )
+          );
         }
         if (dateFrom !== null) {
-          filtered = filtered.filter((e) => e.timestamp >= dateFrom)
+          filtered = filtered.filter((e) => e.timestamp >= dateFrom);
         }
         if (dateTo !== null) {
-          const endOfDay = dateTo + 86399999
-          filtered = filtered.filter((e) => e.timestamp <= endOfDay)
+          const endOfDay = dateTo + 86399999;
+          filtered = filtered.filter((e) => e.timestamp <= endOfDay);
         }
 
         filtered.sort((a, b) => {
-          let cmp = 0
+          let cmp = 0;
           switch (sortBy) {
-            case 'date':
-              cmp = a.timestamp - b.timestamp
-              break
-            case 'price':
-              cmp = a.sellPrice - b.sellPrice
-              break
-            case 'profit':
-              cmp = a.profit - b.profit
-              break
-            case 'name':
-              cmp = a.name.localeCompare(b.name)
-              break
+            case "date":
+              cmp = a.timestamp - b.timestamp;
+              break;
+            case "price":
+              cmp = a.sellPrice - b.sellPrice;
+              break;
+            case "profit":
+              cmp = a.profit - b.profit;
+              break;
+            case "name":
+              cmp = a.name.localeCompare(b.name);
+              break;
           }
-          return sortOrder === 'desc' ? -cmp : cmp
-        })
+          return sortOrder === "desc" ? -cmp : cmp;
+        });
 
-        return filtered
+        return filtered;
       },
 
       getTopPrinters: (limit = 5) => {
-        const entries = get().entries
-        const map = new Map<string, { profit: number; count: number }>()
+        const entries = get().entries;
+        const map = new Map<string, { profit: number; count: number }>();
         for (const e of entries) {
-          const name = e.snapshot?.selectedPrinterId || (e.type === 'resin' ? 'Impressora Resina' : 'Impressora FDM')
-          const existing = map.get(name) || { profit: 0, count: 0 }
-          existing.profit += e.profit
-          existing.count++
-          map.set(name, existing)
+          const name =
+            e.snapshot?.selectedPrinterId ||
+            (e.type === "resin" ? "Impressora Resina" : "Impressora FDM");
+          const existing = map.get(name) || { profit: 0, count: 0 };
+          existing.profit += e.profit;
+          existing.count++;
+          map.set(name, existing);
         }
         return Array.from(map.entries())
           .map(([name, data]) => ({ name, ...data }))
           .sort((a, b) => b.profit - a.profit)
-          .slice(0, limit)
+          .slice(0, limit);
       },
 
       getTopMaterials: (limit = 5) => {
-        const entries = get().entries
-        const map = new Map<string, { count: number; totalCost: number }>()
+        const entries = get().entries;
+        const map = new Map<string, { count: number; totalCost: number }>();
         for (const e of entries) {
-          const type = e.snapshot?.fdmMaterial?.type || e.snapshot?.resinMaterial?.type || e.type
-          const existing = map.get(type) || { count: 0, totalCost: 0 }
-          existing.count++
-          existing.totalCost += e.totalCost
-          map.set(type, existing)
+          const type =
+            e.snapshot?.fdmMaterial?.type ||
+            e.snapshot?.resinMaterial?.type ||
+            e.type;
+          const existing = map.get(type) || { count: 0, totalCost: 0 };
+          existing.count++;
+          existing.totalCost += e.totalCost;
+          map.set(type, existing);
         }
         return Array.from(map.entries())
           .map(([name, data]) => ({ name, ...data }))
           .sort((a, b) => b.count - a.count)
-          .slice(0, limit)
+          .slice(0, limit);
       },
 
       exportJson: () => {
         return JSON.stringify(
           {
             entries: get().entries,
-            version: '2.0',
+            version: "2.0",
             exportedAt: new Date().toISOString(),
           },
           null,
           2,
-        )
+        );
       },
 
       importJson: (json) => {
         try {
-          const data = JSON.parse(json)
-          const incoming = Array.isArray(data.entries) ? data.entries : []
-          let imported = 0
-          let skipped = 0
+          const data = JSON.parse(json);
+          const incoming = Array.isArray(data.entries) ? data.entries : [];
+          let imported = 0;
+          let skipped = 0;
 
           set((state) => {
-            const existingIds = new Set(state.entries.map((e) => e.id))
-            const newEntries = incoming.flatMap((entry: unknown) => {
-              const e = entry as Partial<HistoryEntry>
-              if (!e || typeof e !== 'object' || !e.result) {
-                skipped++
-                return []
-              }
-              const normalized: HistoryEntry = {
-                id: typeof e.id === 'string' && e.id.trim()
-                  ? e.id
-                  : `hist_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
-                timestamp: typeof e.timestamp === 'number' ? e.timestamp : Date.now(),
-                type: e.type === 'resin' ? 'resin' : 'fdm',
-                name: typeof e.name === 'string' && e.name.trim() ? e.name : 'Histórico',
-                summary: typeof e.summary === 'string' ? e.summary : '',
-                totalCost: Number(e.totalCost || 0),
-                sellPrice: Number(e.sellPrice || 0),
-                profit: Number(e.profit || 0),
-                result: e.result,
-                snapshot: e.snapshot ?? null,
-              }
-              return [normalized]
-            }).filter((e: HistoryEntry) => {
-              if (existingIds.has(e.id)) {
-                skipped++
-                return false
-              }
-              imported++
-              return true
-            })
-            return { entries: [...state.entries, ...newEntries] }
-          })
+            const existingIds = new Set(state.entries.map((e) => e.id));
+            const newEntries = incoming
+              .flatMap((entry: unknown) => {
+                const e = entry as Partial<HistoryEntry>;
+                if (!e || typeof e !== "object" || !e.result) {
+                  skipped++;
+                  return [];
+                }
+                const normalized: HistoryEntry = {
+                  id:
+                    typeof e.id === "string" && e.id.trim()
+                      ? e.id
+                      : `hist_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+                  timestamp:
+                    typeof e.timestamp === "number" ? e.timestamp : Date.now(),
+                  type: e.type === "resin" ? "resin" : "fdm",
+                  name:
+                    typeof e.name === "string" && e.name.trim()
+                      ? e.name
+                      : "Histórico",
+                  summary: typeof e.summary === "string" ? e.summary : "",
+                  totalCost: Number(e.totalCost || 0),
+                  sellPrice: Number(e.sellPrice || 0),
+                  profit: Number(e.profit || 0),
+                  result: e.result,
+                  snapshot: e.snapshot ?? null,
+                };
+                return [normalized];
+              })
+              .filter((e: HistoryEntry) => {
+                if (existingIds.has(e.id)) {
+                  skipped++;
+                  return false;
+                }
+                imported++;
+                return true;
+              });
+            return { entries: [...state.entries, ...newEntries] };
+          });
 
-          return { imported, skipped }
+          return { imported, skipped };
         } catch {
-          return { imported: 0, skipped: 0 }
+          return { imported: 0, skipped: 0 };
         }
       },
     }),
     {
-      name: 'open3dcalc_history_v2',
+      name: "open3dcalc_history_v2",
       version: 2,
+      storage: manifestStorage(),
     },
   ),
-)
+);

--- a/src/shared/stores/productInventory.ts
+++ b/src/shared/stores/productInventory.ts
@@ -1,23 +1,27 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import type { Product, ProductFormData } from '@/shared/types'
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { manifestStorage } from "@/shared/lib/manifestStorage";
+import type { Product, ProductFormData } from "@/shared/types";
 
 function generateId(): string {
-  return `prod_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+  return `prod_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
 }
 
 /** True when the sale price is below cost. Warn-only — never blocks saving. */
-export function isBelowCost(p: Pick<Product, 'costPrice' | 'salePrice'>): boolean {
-  return p.salePrice < p.costPrice
+export function isBelowCost(
+  p: Pick<Product, "costPrice" | "salePrice">,
+): boolean {
+  return p.salePrice < p.costPrice;
 }
 
 function escapeCsvCell(value: string | number): string {
-  const s = String(value)
-  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+  const s = String(value);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
 export function exportProductsCSV(): string {
-  const header = 'id,name,weightGrams,filamentType,costPrice,salePrice,sold,createdAt,updatedAt'
+  const header =
+    "id,name,weightGrams,filamentType,costPrice,salePrice,sold,createdAt,updatedAt";
   const rows = useProductInventory
     .getState()
     .products.map((p) =>
@@ -33,22 +37,22 @@ export function exportProductsCSV(): string {
         p.updatedAt,
       ]
         .map(escapeCsvCell)
-        .join(','),
-    )
-  return [header, ...rows].join('\n')
+        .join(","),
+    );
+  return [header, ...rows].join("\n");
 }
 
 interface ProductInventoryState {
-  products: Product[]
+  products: Product[];
 
-  addProduct: (data: ProductFormData) => string
-  updateProduct: (id: string, data: Partial<ProductFormData>) => void
-  removeProduct: (id: string) => void
-  markSold: (id: string, sold: boolean) => void
+  addProduct: (data: ProductFormData) => string;
+  updateProduct: (id: string, data: Partial<ProductFormData>) => void;
+  removeProduct: (id: string) => void;
+  markSold: (id: string, sold: boolean) => void;
 
-  getProduct: (id: string) => Product | undefined
-  searchProducts: (query: string) => Product[]
-  getAllProducts: () => Product[]
+  getProduct: (id: string) => Product | undefined;
+  searchProducts: (query: string) => Product[];
+  getAllProducts: () => Product[];
 }
 
 export const useProductInventory = create<ProductInventoryState>()(
@@ -57,25 +61,25 @@ export const useProductInventory = create<ProductInventoryState>()(
       products: [],
 
       addProduct: (data) => {
-        const name = data.name.trim()
+        const name = data.name.trim();
         if (name.length < 2) {
-          throw new Error('Name must be at least 2 characters')
+          throw new Error("Name must be at least 2 characters");
         }
-        const now = Date.now()
-        const id = generateId()
+        const now = Date.now();
+        const id = generateId();
         const product: Product = {
           id,
           name,
           weightGrams: data.weightGrams || 0,
-          filamentType: data.filamentType || '',
+          filamentType: data.filamentType || "",
           costPrice: data.costPrice || 0,
           salePrice: data.salePrice || 0,
           sold: false,
           createdAt: now,
           updatedAt: now,
-        }
-        set((state) => ({ products: [...state.products, product] }))
-        return id
+        };
+        set((state) => ({ products: [...state.products, product] }));
+        return id;
       },
 
       updateProduct: (id, data) => {
@@ -85,15 +89,23 @@ export const useProductInventory = create<ProductInventoryState>()(
               ? {
                   ...p,
                   ...(data.name !== undefined ? { name: data.name } : {}),
-                  ...(data.weightGrams !== undefined ? { weightGrams: data.weightGrams } : {}),
-                  ...(data.filamentType !== undefined ? { filamentType: data.filamentType } : {}),
-                  ...(data.costPrice !== undefined ? { costPrice: data.costPrice } : {}),
-                  ...(data.salePrice !== undefined ? { salePrice: data.salePrice } : {}),
+                  ...(data.weightGrams !== undefined
+                    ? { weightGrams: data.weightGrams }
+                    : {}),
+                  ...(data.filamentType !== undefined
+                    ? { filamentType: data.filamentType }
+                    : {}),
+                  ...(data.costPrice !== undefined
+                    ? { costPrice: data.costPrice }
+                    : {}),
+                  ...(data.salePrice !== undefined
+                    ? { salePrice: data.salePrice }
+                    : {}),
                   updatedAt: Date.now(),
                 }
               : p,
           ),
-        }))
+        }));
       },
 
       removeProduct: (id) =>
@@ -111,21 +123,22 @@ export const useProductInventory = create<ProductInventoryState>()(
       getProduct: (id) => get().products.find((p) => p.id === id),
 
       searchProducts: (query) => {
-        const { products } = get()
-        if (!query) return [...products]
-        const q = query.toLowerCase()
+        const { products } = get();
+        if (!query) return [...products];
+        const q = query.toLowerCase();
         return products.filter(
           (p) =>
             p.name.toLowerCase().includes(q) ||
             (p.filamentType && p.filamentType.toLowerCase().includes(q)),
-        )
+        );
       },
 
       getAllProducts: () => [...get().products],
     }),
     {
-      name: 'open3dcalc_products',
+      name: "open3dcalc_products",
       version: 1,
+      storage: manifestStorage(),
     },
   ),
-)
+);

--- a/src/shared/stores/quoteStore.ts
+++ b/src/shared/stores/quoteStore.ts
@@ -1,35 +1,36 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import type { Quote, QuoteItem, QuoteFormData } from '@/shared/types'
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { manifestStorage } from "@/shared/lib/manifestStorage";
+import type { Quote, QuoteItem, QuoteFormData } from "@/shared/types";
 
 function generateId(): string {
-  return `quote_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+  return `quote_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
 }
 
 interface QuoteStore {
-  quotes: Quote[]
-  nextNumber: number
-  searchQuery: string
-  statusFilter: 'all' | 'draft' | 'sent' | 'approved' | 'rejected'
+  quotes: Quote[];
+  nextNumber: number;
+  searchQuery: string;
+  statusFilter: "all" | "draft" | "sent" | "approved" | "rejected";
 
-  addQuote: (data: QuoteFormData) => string
-  updateQuote: (id: string, data: Partial<Quote>) => void
-  removeQuote: (id: string) => void
-  getQuote: (id: string) => Quote | undefined
-  getQuotesByCustomer: (customerId: string) => Quote[]
-  setQuoteStatus: (id: string, status: Quote['status']) => void
+  addQuote: (data: QuoteFormData) => string;
+  updateQuote: (id: string, data: Partial<Quote>) => void;
+  removeQuote: (id: string) => void;
+  getQuote: (id: string) => Quote | undefined;
+  getQuotesByCustomer: (customerId: string) => Quote[];
+  setQuoteStatus: (id: string, status: Quote["status"]) => void;
 
-  setSearchQuery: (query: string) => void
-  setStatusFilter: (filter: QuoteStore['statusFilter']) => void
-  getFilteredQuotes: () => Quote[]
+  setSearchQuery: (query: string) => void;
+  setStatusFilter: (filter: QuoteStore["statusFilter"]) => void;
+  getFilteredQuotes: () => Quote[];
 
-  exportQuotes: () => string
-  importQuotes: (json: string) => { imported: number; skipped: number }
+  exportQuotes: () => string;
+  importQuotes: (json: string) => { imported: number; skipped: number };
 
   calculateTotals: (
-    items: Pick<QuoteItem, 'quantity' | 'unitPrice' | 'discountPercent'>[],
+    items: Pick<QuoteItem, "quantity" | "unitPrice" | "discountPercent">[],
     globalDiscountPercent: number,
-  ) => { subtotal: number; discountAmount: number; total: number }
+  ) => { subtotal: number; discountAmount: number; total: number };
 }
 
 export const useQuoteStore = create<QuoteStore>()(
@@ -37,29 +38,29 @@ export const useQuoteStore = create<QuoteStore>()(
     (set, get) => ({
       quotes: [],
       nextNumber: 1,
-      searchQuery: '',
-      statusFilter: 'all',
+      searchQuery: "",
+      statusFilter: "all",
 
       calculateTotals: (items, globalDiscountPercent) => {
         const subtotal = items.reduce((acc, item) => {
-          return acc + item.quantity * item.unitPrice
-        }, 0)
-        const discountAmount = subtotal * (globalDiscountPercent / 100)
-        const total = subtotal - discountAmount
-        return { subtotal, discountAmount, total }
+          return acc + item.quantity * item.unitPrice;
+        }, 0);
+        const discountAmount = subtotal * (globalDiscountPercent / 100);
+        const total = subtotal - discountAmount;
+        return { subtotal, discountAmount, total };
       },
 
       addQuote: (data) => {
-        const { nextNumber } = get()
-        const now = Date.now()
-        const id = generateId()
+        const { nextNumber } = get();
+        const now = Date.now();
+        const id = generateId();
 
         const items: QuoteItem[] = data.items.map((item, idx) => {
-          const unitPrice = 0 // will be populated from history sync
-          const qty = item.quantity
-          const discPct = item.discountPercent ?? 0
-          const lineTotal = qty * unitPrice
-          const discountedLineTotal = lineTotal * (1 - discPct / 100)
+          const unitPrice = 0; // will be populated from history sync
+          const qty = item.quantity;
+          const discPct = item.discountPercent ?? 0;
+          const lineTotal = qty * unitPrice;
+          const discountedLineTotal = lineTotal * (1 - discPct / 100);
           return {
             historyEntryId: item.historyEntryId,
             name: `Item #${idx + 1}`,
@@ -67,15 +68,15 @@ export const useQuoteStore = create<QuoteStore>()(
             unitPrice,
             totalPrice: discountedLineTotal,
             discountPercent: discPct,
-          }
-        })
+          };
+        });
 
         const { subtotal, discountAmount, total } = get().calculateTotals(
           items,
           data.globalDiscountPercent,
-        )
+        );
 
-        const customerSnapshot = undefined
+        const customerSnapshot = undefined;
 
         const quote: Quote = {
           id,
@@ -88,21 +89,21 @@ export const useQuoteStore = create<QuoteStore>()(
           subtotal,
           discountAmount,
           total,
-          status: 'draft',
+          status: "draft",
           validUntil: data.validUntil,
           paymentTerms: data.paymentTerms,
           deliveryEstimate: data.deliveryEstimate,
           footerNote: data.footerNote,
           createdAt: now,
           updatedAt: now,
-        }
+        };
 
         set((state) => ({
           quotes: [...state.quotes, quote],
           nextNumber: state.nextNumber + 1,
-        }))
+        }));
 
-        return id
+        return id;
       },
 
       updateQuote: (id, data) => {
@@ -110,7 +111,7 @@ export const useQuoteStore = create<QuoteStore>()(
           quotes: state.quotes.map((q) =>
             q.id === id ? { ...q, ...data, updatedAt: Date.now() } : q,
           ),
-        }))
+        }));
       },
 
       removeQuote: (id) =>
@@ -128,87 +129,90 @@ export const useQuoteStore = create<QuoteStore>()(
           quotes: state.quotes.map((q) =>
             q.id === id ? { ...q, status, updatedAt: Date.now() } : q,
           ),
-        }))
+        }));
       },
 
       setSearchQuery: (query) => set({ searchQuery: query }),
       setStatusFilter: (filter) => set({ statusFilter: filter }),
 
       getFilteredQuotes: () => {
-        const { quotes, searchQuery, statusFilter } = get()
-        let filtered = [...quotes]
+        const { quotes, searchQuery, statusFilter } = get();
+        let filtered = [...quotes];
 
-        if (statusFilter !== 'all') {
-          filtered = filtered.filter((q) => q.status === statusFilter)
+        if (statusFilter !== "all") {
+          filtered = filtered.filter((q) => q.status === statusFilter);
         }
 
         if (searchQuery) {
-          const q = searchQuery.toLowerCase()
+          const q = searchQuery.toLowerCase();
           filtered = filtered.filter(
             (entry) =>
               entry.title.toLowerCase().includes(q) ||
               (entry.customerSnapshot?.name &&
                 entry.customerSnapshot.name.toLowerCase().includes(q)),
-          )
+          );
         }
 
-        return filtered
+        return filtered;
       },
 
       exportQuotes: () => {
         return JSON.stringify(
           {
             quotes: get().quotes,
-            version: '1.0',
+            version: "1.0",
             exportedAt: new Date().toISOString(),
           },
           null,
           2,
-        )
+        );
       },
 
       importQuotes: (json) => {
         try {
-          const data = JSON.parse(json)
-          const incoming = Array.isArray(data.quotes) ? data.quotes : []
-          let imported = 0
-          let skipped = 0
+          const data = JSON.parse(json);
+          const incoming = Array.isArray(data.quotes) ? data.quotes : [];
+          let imported = 0;
+          let skipped = 0;
 
           set((state) => {
-            const existingIds = new Set(state.quotes.map((q) => q.id))
-            const newQuotes = incoming.flatMap((entry: unknown) => {
-              const e = entry as Partial<Quote>
-              if (
-                !e ||
-                typeof e !== 'object' ||
-                !e.id ||
-                typeof e.id !== 'string'
-              ) {
-                skipped++
-                return []
-              }
-              return [e as Quote]
-            }).filter((q: Quote) => {
-              if (existingIds.has(q.id)) {
-                skipped++
-                return false
-              }
-              existingIds.add(q.id)
-              imported++
-              return true
-            })
-            return { quotes: [...state.quotes, ...newQuotes] }
-          })
+            const existingIds = new Set(state.quotes.map((q) => q.id));
+            const newQuotes = incoming
+              .flatMap((entry: unknown) => {
+                const e = entry as Partial<Quote>;
+                if (
+                  !e ||
+                  typeof e !== "object" ||
+                  !e.id ||
+                  typeof e.id !== "string"
+                ) {
+                  skipped++;
+                  return [];
+                }
+                return [e as Quote];
+              })
+              .filter((q: Quote) => {
+                if (existingIds.has(q.id)) {
+                  skipped++;
+                  return false;
+                }
+                existingIds.add(q.id);
+                imported++;
+                return true;
+              });
+            return { quotes: [...state.quotes, ...newQuotes] };
+          });
 
-          return { imported, skipped }
+          return { imported, skipped };
         } catch {
-          return { imported: 0, skipped: 0 }
+          return { imported: 0, skipped: 0 };
         }
       },
     }),
     {
-      name: 'open3dcalc_quotes_v1',
+      name: "open3dcalc_quotes_v1",
       version: 1,
+      storage: manifestStorage(),
     },
   ),
-)
+);

--- a/src/shared/stores/storeBridge.ts
+++ b/src/shared/stores/storeBridge.ts
@@ -1,36 +1,41 @@
-import { useCalculatorStore } from '@/shared/stores/calculatorStore'
-import { useCatalogStore } from '@/shared/stores/catalogStore'
-import type { FilamentSpool } from '@/shared/stores/filamentInventory'
-import type { Product } from '@/shared/types'
-import type { PrinterProfile, Marketplace } from '@/shared/types'
+import { useCalculatorStore } from "@/shared/stores/calculatorStore";
+import { useCatalogStore } from "@/shared/stores/catalogStore";
+import type { FilamentSpool } from "@/shared/stores/filamentInventory";
+import type { Product } from "@/shared/types";
+import type { PrinterProfile, Marketplace } from "@/shared/types";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
 export function selectSpool(spool: FilamentSpool) {
-  const state = useCalculatorStore.getState()
+  const state = useCalculatorStore.getState();
   useCalculatorStore.getState().setFdmMaterial({
     ...state.fdmMaterial,
     type: spool.material,
     costPerKg: spool.costPerKg,
-  })
+  });
 }
 
-export function selectProduct(product: Pick<Product, 'name'>) {
-  useCalculatorStore.getState().setProductName(product.name)
+export function selectProduct(product: Pick<Product, "name">) {
+  useCalculatorStore.getState().setProductName(product.name);
 }
 
 export function restoreAutoSnapshot(): boolean {
-  if (typeof window === 'undefined') return false
+  if (typeof window === "undefined") return false;
   try {
-    const raw = localStorage.getItem('open3dcalc_settings_v2')
-    if (!raw) return false
-    const data = JSON.parse(raw)
-    const calc = useCalculatorStore.getState()
-    const catalogPrinters = useCatalogStore.getState().printers
-    const catalogMarketplaces = useCatalogStore.getState().marketplaces
-    const printer = catalogPrinters.find((p: { id: string }) => p.id === data.selectedPrinterId)
-    const marketplace = catalogMarketplaces.find((m: { id: string }) => m.id === data.selectedMarketplaceId)
+    const raw = guardedStorage.getItem("open3dcalc_settings_v2");
+    if (!raw) return false;
+    const data = JSON.parse(raw);
+    const calc = useCalculatorStore.getState();
+    const catalogPrinters = useCatalogStore.getState().printers;
+    const catalogMarketplaces = useCatalogStore.getState().marketplaces;
+    const printer = catalogPrinters.find(
+      (p: { id: string }) => p.id === data.selectedPrinterId,
+    );
+    const marketplace = catalogMarketplaces.find(
+      (m: { id: string }) => m.id === data.selectedMarketplaceId,
+    );
 
     useCalculatorStore.setState({
-      activeTab: data.activeTab || 'fdm',
+      activeTab: data.activeTab || "fdm",
       fdmMaterial: data.fdmMaterial || calc.fdmMaterial,
       fdmPrintParams: data.fdmPrintParams || calc.fdmPrintParams,
       fdmAmsEnabled: data.fdmAmsEnabled ?? false,
@@ -58,11 +63,13 @@ export function restoreAutoSnapshot(): boolean {
       infillPercent: data.infillPercent ?? calc.infillPercent,
       targetMarginMode: data.targetMarginMode ?? calc.targetMarginMode,
       enabledSections: data.enabledSections || calc.enabledSections,
-      selectedPrinter: (printer || catalogPrinters[0]) as unknown as PrinterProfile,
-      selectedMarketplace: (marketplace || catalogMarketplaces[0]) as unknown as Marketplace,
-    })
-    return true
+      selectedPrinter: (printer ||
+        catalogPrinters[0]) as unknown as PrinterProfile,
+      selectedMarketplace: (marketplace ||
+        catalogMarketplaces[0]) as unknown as Marketplace,
+    });
+    return true;
   } catch {
-    return false
+    return false;
   }
 }

--- a/src/shared/stores/tutorialStore.ts
+++ b/src/shared/stores/tutorialStore.ts
@@ -1,69 +1,72 @@
-import { create } from 'zustand'
+import { create } from "zustand";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
 
-const STORAGE_KEY = 'open3dcalc_tutorial_v1'
-const TOTAL_STEPS = 7
+const STORAGE_KEY = "open3dcalc_tutorial_v1";
+const TOTAL_STEPS = 7;
 
 interface PersistedTutorialData {
-  isCompleted: boolean
-  completedSteps: number[]
+  isCompleted: boolean;
+  completedSteps: number[];
 }
 
 interface TutorialState extends PersistedTutorialData {
-  isActive: boolean
-  currentStep: number
+  isActive: boolean;
+  currentStep: number;
   /** Dismissed for the current session (non-persistent) */
-  sessionDismissed: boolean
+  sessionDismissed: boolean;
 
-  startTutorial: () => void
-  nextStep: () => void
-  previousStep: () => void
-  goToStep: (step: number) => void
-  completeStep: (step: number) => void
-  finishTutorial: () => void
-  skipTutorial: () => void
-  dismissTutorial: () => void
-  resetTutorial: () => void
+  startTutorial: () => void;
+  nextStep: () => void;
+  previousStep: () => void;
+  goToStep: (step: number) => void;
+  completeStep: (step: number) => void;
+  finishTutorial: () => void;
+  skipTutorial: () => void;
+  dismissTutorial: () => void;
+  resetTutorial: () => void;
 }
 
 // --- persistence helpers (mirrors calculatorStore.helpers) ---
 
-let saveTimer: ReturnType<typeof setTimeout> | null = null
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
-function debouncedPersist(state: Pick<TutorialState, 'isCompleted' | 'completedSteps'>) {
-  if (saveTimer) clearTimeout(saveTimer)
+function debouncedPersist(
+  state: Pick<TutorialState, "isCompleted" | "completedSteps">,
+) {
+  if (saveTimer) clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {
-    localStorage.setItem(
+    guardedStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
         isCompleted: state.isCompleted,
         completedSteps: state.completedSteps,
       } satisfies PersistedTutorialData),
-    )
-  }, 800)
+    );
+  }, 800);
 }
 
 function loadPersistedData(): PersistedTutorialData {
-  if (typeof window === 'undefined') {
-    return { isCompleted: false, completedSteps: [] }
+  if (typeof window === "undefined") {
+    return { isCompleted: false, completedSteps: [] };
   }
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return { isCompleted: false, completedSteps: [] }
-    const parsed = JSON.parse(raw) as Partial<PersistedTutorialData>
+    const raw = guardedStorage.getItem(STORAGE_KEY);
+    if (!raw) return { isCompleted: false, completedSteps: [] };
+    const parsed = JSON.parse(raw) as Partial<PersistedTutorialData>;
     return {
       isCompleted: parsed.isCompleted ?? false,
       completedSteps: Array.isArray(parsed.completedSteps)
         ? parsed.completedSteps
         : [],
-    }
+    };
   } catch {
-    return { isCompleted: false, completedSteps: [] }
+    return { isCompleted: false, completedSteps: [] };
   }
 }
 
 // --- store ---
 
-const initialState: PersistedTutorialData = loadPersistedData()
+const initialState: PersistedTutorialData = loadPersistedData();
 
 export const useTutorialStore = create<TutorialState>((set, get) => ({
   // persisted state
@@ -78,58 +81,63 @@ export const useTutorialStore = create<TutorialState>((set, get) => ({
   // --- actions ---
 
   startTutorial: () => {
-    set({ isActive: true, currentStep: 1 })
+    set({ isActive: true, currentStep: 1 });
   },
 
   nextStep: () => {
-    const { currentStep } = get()
+    const { currentStep } = get();
     if (currentStep < TOTAL_STEPS) {
-      set({ currentStep: currentStep + 1 })
+      set({ currentStep: currentStep + 1 });
     }
   },
 
   previousStep: () => {
-    const { currentStep } = get()
+    const { currentStep } = get();
     if (currentStep > 1) {
-      set({ currentStep: currentStep - 1 })
+      set({ currentStep: currentStep - 1 });
     }
   },
 
   goToStep: (step: number) => {
-    const clamped = Math.max(1, Math.min(step, TOTAL_STEPS))
-    set({ currentStep: clamped })
+    const clamped = Math.max(1, Math.min(step, TOTAL_STEPS));
+    set({ currentStep: clamped });
   },
 
   completeStep: (step: number) => {
     set((state) => {
-      if (state.completedSteps.includes(step)) return state
-      const completedSteps = [...state.completedSteps, step].sort((a, b) => a - b)
-      debouncedPersist({ ...state, completedSteps })
-      return { completedSteps }
-    })
+      if (state.completedSteps.includes(step)) return state;
+      const completedSteps = [...state.completedSteps, step].sort(
+        (a, b) => a - b,
+      );
+      debouncedPersist({ ...state, completedSteps });
+      return { completedSteps };
+    });
   },
 
   finishTutorial: () => {
     set((state) => {
-      const isCompleted = true
-      debouncedPersist({ isCompleted, completedSteps: state.completedSteps })
-      return { isCompleted, isActive: false }
-    })
+      const isCompleted = true;
+      debouncedPersist({ isCompleted, completedSteps: state.completedSteps });
+      return { isCompleted, isActive: false };
+    });
   },
 
   skipTutorial: () => {
-    set({ isActive: false, currentStep: 1 })
+    set({ isActive: false, currentStep: 1 });
   },
 
   dismissTutorial: () => {
-    set({ isActive: false, sessionDismissed: true })
+    set({ isActive: false, sessionDismissed: true });
   },
 
   resetTutorial: () => {
-    const fresh: PersistedTutorialData = { isCompleted: false, completedSteps: [] }
-    set({ ...fresh, isActive: false, currentStep: 1, sessionDismissed: false })
-    localStorage.removeItem(STORAGE_KEY)
+    const fresh: PersistedTutorialData = {
+      isCompleted: false,
+      completedSteps: [],
+    };
+    set({ ...fresh, isActive: false, currentStep: 1, sessionDismissed: false });
+    guardedStorage.removeItem(STORAGE_KEY);
   },
-}))
+}));
 
-export const TUTORIAL_TOTAL_STEPS = TOTAL_STEPS
+export const TUTORIAL_TOTAL_STEPS = TOTAL_STEPS;


### PR DESCRIPTION
## D1.1 S1 — SPEC-01 manifest loader + gated storage

Implements slice **S1** of the D1 track (OWNERS-RUNBOOK §4): manifest loader + schema
validation wired into every storage writer, with default-deny on unknown keys.

### Declared scope (OWNERS-RUNBOOK §6)

- `src/shared/lib/dataManifest.ts` — SPEC-01 vocabularies, entry/document validation
  (TEST-MATRIX 1.2–1.11), loader with duplicate-key rejection, shipped-fixture loader,
  policy-version accessors, orphan-key enumeration.
- `src/shared/lib/manifestGate.ts` — fail-closed gate: unknown keys throw in dev and
  deny-safely in production; unreadable manifest denies everything; `isKeyAllowed`
  non-throwing variant for bulk paths; logs carry key NAMES only (TEST-MATRIX 3.2).
- `src/shared/lib/manifestStorage.ts` — `manifestStorage()` (zustand `PersistStorage`
  drop-in) and `guardedStorage` (localStorage-shaped facade). Deny is a real no-op;
  unavailable backing storage degrades to no-ops.
- Gate wiring: persist stores (consent, customer, history, product, quote) + all direct
  localStorage writers (calculator store/helpers, catalog, filaments, tutorial,
  storeBridge, web/desktop App, Dashboard, QuickStartBanner, OnboardingModal, useTheme,
  theme-persistence, dataSync); desktop persistence-bridge gates SQLite↔localStorage
  copies and skips unknown keys per key (never aborts the whole backup).
- Contract docs: **only** `SPEC-01-manifest-fixture.json` changed, with `policy_version`
  1.0 → 1.1 per runbook §6 (renamed `migration_flags`→`migration_done_v2`,
  `quickstart_done`→`quickstart_dismissed` to match shipped code; registered
  `open3dcalc_onboarded` and `i18nextLng`). Fixture schema-validated.
- `STATUS.md` updated (replaces stale D0 entry — D0 merged as #105).

### Contract tests (TEST-MATRIX)

- Rows 1.1–1.11 encoded in `dataManifest.test.ts`; deny-path rows in
  `manifestGate.test.ts`; storage wrapper rows in `manifestStorage.test.ts`.
- Coverage on the three contract modules: **94.6% / 91.9% / 96% lines** (≥80% bar §9.1).
- Full suite: **1,275 passed** across 92 files. Typecheck (app + Electron), lint, and
  desktop/web builds pass. Pre-push gate green.

### Defects found and fixed during the slice

- Production fail-open: the original wrappers discarded `checkKey`'s decision and wrote
  anyway on `{ allowed: false }`. Deny is now a real no-op, with regression tests.
- `guardedStorage` crashed when `window.localStorage` was unavailable; now shares the
  no-op fallback (SSR-safe).

### Rollback (OWNERS-RUNBOOK §7)

Revert = flag flip: stores return to direct-key behavior; the fixture remains a
read-only document. No data migration in S1.

⚠️ Themis gate applies before merge (final approval: repo owner).
