### PR TITLE
feat(privacy): D1.1 S4 — legacy plaintext quarantine + privacy screen (ADR-002)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,63 +1,65 @@
-# Deepwork D1.1 S3 — PII encryption on write paths + startup scan (ADR-002)
+# Deepwork D1.1 S4 — Legacy quarantine state + privacy screen + migrate/eliminate (ADR-002)
 
-- **Branch/worktree:** `feat/d1-s3-pii-encryption` / `../open3dcalc-d1-s3-pii`
+- **Branch/worktree:** `feat/d1-s4-quarantine` / `../open3dcalc-d1-s4-quarantine`
 - **Status:** implementation complete — local gates green; awaiting Themis review (PR next).
-- **Scope (OWNERS-RUNBOOK §6 declared):** ADR-002 §2.1 default-deny enforced at the
-  desktop storage write path (`db:save`/`db:load` gated per-key by the SPEC-01
-  manifest `pii` flag through the S2 capability layer), the ADR-002 §2.3 startup
-  legacy-plaintext scanner (same classifier the SPEC-02 saga will reuse), the
-  `privacy:scan-report` IPC, and the dataManifest/shippedManifest module split that
-  lets the main process consume the manifest without an ESM JSON import. Packaging
-  ships the fixture inside the asar. No contract documents modified (no policy bump).
-- **Base:** `main` @ `f6c8734` (includes PR #109 D1.1 S2).
+- **Scope (OWNERS-RUNBOOK §6 declared):** ADR-002 §2.2 legacy plaintext quarantine —
+  quarantine state derived from the §2.3 scan (a PII key holding legacy plaintext is
+  quarantined), read-only enforcement at the persistence gate, the two explicit exits
+  (migrate with verify-then-destroy + VACUUM scrub; eliminate with verified absence),
+  the quarantine/migrate/eliminate IPC surface, and the dedicated privacy screen
+  (new nav tab, pt-BR/en-US i18n) reachable in the app. No contract documents modified
+  (no policy bump): the state needs no new storage key — it is derived from the scan.
+- **Base:** `main` @ `26eb0d3` (includes PR #110 D1.1 S3).
 
 ## What landed in this slice
 
-- `electron/persistGate.ts` — the write-path choke point: unknown keys are denied
-  (SPEC-01 default-deny), non-PII keys pass through (plaintext_allowed only for
-  pii:false, schema-enforced), PII keys go through `encryptForStorage` and the write
-  is REFUSED when no ADR-001 capability exists (fail-closed, never downgraded).
-  Loads decrypt capability blobs; legacy plaintext stays READABLE
-  (ADR-002 §2.2.1) and is classified as `legacy_plaintext` for the S4 quarantine.
-- `electron/legacyScan.ts` — ADR-002 §2.3 startup scanner: classifies every storage
-  row against the manifest's expected encrypted form, counts the plaintext domain
-  tables (customers/quotes/quote_items), and produces a METADATA-ONLY report
-  (key names + counts, never values — TEST-MATRIX §3.2).
-- `electron/manifestSource.ts` — main-process manifest loader via fs with
-  dev/packaged/self-test candidate paths (fail-closed: unreadable fixture denies
-  every key).
-- `main.ts` — `db:save`/`db:load` now route through the gate; the scan runs at
-  startup (metadata-only summary logged) and on demand via `privacy:scan-report`;
-  `preload.cts` exposes `window.electronAPI.privacy.scanReport` (typed in
-  `electron.d.ts`).
-- `src/shared/lib/dataManifest.ts` / `shippedManifest.ts` split — pure validation
-  stays importable by the compiled main process (node16 ESM cannot execute a static
-  JSON import); the renderer keeps the same S1 API via `manifestGate`.
-- `package.json` (electron-builder `files`) — ships the SPEC-01 fixture inside the
-  asar so the packaged main process reads the same manifest file.
+- `electron/quarantine.ts` — state machine per ADR-002 §2.3:
+  `legacy_plaintext ⇒ QUARANTINED` (read-only, never auto-resolves);
+  MIGRATE encrypts through the ADR-001 capability, replaces the row, verifies the
+  encrypted copy reads back identical, and only then considers the plaintext
+  destroyed — with `VACUUM` scrubbing freed pages (physical destruction; WAL/SHM
+  handling is finalized by the SPEC-02 saga in S7). ELIMINATE deletes the quarantined
+  rows and verifies absence. Migration restores the plaintext row if verification
+  fails — data loss is impossible by construction. Deny-path platforms can only
+  eliminate (no capability ⇒ migration refused).
+- `electron/persistGate.ts` — §2.2.1 read-only enforcement: gated writes over a
+  quarantined key are refused (`quarantined_read_only`) until the user acts; writes
+  over encrypted or non-PII keys are unaffected.
+- IPC + preload + types: `privacy:quarantine-report`, `privacy:migrate-key`,
+  `privacy:eliminate-key` (all metadata-only in logs).
+- `PrivacyScreen` (`src/shared/components/Privacy/`) — new "Privacy" nav tab: lists
+  quarantined keys with record counts, offers migrate/eliminate with confirmations,
+  shows per-action results, never renders quarantined VALUES (metadata only), and
+  degrades to a desktop-only notice on web. i18n keys in pt-BR + en-US
+  (TEST-MATRIX §9.2).
 
 ## Verified by the real-Electron self-test (no mocks, real SQLite file)
 
-- Gated PII write lands as ciphertext (`enc1:*` prefix); gated load round-trips.
-- Unknown keys are refused and never written; non-PII passes through as plaintext.
-- Deliberately planted legacy plaintext row: readable through the gate, flagged by
-  the scanner (`legacyCount`/key names in report), and the DB-file byte scan shows
-  the synthetic marker ONLY in that planted row — every gated write stayed
-  ciphertext.
+- Quarantined key detected (with record count); gated write over it REFUSED.
+- MIGRATE: row becomes ciphertext, reads back verified, plaintext physically gone.
+- ELIMINATE: second planted legacy key deleted, absence verified.
+- After both exits the quarantine report is empty and the DB-file byte scan finds
+  ZERO occurrences of the synthetic PII marker (S3 left exactly the planted rows;
+  S4's explicit flows destroyed them).
 
-## S4 boundary
+## S5+ boundary
 
-Renderer localStorage keeps working as today (plaintext working cache); its
-encrypted-at-rest wiring plus the quarantine state machine (read-only enforcement,
-sync/export exclusions, privacy screen, passphrase UX, migrate/eliminate flows) is
-S4. Domain tables have no runtime writers today; the scan counts their rows so any
-future writer is automatically covered.
+Sync/export exclusion of quarantined data becomes enforceable where those flows are
+reclassified: SPEC-03 envelope replaces the legacy bundle in S5 (quarantined
+localStorage data never reaches it — the legacy bundle keeps its own S7-era
+treatment), and ADR-003 gates the raw `db:export` in S6. The SPEC-02 saga (S7)
+absorbs the per-key elimination performed here into the resumable cross-surface
+flow with receipts.
 
 ## Verification
 
-- 1,319 tests across 96 files; typecheck (app + Electron), lint, desktop/web builds.
-- Coverage on the S3 contract modules: 88.3% lines / 84.1% branches.
-- Rollback (OWNERS-RUNBOOK §7): revert — no data migration happened; values written
-  encrypted under this slice remain readable only via the gate (decrypt path kept).
+- 1,332 tests across 101 files; typecheck (app + Electron), lint, desktop/web
+  builds, pre-push gate — all green.
+- Coverage on the S4 contract modules: 87.9% lines / 84.6% branches.
+- Rollback (OWNERS-RUNBOOK §7): revert — the screen disappears and the gate stops
+  refusing quarantined writes; no data migration happens without explicit user
+  action, so nothing needs reversing.
 
-**D1.1 S3 is pending Themis review. S4 (quarantine + privacy screen) is next.**
+**D1.1 S4 is pending Themis review. S5 (export envelope v1.1) and S6 (db:export
+reclassification) can proceed in parallel; S7 (erasure saga) depends on S1+S2 and
+absorbs S4's elimination into the full saga.**

--- a/electron/__tests__/crypto.selftest.test.ts
+++ b/electron/__tests__/crypto.selftest.test.ts
@@ -58,6 +58,14 @@ interface SelftestReport {
     scanLegacyCount?: number;
     scanEncryptedCount?: number;
   };
+  s4?: {
+    quarantinedDetected?: boolean;
+    quarantinedWriteRefused?: boolean;
+    legacyMigrated?: boolean;
+    migrationVerified?: boolean;
+    legacyEliminated?: boolean;
+    quarantineCleared?: boolean;
+  };
   error?: string;
 }
 
@@ -189,8 +197,17 @@ describe("crypto self-test (real Electron, real SQLite)", () => {
     expect(report.s3?.legacyFlaggedByScan).toBe(true);
     expect(report.s3?.scanEncryptedCount ?? 0).toBeGreaterThanOrEqual(1);
 
-    // §3.1-style byte scan: the marker appears ONLY in the deliberately
-    // planted legacy row — every gated write stayed ciphertext.
-    expect(report.plaintextHitsInDbFile).toBe(1);
+    // S4 — quarantine (ADR-002 §2.2): detected, read-only, and resolved
+    // ONLY through the explicit migrate/eliminate exits.
+    expect(report.s4?.quarantinedDetected).toBe(true);
+    expect(report.s4?.quarantinedWriteRefused).toBe(true);
+    expect(report.s4?.legacyMigrated).toBe(true);
+    expect(report.s4?.migrationVerified).toBe(true);
+    expect(report.s4?.legacyEliminated).toBe(true);
+    expect(report.s4?.quarantineCleared).toBe(true);
+
+    // §3.1-style byte scan: after migration (plaintext destroyed) and
+    // elimination (rows deleted), ZERO marker hits remain in the file.
+    expect(report.plaintextHitsInDbFile).toBe(0);
   }, 180_000);
 });

--- a/electron/__tests__/quarantine.test.ts
+++ b/electron/__tests__/quarantine.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the legacy plaintext quarantine (D1.1 S4 — ADR-002 §2.2).
+ * The `electron` module is mocked to drive the capability rows; the real
+ * end-to-end flows are covered by crypto.selftest.test.ts (real Electron,
+ * real SQLite file, no mocks).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  mockSafeStorage: {
+    isEncryptionAvailable: vi.fn<[], boolean>(() => true),
+    encryptString: vi.fn<[], Buffer>(),
+    decryptString: vi.fn<[], string>(),
+  },
+}));
+
+vi.mock("electron", () => ({ safeStorage: hoisted.mockSafeStorage }));
+
+import {
+  buildQuarantineReport,
+  migrateKey,
+  eliminateKey,
+  readStoredRow,
+} from "../quarantine.js";
+import { saveGated } from "../persistGate.js";
+import { CryptoDeniedError } from "../cryptoCapability.js";
+import {
+  setSessionPassphrase,
+  zeroizeSessionPassphrase,
+} from "../../src/shared/lib/crypto/passphraseSession.js";
+
+const PII_KEY = "open3dcalc_customers_v1";
+const LEGACY_KEY = "open3dcalc_quotes_v1";
+const NON_PII_KEY = "open3dcalc_settings_v2";
+const MARKER = "Fernanda Sintética <fernanda@exemplo.teste>";
+
+function makeDb(initial: Array<[string, string]> = []) {
+  const rows = new Map<string, string>(initial);
+  const db = {
+    prepare(sql: string) {
+      return {
+        get(...params: unknown[]) {
+          if (sql.startsWith("SELECT value")) {
+            const key = params[0] as string;
+            return rows.has(key) ? { value: rows.get(key) } : undefined;
+          }
+          if (sql.startsWith("SELECT key, value")) {
+            throw new Error("use .all()");
+          }
+          return undefined;
+        },
+        run(...params: unknown[]) {
+          if (sql.startsWith("INSERT INTO storage")) {
+            rows.set(params[0] as string, params[1] as string);
+          } else if (sql.startsWith("DELETE FROM storage")) {
+            rows.delete(params[0] as string);
+          }
+          return undefined;
+        },
+      };
+    },
+    all() {
+      return Array.from(rows, ([key, value]) => ({ key, value }));
+    },
+    rows,
+  };
+  return db;
+}
+
+// The quarantine report reads all rows via `prepare(...).all()`; adapt the
+// MinimalStorageDb shape used by the real better-sqlite3 client.
+function withAll(db: ReturnType<typeof makeDb>) {
+  return {
+    prepare(sql: string) {
+      const inner = db.prepare(sql);
+      return {
+        get: inner.get,
+        run: inner.run,
+        all: () => db.all(),
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  zeroizeSessionPassphrase();
+  vi.clearAllMocks();
+  hoisted.mockSafeStorage.isEncryptionAvailable.mockReturnValue(true);
+  hoisted.mockSafeStorage.encryptString.mockImplementation((s: string) =>
+    Buffer.from(`safe:${s}`, "utf8"),
+  );
+  hoisted.mockSafeStorage.decryptString.mockImplementation((b: Buffer) =>
+    Buffer.from(b).toString("utf8").slice(5),
+  );
+});
+
+describe("buildQuarantineReport (state derived from the scan)", () => {
+  it("flags legacy plaintext PII as quarantined with record counts", () => {
+    const db = makeDb([
+      [LEGACY_KEY, `[{"name":"${MARKER}"}]`],
+      [PII_KEY, "enc1:envelope:{...}"],
+      [NON_PII_KEY, "{}"],
+    ]);
+    const report = buildQuarantineReport(withAll(db));
+    expect(report.quarantinedKeys).toEqual([LEGACY_KEY]);
+    const legacy = report.entries.find((e) => e.key === LEGACY_KEY);
+    expect(legacy?.status).toBe("quarantined");
+    expect(legacy?.recordCount).toBe(1);
+    expect(report.entries.find((e) => e.key === PII_KEY)?.status).toBe(
+      "encrypted",
+    );
+    expect(report.entries.find((e) => e.key === NON_PII_KEY)?.status).toBe(
+      "non_pii",
+    );
+  });
+});
+
+describe("read-only quarantine (ADR-002 §2.2.1)", () => {
+  it("refuses gated writes over a quarantined key and keeps the row", async () => {
+    const original = `[{"name":"${MARKER}"}]`;
+    const db = makeDb([[LEGACY_KEY, original]]);
+    await expect(saveGated(withAll(db), LEGACY_KEY, "{}")).rejects.toThrow(
+      /quarantined_read_only/,
+    );
+    expect(readStoredRow(withAll(db), LEGACY_KEY)).toBe(original);
+  });
+
+  it("does not refuse writes over already-encrypted or non-PII keys", async () => {
+    const db = makeDb([
+      [PII_KEY, "enc1:envelope:{...}"],
+      [NON_PII_KEY, "{}"],
+    ]);
+    await expect(
+      saveGated(withAll(db), PII_KEY, '{"n":1}'),
+    ).resolves.toBeUndefined();
+    await expect(
+      saveGated(withAll(db), NON_PII_KEY, '{"n":2}'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("migrateKey (ADR-002 §2.2.3 — verify then destroy)", () => {
+  it("encrypts, verifies the round-trip and destroys the plaintext", async () => {
+    setSessionPassphrase("sessão-sintética-3131");
+    hoisted.mockSafeStorage.isEncryptionAvailable.mockReturnValue(false);
+    const db = makeDb([[LEGACY_KEY, MARKER]]);
+    const result = await migrateKey(withAll(db), LEGACY_KEY);
+    expect(result).toEqual({ key: LEGACY_KEY, migrated: true, verified: true });
+    const stored = readStoredRow(withAll(db), LEGACY_KEY) ?? "";
+    expect(stored.startsWith("enc1:")).toBe(true);
+    expect(stored).not.toContain(MARKER);
+    // Post-migration: writes over the encrypted key are allowed again.
+    await expect(
+      saveGated(withAll(db), LEGACY_KEY, '{"n":2}'),
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses migration without a capability (deny-path ⇒ eliminate only)", async () => {
+    hoisted.mockSafeStorage.isEncryptionAvailable.mockReturnValue(false);
+    const db = makeDb([[LEGACY_KEY, MARKER]]);
+    await expect(migrateKey(withAll(db), LEGACY_KEY)).rejects.toThrow(
+      /no_capability/,
+    );
+    expect(readStoredRow(withAll(db), LEGACY_KEY)).toBe(MARKER);
+  });
+
+  it("is a no-op for already-encrypted keys and refuses unknown/non-PII", async () => {
+    setSessionPassphrase("sessão-sintética-3131");
+    const db = makeDb([
+      [PII_KEY, "enc1:envelope:{...}"],
+      [NON_PII_KEY, "{}"],
+    ]);
+    expect(await migrateKey(withAll(db), PII_KEY)).toMatchObject({
+      migrated: false,
+      alreadyEncrypted: true,
+    });
+    await expect(migrateKey(withAll(db), "open3dcalc_rogue")).rejects.toThrow(
+      /unknown_key/,
+    );
+    await expect(migrateKey(withAll(db), NON_PII_KEY)).rejects.toThrow(
+      /not_pii/,
+    );
+  });
+});
+
+describe("eliminateKey (ADR-002 §2.2.3)", () => {
+  it("deletes the quarantined row and verifies absence", () => {
+    setSessionPassphrase("sessão-sintética-3131");
+    const db = makeDb([[LEGACY_KEY, MARKER]]);
+    expect(eliminateKey(withAll(db), LEGACY_KEY)).toEqual({
+      key: LEGACY_KEY,
+      eliminated: true,
+    });
+    expect(readStoredRow(withAll(db), LEGACY_KEY)).toBeNull();
+  });
+
+  it("refuses unknown and non-PII keys", () => {
+    const db = makeDb([[NON_PII_KEY, "{}"]]);
+    expect(() => eliminateKey(withAll(db), "open3dcalc_rogue")).toThrow(
+      /unknown_key/,
+    );
+    expect(() => eliminateKey(withAll(db), NON_PII_KEY)).toThrow(/not_pii/);
+  });
+});

--- a/electron/__tests__/quarantine.test.ts
+++ b/electron/__tests__/quarantine.test.ts
@@ -26,7 +26,6 @@ import {
   readStoredRow,
 } from "../quarantine.js";
 import { saveGated } from "../persistGate.js";
-import { CryptoDeniedError } from "../cryptoCapability.js";
 import {
   setSessionPassphrase,
   zeroizeSessionPassphrase,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,11 @@ import {
 } from "./cryptoCapability.js";
 import { saveGated, loadGated } from "./persistGate.js";
 import { buildScanReport, summarizeReport } from "./legacyScan.js";
+import {
+  buildQuarantineReport,
+  migrateKey,
+  eliminateKey,
+} from "./quarantine.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -579,6 +584,57 @@ function setupIpcHandlers(): void {
       return runPrivacyScan();
     } catch (error) {
       console.error("[privacy:scan-report] Error:", error);
+      throw error;
+    }
+  });
+
+  // ── privacy:quarantine-report (D1.1 S4 — ADR-002 §2.2) ──────────────
+  // Quarantine state derived from the scan: PII keys holding legacy
+  // plaintext are quarantined (read-only) until migrate/eliminate.
+  ipcMain.handle("privacy:quarantine-report", (event) => {
+    try {
+      assertTrustedSender(event);
+      return buildQuarantineReport(db.$client);
+    } catch (error) {
+      console.error("[privacy:quarantine-report] Error:", error);
+      throw error;
+    }
+  });
+
+  // ── privacy:migrate-key (ADR-002 §2.2.3) ────────────────────────────
+  // Encrypt the quarantined plaintext with the ADR-001 capability, verify
+  // the encrypted copy reads back, then consider the plaintext destroyed.
+  ipcMain.handle("privacy:migrate-key", async (event, key: string) => {
+    try {
+      assertTrustedSender(event);
+      if (typeof key !== "string" || key.trim().length === 0) {
+        throw new Error("Key must be a non-empty string");
+      }
+      const result = await migrateKey(db.$client, key);
+      console.log(
+        `[privacy] migrated key "${key}" (verified=${result.verified})`,
+      );
+      return result;
+    } catch (error) {
+      console.error("[privacy:migrate-key] Error:", error);
+      throw error;
+    }
+  });
+
+  // ── privacy:eliminate-key (ADR-002 §2.2.3) ──────────────────────────
+  // Delete the quarantined rows for a PII key (SPEC-02 saga in S7
+  // formalizes the cross-surface erasure with receipts).
+  ipcMain.handle("privacy:eliminate-key", async (event, key: string) => {
+    try {
+      assertTrustedSender(event);
+      if (typeof key !== "string" || key.trim().length === 0) {
+        throw new Error("Key must be a non-empty string");
+      }
+      const result = eliminateKey(db.$client, key);
+      console.log(`[privacy] eliminated key "${key}"`);
+      return result;
+    } catch (error) {
+      console.error("[privacy:eliminate-key] Error:", error);
       throw error;
     }
   });

--- a/electron/persistGate.ts
+++ b/electron/persistGate.ts
@@ -121,14 +121,37 @@ export interface MinimalStorageDb {
   prepare(sql: string): {
     get(...params: unknown[]): unknown;
     run(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
   };
+  /** Optional for callers like the real better-sqlite3 client (VACUUM etc.). */
+  exec?(sql: string): void;
 }
 
 const STORAGE_COLUMNS = "value FROM storage WHERE key = ?";
 
+export function writeStoredRow(
+  db: MinimalStorageDb,
+  key: string,
+  value: string,
+): void {
+  db.prepare(
+    "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+  ).run(key, value, Date.now());
+}
+
+function readStoredRow(db: MinimalStorageDb, key: string): string | null {
+  const row = db.prepare(`SELECT ${STORAGE_COLUMNS}`).get(key) as
+    { value: string } | undefined;
+  return row ? row.value : null;
+}
+
 /**
  * Gate and write a key/value pair into the storage table.
  * Throws on denial (fail-closed refusal — ADR-002 §2.1) and on SQL errors.
+ * S4 (ADR-002 §2.2.1): a PII key holding legacy plaintext is QUARANTINED —
+ * writes to it are refused (read-only) until the user migrates or
+ * eliminates it via the privacy screen. Non-PII and encrypted states are
+ * unaffected.
  */
 export async function saveGated(
   db: MinimalStorageDb,
@@ -139,9 +162,13 @@ export async function saveGated(
   if (outcome.action === "denied") {
     throw new CryptoDeniedError(outcome.reason);
   }
-  db.prepare(
-    "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
-  ).run(key, outcome.value, Date.now());
+  if (outcome.action === "encrypted") {
+    const current = readStoredRow(db, key);
+    if (current !== null && !current.startsWith("enc1:")) {
+      throw new CryptoDeniedError("quarantined_read_only");
+    }
+  }
+  writeStoredRow(db, key, outcome.value);
 }
 
 /**

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -172,6 +172,37 @@ const electronAPI = {
       domainTables: { customers: number; quotes: number; quote_items: number };
       manifestAvailable: boolean;
     }> => ipcRenderer.invoke("privacy:scan-report"),
+
+    /**
+     * ADR-002 §2.2 quarantine report: PII keys holding legacy plaintext
+     * (quarantined, read-only) and their record counts.
+     */
+    quarantineReport: (): Promise<{
+      scannedAt: string;
+      entries: Array<{
+        key: string;
+        status: string;
+        recordCount?: number;
+      }>;
+      quarantinedKeys: string[];
+    }> => ipcRenderer.invoke("privacy:quarantine-report"),
+
+    /**
+     * ADR-002 §2.2.3 migrate: encrypt the quarantined plaintext with the
+     * ADR-001 capability and verify before the plaintext is destroyed.
+     */
+    migrateKey: (
+      key: string,
+    ): Promise<{ key: string; migrated: boolean; verified: boolean }> =>
+      ipcRenderer.invoke("privacy:migrate-key", key),
+
+    /**
+     * ADR-002 §2.2.3 eliminate: delete the quarantined rows for a PII key.
+     */
+    eliminateKey: (
+      key: string,
+    ): Promise<{ key: string; eliminated: boolean }> =>
+      ipcRenderer.invoke("privacy:eliminate-key", key),
   },
 } as const;
 

--- a/electron/quarantine.ts
+++ b/electron/quarantine.ts
@@ -1,0 +1,195 @@
+/**
+ * Legacy plaintext quarantine (D1.1 S4) — ADR-002 §2.2/§2.3.
+ *
+ * The quarantine STATE is derived from the ADR-002 §2.3 startup scan — a
+ * PII key whose stored value is legacy plaintext is QUARANTINED: readable,
+ * excluded from new writes (the persistence gate refuses them), and surfaced
+ * in the privacy screen. It never auto-resolves; the only exits are the
+ * explicit user actions below:
+ *
+ *  - MIGRATE: encrypt the plaintext through the ADR-001 capability layer,
+ *    replace the row, verify the encrypted copy reads back byte-identical,
+ *    and only then is the plaintext copy considered destroyed. Requires a
+ *    capability — on deny-path platforms the only exit is elimination.
+ *  - ELIMINATE: delete the quarantined rows (per-key; the SPEC-02 saga with
+ *    journal/receipts formalizes this in S7).
+ *
+ * All operations are metadata-only in logs (key NAMES, never values).
+ */
+
+import { loadManifestFromDisk } from "./manifestSource.js";
+import { isKnownKey, getEntry } from "../src/shared/lib/dataManifest.js";
+import {
+  CryptoDeniedError,
+  encryptForStorage,
+  getCapability,
+} from "./cryptoCapability.js";
+import {
+  gateLoad,
+  writeStoredRow,
+  type MinimalStorageDb,
+} from "./persistGate.js";
+
+const ENCRYPTED_PREFIX = "enc1:";
+
+export type QuarantineStatus =
+  "quarantined" | "encrypted" | "absent" | "non_pii" | "unknown_key";
+
+export interface QuarantineEntry {
+  key: string;
+  status: QuarantineStatus;
+  /** Record count when the stored value is a JSON array (display only). */
+  recordCount?: number;
+}
+
+export interface QuarantineReport {
+  scannedAt: string;
+  entries: QuarantineEntry[];
+  quarantinedKeys: string[];
+}
+
+export function readStoredRow(
+  db: MinimalStorageDb,
+  key: string,
+): string | null {
+  const row = db.prepare("SELECT value FROM storage WHERE key = ?").get(key) as
+    { value: string } | undefined;
+  return row ? row.value : null;
+}
+
+function countRecords(value: string): number | undefined {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (Array.isArray(parsed)) return parsed.length;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Derive the quarantine report from the live storage table. */
+export function buildQuarantineReport(db: MinimalStorageDb): QuarantineReport {
+  const rows = db.prepare("SELECT key, value FROM storage").all() as Array<{
+    key: string;
+    value: string;
+  }>;
+  let manifest: ReturnType<typeof loadManifestFromDisk>;
+  try {
+    manifest = loadManifestFromDisk();
+  } catch {
+    // Fail-closed: unreadable manifest ⇒ nothing can be trusted as encrypted.
+    return {
+      scannedAt: new Date().toISOString(),
+      entries: rows.map((r) => ({
+        key: r.key,
+        status: "quarantined" as QuarantineStatus,
+        recordCount: countRecords(r.value),
+      })),
+      quarantinedKeys: rows.map((r) => r.key),
+    };
+  }
+  const entries: QuarantineEntry[] = rows.map((r) => {
+    if (!isKnownKey(manifest, r.key)) {
+      return { key: r.key, status: "unknown_key" };
+    }
+    const entry = getEntry(manifest, r.key);
+    if (!entry?.pii) return { key: r.key, status: "non_pii" };
+    if (r.value.startsWith(ENCRYPTED_PREFIX)) {
+      return { key: r.key, status: "encrypted" };
+    }
+    return {
+      key: r.key,
+      status: "quarantined",
+      recordCount: countRecords(r.value),
+    };
+  });
+  return {
+    scannedAt: new Date().toISOString(),
+    entries,
+    quarantinedKeys: entries
+      .filter((e) => e.status === "quarantined")
+      .map((e) => e.key)
+      .sort(),
+  };
+}
+
+export interface MigrateResult {
+  key: string;
+  migrated: boolean;
+  verified: boolean;
+  alreadyEncrypted?: boolean;
+}
+
+/**
+ * ADR-002 §2.2.3 MIGRATE: encrypt the quarantined plaintext with the
+ * ADR-001 capability, replace the row, and verify the encrypted copy reads
+ * back identical BEFORE considering the plaintext destroyed. Atomic per
+ * key: on verification failure the plaintext row is restored.
+ */
+export async function migrateKey(
+  db: MinimalStorageDb,
+  key: string,
+): Promise<MigrateResult> {
+  const manifest = loadManifestFromDisk();
+  if (!isKnownKey(manifest, key)) {
+    throw new CryptoDeniedError("unknown_key");
+  }
+  const entry = getEntry(manifest, key);
+  if (!entry?.pii) throw new CryptoDeniedError("not_pii");
+
+  const stored = readStoredRow(db, key);
+  if (stored === null) throw new CryptoDeniedError("nothing_to_migrate");
+  if (stored.startsWith(ENCRYPTED_PREFIX)) {
+    return { key, migrated: false, verified: true, alreadyEncrypted: true };
+  }
+  if (getCapability().piiPersistence !== "encrypted_at_rest") {
+    // Deny-path platform: migration impossible, elimination is the exit.
+    throw new CryptoDeniedError("no_capability");
+  }
+
+  const plaintext = stored;
+  const blob = await encryptForStorage(key, plaintext);
+  writeStoredRow(db, key, blob);
+
+  // Verify the encrypted copy reads back identical before declaring the
+  // plaintext destroyed (ADR-002 §2.2.3).
+  const loaded = await gateLoad(key, readStoredRow(db, key) ?? "");
+  if (loaded.action !== "decrypted" || loaded.value !== plaintext) {
+    // Restore the plaintext row — never lose data to a failed migration.
+    writeStoredRow(db, key, plaintext);
+    throw new CryptoDeniedError("migration_verification_failed");
+  }
+  // §2.2.3: physically scrub the freed pages so the plaintext copy is
+  // destroyed, not just logically replaced. (WAL/SHM handling is finalized
+  // by the SPEC-02 saga in S7.)
+  db.exec?.("VACUUM");
+  return { key, migrated: true, verified: true };
+}
+
+export interface EliminateResult {
+  key: string;
+  eliminated: boolean;
+}
+
+/**
+ * ADR-002 §2.2.3 ELIMINATE: delete the quarantined rows for a PII key and
+ * verify absence. (The SPEC-02 saga with journal, snapshots and receipts
+ * formalizes the cross-surface erasure in S7.)
+ */
+export function eliminateKey(
+  db: MinimalStorageDb,
+  key: string,
+): EliminateResult {
+  const manifest = loadManifestFromDisk();
+  if (!isKnownKey(manifest, key)) {
+    throw new CryptoDeniedError("unknown_key");
+  }
+  const entry = getEntry(manifest, key);
+  if (!entry?.pii) throw new CryptoDeniedError("not_pii");
+  db.prepare("DELETE FROM storage WHERE key = ?").run(key);
+  const eliminated = readStoredRow(db, key) === null;
+  if (!eliminated) throw new CryptoDeniedError("elimination_failed");
+  // Physically scrub the freed pages (same rationale as migrateKey).
+  db.exec?.("VACUUM");
+  return { key, eliminated: true };
+}

--- a/electron/selftest/crypto-selftest.ts
+++ b/electron/selftest/crypto-selftest.ts
@@ -35,6 +35,11 @@ import {
 } from "../cryptoCapability.js";
 import { saveGated, loadGated, gateLoad } from "../persistGate.js";
 import { buildScanReport } from "../legacyScan.js";
+import {
+  buildQuarantineReport,
+  migrateKey,
+  eliminateKey,
+} from "../quarantine.js";
 
 const MARKER = "Fernanda Sintética <fernanda@exemplo.teste>";
 const PII_KEY = "open3dcalc_customers_v1";
@@ -61,6 +66,15 @@ interface S3Report {
   scanEncryptedCount: number;
 }
 
+interface S4Report {
+  quarantinedDetected: boolean;
+  quarantinedWriteRefused: boolean;
+  legacyMigrated: boolean;
+  migrationVerified: boolean;
+  legacyEliminated: boolean;
+  quarantineCleared: boolean;
+}
+
 interface SelftestReport {
   capability: ReturnType<typeof getCapability>;
   safeStorageProbe: boolean;
@@ -68,6 +82,7 @@ interface SelftestReport {
   scenarios: ScenarioReport[];
   plaintextHitsInDbFile: number;
   s3?: S3Report;
+  s4?: S4Report;
   error?: string;
 }
 
@@ -176,8 +191,10 @@ async function runSelftest(): Promise<SelftestReport> {
     scanEncryptedCount: 0,
   };
 
-  // §2.2 setup: plant pre-D1.1 plaintext PII exactly as legacy users have.
-  insertRaw.run(LEGACY_KEY, MARKER, Date.now() - 1000);
+  // §2.2 setup: plant pre-D1.1 plaintext PII exactly as legacy users have
+  // (a JSON array of records, the shape the stores persist).
+  const LEGACY_PLAINTEXT = JSON.stringify([{ name: MARKER }]);
+  insertRaw.run(LEGACY_KEY, LEGACY_PLAINTEXT, Date.now() - 1000);
 
   // §2.1: gated write of a PII key goes through the capability layer.
   await saveGated(db, PII_KEY, MARKER);
@@ -188,7 +205,7 @@ async function runSelftest(): Promise<SelftestReport> {
   s3.gateRoundTrip = (await loadGated(db, PII_KEY)) === MARKER;
 
   // §2.2: legacy plaintext PII stays readable through the gate...
-  s3.legacyReadable = (await loadGated(db, LEGACY_KEY)) === MARKER;
+  s3.legacyReadable = (await loadGated(db, LEGACY_KEY)) === LEGACY_PLAINTEXT;
   const legacyOutcome = await gateLoad(
     LEGACY_KEY,
     readRow(db, LEGACY_KEY) ?? "",
@@ -226,7 +243,73 @@ async function runSelftest(): Promise<SelftestReport> {
   );
   report.s3 = s3;
 
-  // §3.1-style byte scan: the marker appears ONLY in the planted legacy row.
+  // ------------------------------------------------------------------
+  // S4 — quarantine state + migrate/eliminate flows (ADR-002 §2.2)
+  // ------------------------------------------------------------------
+  const s4: S4Report = {
+    quarantinedDetected: false,
+    quarantinedWriteRefused: false,
+    legacyMigrated: false,
+    migrationVerified: false,
+    legacyEliminated: false,
+    quarantineCleared: false,
+  };
+
+  // §2.2: the quarantined key shows in the report...
+  let qReport = buildQuarantineReport(db);
+  s4.quarantinedDetected =
+    qReport.quarantinedKeys.includes(LEGACY_KEY) &&
+    (qReport.entries.find((e) => e.key === LEGACY_KEY)?.recordCount ?? 0) >= 1;
+
+  // §2.2.1: gated writes over the quarantined key are refused (read-only).
+  try {
+    await saveGated(db, LEGACY_KEY, '{"n":9}');
+    s4.quarantinedWriteRefused = false;
+  } catch (error) {
+    s4.quarantinedWriteRefused =
+      error instanceof CryptoDeniedError &&
+      error.message.includes("quarantined_read_only");
+  }
+
+  // §2.2.3 MIGRATE: encrypt, verify, plaintext destroyed.
+  const migrated = await migrateKey(db, LEGACY_KEY);
+  s4.legacyMigrated = migrated.migrated && migrated.verified;
+  s4.migrationVerified = readRow(db, LEGACY_KEY)?.startsWith("enc1:") === true;
+  const afterMigration = await gateLoad(
+    LEGACY_KEY,
+    readRow(db, LEGACY_KEY) ?? "",
+  );
+  s4.migrationVerified =
+    s4.migrationVerified && afterMigration.action === "decrypted";
+
+  // §2.2.3 ELIMINATE: plant another legacy key, then eliminate it.
+  const HISTORY_KEY = "open3dcalc_history_v2";
+  insertRaw.run(HISTORY_KEY, MARKER, Date.now());
+  qReport = buildQuarantineReport(db);
+  const historyQuarantined = qReport.quarantinedKeys.includes(HISTORY_KEY);
+  try {
+    await saveGated(db, HISTORY_KEY, "{}");
+    s4.quarantinedWriteRefused = false;
+  } catch (error) {
+    s4.quarantinedWriteRefused =
+      s4.quarantinedWriteRefused &&
+      error instanceof CryptoDeniedError &&
+      error.message.includes("quarantined_read_only");
+  }
+  const eliminated = eliminateKey(db, HISTORY_KEY);
+  s4.legacyEliminated =
+    eliminated.eliminated &&
+    historyQuarantined &&
+    readRow(db, HISTORY_KEY) === null;
+
+  // §2.2.5: after both explicit exits, quarantine is empty — never
+  // auto-resolved, only by the user actions above.
+  qReport = buildQuarantineReport(db);
+  s4.quarantineCleared = qReport.quarantinedKeys.length === 0;
+  report.s4 = s4;
+
+  // §3.1-style byte scan: after migrate (plaintext destroyed) and eliminate
+  // (rows deleted), the synthetic marker must have ZERO hits in the file.
   report.plaintextHitsInDbFile = countMarkerHits(readFileSync(dbPath));
 
   db.close();

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -27,6 +27,7 @@
     "../db/**/*.ts",
     "persistGate.ts",
     "legacyScan.ts",
+    "quarantine.ts",
     "manifestSource.ts",
     "../src/shared/lib/dataManifest.ts"
   ],

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/ils15/open3dcalc/node_modules

--- a/src/platform/desktop/App.tsx
+++ b/src/platform/desktop/App.tsx
@@ -10,6 +10,7 @@ import { InfillCalculator } from "@/shared/components/Calculator/InfillCalculato
 import { FilamentInventory } from "@/shared/components/Catalog/FilamentInventory";
 import { CustomerTab } from "@/shared/components/Catalog/CustomerTab";
 import { ProductInventory } from "@/shared/components/Catalog/ProductInventory";
+import { PrivacyScreen } from "@/shared/components/Privacy/PrivacyScreen";
 import { QuoteSection } from "@/shared/components/Calculator/QuoteSection";
 import { restoreAutoSnapshot } from "@/shared/stores/storeBridge";
 import { guardedStorage } from "@/shared/lib/manifestStorage";
@@ -37,6 +38,7 @@ import {
   FileText,
   Users,
   Package,
+  ShieldCheck,
 } from "lucide-react";
 
 type Tab =
@@ -49,7 +51,8 @@ type Tab =
   | "changelog"
   | "quotes"
   | "customers"
-  | "products";
+  | "products"
+  | "privacy";
 type LegacyProduct = {
   name?: string;
   result?: CalculationResult;
@@ -131,6 +134,12 @@ const TABS: {
     icon: <Package className="w-[18px] h-[18px]" />,
     labelKey: "nav.products",
     label: "Produtos",
+  },
+  {
+    id: "privacy",
+    icon: <ShieldCheck className="w-[18px] h-[18px]" />,
+    labelKey: "nav.privacy",
+    label: "Privacidade",
   },
 ];
 
@@ -477,6 +486,7 @@ function App() {
             {activeTab === "quotes" && <QuoteSection />}
             {activeTab === "customers" && <CustomerTab />}
             {activeTab === "products" && <ProductInventory />}
+            {activeTab === "privacy" && <PrivacyScreen />}
           </div>
         </main>
       </div>

--- a/src/platform/desktop/types/electron.d.ts
+++ b/src/platform/desktop/types/electron.d.ts
@@ -29,6 +29,31 @@ declare global {
       domainTables: { customers: number; quotes: number; quote_items: number };
       manifestAvailable: boolean;
     }>;
+
+    /**
+     * ADR-002 §2.2 quarantine report: PII keys holding legacy plaintext
+     * (quarantined, read-only) and their record counts.
+     */
+    quarantineReport: () => Promise<{
+      scannedAt: string;
+      entries: Array<{ key: string; status: string; recordCount?: number }>;
+      quarantinedKeys: string[];
+    }>;
+
+    /**
+     * ADR-002 §2.2.3 migrate: encrypt the quarantined plaintext with the
+     * ADR-001 capability and verify before the plaintext is destroyed.
+     */
+    migrateKey: (
+      key: string,
+    ) => Promise<{ key: string; migrated: boolean; verified: boolean }>;
+
+    /**
+     * ADR-002 §2.2.3 eliminate: delete the quarantined rows for a PII key.
+     */
+    eliminateKey: (
+      key: string,
+    ) => Promise<{ key: string; eliminated: boolean }>;
   }
 }
 

--- a/src/platform/web/App.tsx
+++ b/src/platform/web/App.tsx
@@ -10,6 +10,7 @@ import { InfillCalculator } from "@/shared/components/Calculator/InfillCalculato
 import { FilamentInventory } from "@/shared/components/Catalog/FilamentInventory";
 import { CustomerTab } from "@/shared/components/Catalog/CustomerTab";
 import { ProductInventory } from "@/shared/components/Catalog/ProductInventory";
+import { PrivacyScreen } from "@/shared/components/Privacy/PrivacyScreen";
 import { QuoteSection } from "@/shared/components/Calculator/QuoteSection";
 import { restoreAutoSnapshot } from "@/shared/stores/storeBridge";
 import { guardedStorage } from "@/shared/lib/manifestStorage";
@@ -39,6 +40,7 @@ import {
   Users,
   Package,
   MoreHorizontal,
+  ShieldCheck,
   BookOpen,
   DollarSign,
   Globe,
@@ -56,7 +58,8 @@ type Tab =
   | "changelog"
   | "quotes"
   | "customers"
-  | "products";
+  | "products"
+  | "privacy";
 type LegacyProduct = {
   name?: string;
   result?: CalculationResult;
@@ -79,6 +82,7 @@ const MORE_TABS: Tab[] = [
   "quotes",
   "customers",
   "products",
+  "privacy",
   "changelog",
 ];
 
@@ -141,6 +145,12 @@ const TABS: {
     icon: <Package className="w-[18px] h-[18px]" />,
     labelKey: "nav.products",
     label: "Produtos",
+  },
+  {
+    id: "privacy",
+    icon: <ShieldCheck className="w-[18px] h-[18px]" />,
+    labelKey: "nav.privacy",
+    label: "Privacidade",
   },
 ];
 
@@ -508,6 +518,7 @@ function App() {
             {activeTab === "quotes" && <QuoteSection />}
             {activeTab === "customers" && <CustomerTab />}
             {activeTab === "products" && <ProductInventory />}
+            {activeTab === "privacy" && <PrivacyScreen />}
           </div>
         </main>
       </div>

--- a/src/shared/__tests__/TabletOptimization.test.tsx
+++ b/src/shared/__tests__/TabletOptimization.test.tsx
@@ -1,36 +1,36 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
-import React from 'react'
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
 
 // ─── Mock all heavy dependencies ───
-vi.mock('@/shared/components/Header/Header', () => ({
+vi.mock("@/shared/components/Header/Header", () => ({
   Header: () => <header data-testid="header">Header</header>,
-}))
-vi.mock('@/shared/components/Catalog/CatalogTab', () => ({
+}));
+vi.mock("@/shared/components/Catalog/CatalogTab", () => ({
   CatalogTab: () => <div>CatalogTab</div>,
-}))
-vi.mock('@/shared/components/Calculator/HistoryTab/HistoryTab', () => ({
+}));
+vi.mock("@/shared/components/Calculator/HistoryTab/HistoryTab", () => ({
   HistoryTab: () => <div>HistoryTab</div>,
-}))
-vi.mock('@/shared/components/Dashboard/Dashboard', () => ({
+}));
+vi.mock("@/shared/components/Dashboard/Dashboard", () => ({
   Dashboard: () => <div>Dashboard</div>,
-}))
-vi.mock('@/shared/components/Changelog/ChangelogPage', () => ({
+}));
+vi.mock("@/shared/components/Changelog/ChangelogPage", () => ({
   ChangelogPage: () => <div>ChangelogPage</div>,
-}))
-vi.mock('@/shared/components/Calculator/InfillCalculator', () => ({
+}));
+vi.mock("@/shared/components/Calculator/InfillCalculator", () => ({
   InfillCalculator: () => <div>InfillCalculator</div>,
-}))
-vi.mock('@/shared/components/Catalog/FilamentInventory', () => ({
+}));
+vi.mock("@/shared/components/Catalog/FilamentInventory", () => ({
   FilamentInventory: () => <div>FilamentInventory</div>,
-}))
-vi.mock('@/shared/components/Calculator/Calculator', () => ({
+}));
+vi.mock("@/shared/components/Calculator/Calculator", () => ({
   Calculator: () => <div data-testid="calculator-mock">Calculator</div>,
-}))
-vi.mock('@/shared/stores/storeBridge', () => ({
+}));
+vi.mock("@/shared/stores/storeBridge", () => ({
   restoreAutoSnapshot: vi.fn(),
-}))
-vi.mock('@/shared/stores/historyStore', () => ({
+}));
+vi.mock("@/shared/stores/historyStore", () => ({
   useHistoryStore: Object.assign(
     vi.fn(() => ({
       entries: [],
@@ -41,190 +41,200 @@ vi.mock('@/shared/stores/historyStore', () => ({
         entries: [],
         addEntry: vi.fn(),
       })),
-    }
+    },
   ),
-}))
-vi.mock('@/shared/stores/calculatorStore', () => ({
-  useCalculatorStore: vi.fn((selector?: (state: Record<string, unknown>) => unknown) => {
-    const state = {
-      activeTab: 'fdm',
-      currency: 'auto',
-      fdmMaterial: {},
-      fdmPrintParams: {},
-      fdmMachine: {},
-      fdmHardware: {},
-      fdmFinishing: {},
-      fdmLabor: {},
-      fdmExtras: {},
-      fdmSales: {},
-      fdmOps: {},
-      fdmSoft: {},
-      resinMaterial: {},
-      resinPrintParams: {},
-      resinPostProcess: {},
-      resinMachine: {},
-      resinHardware: {},
-      resinLabor: {},
-      resinExtras: {},
-      resinSales: {},
-      resinOps: {},
-      resinSoft: {},
-      selectedPrinter: {},
-      selectedMarketplace: {},
-      fdmAmsEnabled: false,
-      fdmAmsSlots: [],
-      productName: '',
-      quantity: 1,
-      infillPercent: 20,
-      targetMarginMode: 'manual',
-      enabledSections: {},
-    }
-    return selector ? selector(state) : state
-  }),
-}))
+}));
+vi.mock("@/shared/stores/calculatorStore", () => ({
+  useCalculatorStore: vi.fn(
+    (selector?: (state: Record<string, unknown>) => unknown) => {
+      const state = {
+        activeTab: "fdm",
+        currency: "auto",
+        fdmMaterial: {},
+        fdmPrintParams: {},
+        fdmMachine: {},
+        fdmHardware: {},
+        fdmFinishing: {},
+        fdmLabor: {},
+        fdmExtras: {},
+        fdmSales: {},
+        fdmOps: {},
+        fdmSoft: {},
+        resinMaterial: {},
+        resinPrintParams: {},
+        resinPostProcess: {},
+        resinMachine: {},
+        resinHardware: {},
+        resinLabor: {},
+        resinExtras: {},
+        resinSales: {},
+        resinOps: {},
+        resinSoft: {},
+        selectedPrinter: {},
+        selectedMarketplace: {},
+        fdmAmsEnabled: false,
+        fdmAmsSlots: [],
+        productName: "",
+        quantity: 1,
+        infillPercent: 20,
+        targetMarginMode: "manual",
+        enabledSections: {},
+      };
+      return selector ? selector(state) : state;
+    },
+  ),
+}));
 
 // ─── Import after mocks ───
-import App from '../App'
+import App from "../App";
 
 // Mock i18next
-vi.mock('react-i18next', () => ({
+vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
-    i18n: { language: 'pt-BR', changeLanguage: vi.fn() },
+    i18n: { language: "pt-BR", changeLanguage: vi.fn() },
   }),
   Trans: ({ children }: { children: React.ReactNode }) => children,
   I18nextProvider: ({ children }: { children: React.ReactNode }) => children,
-}))
+}));
 
-describe('Phase 2 — Tablet Optimization', () => {
-  describe('2.1 Tablet sidebar in App.tsx', () => {
-    it('renders a tablet sidebar (icons-only) visible at md breakpoint', () => {
-      const { container } = render(<App />)
+describe("Phase 2 — Tablet Optimization", () => {
+  describe("2.1 Tablet sidebar in App.tsx", () => {
+    it("renders a tablet sidebar (icons-only) visible at md breakpoint", () => {
+      const { container } = render(<App />);
 
       // Find the tablet sidebar: <aside> with class containing "hidden md:flex lg:hidden"
-      const allAsides = container.querySelectorAll('aside')
-      const tabletSidebar = Array.from(allAsides).find((aside) =>
-        aside.className.includes('hidden') &&
-        aside.className.includes('md:flex') &&
-        aside.className.includes('lg:hidden')
-      )
+      const allAsides = container.querySelectorAll("aside");
+      const tabletSidebar = Array.from(allAsides).find(
+        (aside) =>
+          aside.className.includes("hidden") &&
+          aside.className.includes("md:flex") &&
+          aside.className.includes("lg:hidden"),
+      );
 
-      expect(tabletSidebar).toBeDefined()
-      expect(tabletSidebar).not.toBeNull()
-    })
+      expect(tabletSidebar).toBeDefined();
+      expect(tabletSidebar).not.toBeNull();
+    });
 
-    it('tablet sidebar has w-16 width class', () => {
-      const { container } = render(<App />)
+    it("tablet sidebar has w-16 width class", () => {
+      const { container } = render(<App />);
 
-      const allAsides = container.querySelectorAll('aside')
-      const tabletSidebar = Array.from(allAsides).find((aside) =>
-        aside.className.includes('md:flex') &&
-        aside.className.includes('lg:hidden')
-      )
+      const allAsides = container.querySelectorAll("aside");
+      const tabletSidebar = Array.from(allAsides).find(
+        (aside) =>
+          aside.className.includes("md:flex") &&
+          aside.className.includes("lg:hidden"),
+      );
 
-      expect(tabletSidebar).toBeDefined()
-      expect(tabletSidebar!.className).toContain('w-16')
-    })
+      expect(tabletSidebar).toBeDefined();
+      expect(tabletSidebar!.className).toContain("w-16");
+    });
 
-    it('tablet sidebar has px-2 padding class', () => {
-      const { container } = render(<App />)
+    it("tablet sidebar has px-2 padding class", () => {
+      const { container } = render(<App />);
 
-      const allAsides = container.querySelectorAll('aside')
-      const tabletSidebar = Array.from(allAsides).find((aside) =>
-        aside.className.includes('md:flex') &&
-        aside.className.includes('lg:hidden')
-      )
+      const allAsides = container.querySelectorAll("aside");
+      const tabletSidebar = Array.from(allAsides).find(
+        (aside) =>
+          aside.className.includes("md:flex") &&
+          aside.className.includes("lg:hidden"),
+      );
 
-      expect(tabletSidebar).toBeDefined()
-      expect(tabletSidebar!.className).toContain('px-2')
-    })
+      expect(tabletSidebar).toBeDefined();
+      expect(tabletSidebar!.className).toContain("px-2");
+    });
 
-    it('tablet sidebar renders a button for each tab', () => {
-      const { container } = render(<App />)
+    it("tablet sidebar renders a button for each tab", () => {
+      const { container } = render(<App />);
 
-      const allAsides = container.querySelectorAll('aside')
-      const tabletSidebar = Array.from(allAsides).find((aside) =>
-        aside.className.includes('md:flex') &&
-        aside.className.includes('lg:hidden')
-      )
+      const allAsides = container.querySelectorAll("aside");
+      const tabletSidebar = Array.from(allAsides).find(
+        (aside) =>
+          aside.className.includes("md:flex") &&
+          aside.className.includes("lg:hidden"),
+      );
 
-      expect(tabletSidebar).toBeDefined()
-      const buttons = tabletSidebar!.querySelectorAll('button')
-      // TABS array has 9 items (incl. products; changelog moved to sidebar bottom)
-      expect(buttons.length).toBe(9)
-    })
+      expect(tabletSidebar).toBeDefined();
+      const buttons = tabletSidebar!.querySelectorAll("button");
+      // TABS array has 10 items (incl. products and privacy; changelog moved
+      // to sidebar bottom)
+      expect(buttons.length).toBe(10);
+    });
 
-    it('tablet sidebar buttons have title attribute for accessibility', () => {
-      const { container } = render(<App />)
+    it("tablet sidebar buttons have title attribute for accessibility", () => {
+      const { container } = render(<App />);
 
-      const allAsides = container.querySelectorAll('aside')
-      const tabletSidebar = Array.from(allAsides).find((aside) =>
-        aside.className.includes('md:flex') &&
-        aside.className.includes('lg:hidden')
-      )
+      const allAsides = container.querySelectorAll("aside");
+      const tabletSidebar = Array.from(allAsides).find(
+        (aside) =>
+          aside.className.includes("md:flex") &&
+          aside.className.includes("lg:hidden"),
+      );
 
-      expect(tabletSidebar).toBeDefined()
-      const buttons = tabletSidebar!.querySelectorAll('button')
+      expect(tabletSidebar).toBeDefined();
+      const buttons = tabletSidebar!.querySelectorAll("button");
       buttons.forEach((btn) => {
-        expect(btn).toHaveAttribute('title')
-      })
-    })
+        expect(btn).toHaveAttribute("title");
+      });
+    });
 
-    it('tablet sidebar is hidden on mobile (has hidden class)', () => {
-      const { container } = render(<App />)
+    it("tablet sidebar is hidden on mobile (has hidden class)", () => {
+      const { container } = render(<App />);
 
-      const allAsides = container.querySelectorAll('aside')
-      const tabletSidebar = Array.from(allAsides).find((aside) =>
-        aside.className.includes('md:flex') &&
-        aside.className.includes('lg:hidden')
-      )
+      const allAsides = container.querySelectorAll("aside");
+      const tabletSidebar = Array.from(allAsides).find(
+        (aside) =>
+          aside.className.includes("md:flex") &&
+          aside.className.includes("lg:hidden"),
+      );
 
-      expect(tabletSidebar).toBeDefined()
+      expect(tabletSidebar).toBeDefined();
       // Should have 'hidden' as the base state
-      expect(tabletSidebar!.className).toMatch(/\bhidden\b/)
-    })
+      expect(tabletSidebar!.className).toMatch(/\bhidden\b/);
+    });
 
-    it('tablet sidebar is hidden on large screens (has lg:hidden class)', () => {
-      const { container } = render(<App />)
+    it("tablet sidebar is hidden on large screens (has lg:hidden class)", () => {
+      const { container } = render(<App />);
 
-      const allAsides = container.querySelectorAll('aside')
-      const tabletSidebar = Array.from(allAsides).find((aside) =>
-        aside.className.includes('md:flex') &&
-        aside.className.includes('lg:hidden')
-      )
+      const allAsides = container.querySelectorAll("aside");
+      const tabletSidebar = Array.from(allAsides).find(
+        (aside) =>
+          aside.className.includes("md:flex") &&
+          aside.className.includes("lg:hidden"),
+      );
 
-      expect(tabletSidebar).toBeDefined()
-      expect(tabletSidebar!.className).toContain('lg:hidden')
-    })
-  })
+      expect(tabletSidebar).toBeDefined();
+      expect(tabletSidebar!.className).toContain("lg:hidden");
+    });
+  });
 
-  describe('2.2 Responsive typography in index.css', () => {
-    it('body font-size uses clamp() for fluid scaling', async () => {
-      const fs = await import('node:fs/promises')
-      const path = await import('node:path')
-      const cssPath = path.resolve(__dirname, '../index.css')
-      const css = await fs.readFile(cssPath, 'utf-8')
+  describe("2.2 Responsive typography in index.css", () => {
+    it("body font-size uses clamp() for fluid scaling", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const cssPath = path.resolve(__dirname, "../index.css");
+      const css = await fs.readFile(cssPath, "utf-8");
 
       // Find the body rule and check for clamp
-      expect(css).toMatch(/body\s*\{[^}]*font-size:\s*clamp\(/)
-    })
+      expect(css).toMatch(/body\s*\{[^}]*font-size:\s*clamp\(/);
+    });
 
-    it('body font-size clamp starts at 0.9375rem (15px)', async () => {
-      const fs = await import('node:fs/promises')
-      const path = await import('node:path')
-      const cssPath = path.resolve(__dirname, '../index.css')
-      const css = await fs.readFile(cssPath, 'utf-8')
+    it("body font-size clamp starts at 0.9375rem (15px)", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const cssPath = path.resolve(__dirname, "../index.css");
+      const css = await fs.readFile(cssPath, "utf-8");
 
-      expect(css).toContain('clamp(0.9375rem')
-    })
+      expect(css).toContain("clamp(0.9375rem");
+    });
 
-    it('body font-size clamp ends at 1.0625rem (17px)', async () => {
-      const fs = await import('node:fs/promises')
-      const path = await import('node:path')
-      const cssPath = path.resolve(__dirname, '../index.css')
-      const css = await fs.readFile(cssPath, 'utf-8')
+    it("body font-size clamp ends at 1.0625rem (17px)", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const cssPath = path.resolve(__dirname, "../index.css");
+      const css = await fs.readFile(cssPath, "utf-8");
 
-      expect(css).toContain('1.0625rem)')
-    })
-  })
-})
+      expect(css).toContain("1.0625rem)");
+    });
+  });
+});

--- a/src/shared/components/Privacy/PrivacyScreen.tsx
+++ b/src/shared/components/Privacy/PrivacyScreen.tsx
@@ -80,7 +80,11 @@ export function PrivacyScreen() {
   }, [privacyApi, t]);
 
   useEffect(() => {
-    void loadReport();
+    // Deferred to a microtask so the fetch never triggers cascading
+    // synchronous renders from within the effect body.
+    void Promise.resolve().then(() => {
+      void loadReport();
+    });
   }, [loadReport]);
 
   const handleMigrate = useCallback(

--- a/src/shared/components/Privacy/PrivacyScreen.tsx
+++ b/src/shared/components/Privacy/PrivacyScreen.tsx
@@ -1,0 +1,284 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ShieldCheck,
+  RefreshCw,
+  Lock,
+  Trash2,
+  AlertCircle,
+} from "lucide-react";
+
+/**
+ * Privacy screen (D1.1 S4) — ADR-002 §2.2.4.
+ *
+ * A dedicated surface (reachable from the main navigation) that presents
+ * the legacy plaintext quarantine state: which PII keys hold legacy
+ * plaintext, how many records, and the only two exits — migrate (encrypt
+ * through the ADR-001 capability) or eliminate. Quarantine never
+ * auto-resolves and no other flag or banner accepts plaintext (ADR-002
+ * §2.2.4/§2.2.5, SPEC-04).
+ *
+ * Metadata only is displayed: key NAMES and record counts — quarantined
+ * values themselves are never rendered here.
+ */
+
+interface QuarantineEntry {
+  key: string;
+  status: string;
+  recordCount?: number;
+}
+
+interface QuarantineReport {
+  scannedAt: string;
+  entries: QuarantineEntry[];
+  quarantinedKeys: string[];
+}
+
+type ActionResult =
+  | { key: string; ok: true; kind: "migrated" | "eliminated" }
+  | { key: string; ok: false; kind: "migrated" | "eliminated" };
+
+const STATUS_LABEL_KEYS: Record<string, string> = {
+  quarantined: "privacy.quarantine.statusQuarantined",
+  encrypted: "privacy.quarantine.statusEncrypted",
+  absent: "privacy.quarantine.statusAbsent",
+  non_pii: "privacy.quarantine.statusNonPii",
+  unknown_key: "privacy.quarantine.statusUnknown",
+};
+
+export function PrivacyScreen() {
+  const { t } = useTranslation();
+  const [report, setReport] = useState<QuarantineReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [result, setResult] = useState<ActionResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const privacyApi = (
+    window as unknown as {
+      electronAPI?: {
+        privacy: {
+          quarantineReport: () => Promise<QuarantineReport>;
+          migrateKey: (key: string) => Promise<unknown>;
+          eliminateKey: (key: string) => Promise<unknown>;
+        };
+      };
+    }
+  ).electronAPI?.privacy;
+
+  const loadReport = useCallback(async () => {
+    if (!privacyApi) return;
+    setLoading(true);
+    try {
+      setReport(await privacyApi.quarantineReport());
+      setError(null);
+    } catch {
+      setError(t("privacy.quarantine.loadError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [privacyApi, t]);
+
+  useEffect(() => {
+    void loadReport();
+  }, [loadReport]);
+
+  const handleMigrate = useCallback(
+    async (key: string) => {
+      if (!privacyApi) return;
+      if (!window.confirm(t("privacy.quarantine.confirmMigrate", { key })))
+        return;
+      setBusyKey(key);
+      setError(null);
+      try {
+        await privacyApi.migrateKey(key);
+        setResult({ key, ok: true, kind: "migrated" });
+        await loadReport();
+      } catch {
+        setResult({ key, ok: false, kind: "migrated" });
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [privacyApi, t, loadReport],
+  );
+
+  const handleEliminate = useCallback(
+    async (key: string) => {
+      if (!privacyApi) return;
+      if (!window.confirm(t("privacy.quarantine.confirmEliminate", { key })))
+        return;
+      setBusyKey(key);
+      setError(null);
+      try {
+        await privacyApi.eliminateKey(key);
+        setResult({ key, ok: true, kind: "eliminated" });
+        await loadReport();
+      } catch {
+        setResult({ key, ok: false, kind: "eliminated" });
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [privacyApi, t, loadReport],
+  );
+
+  if (!privacyApi) {
+    return (
+      <div className="p-4 sm:p-6 max-w-3xl mx-auto w-full">
+        <div className="surface rounded-xl p-4 flex items-start gap-3">
+          <AlertCircle className="w-5 h-5 text-[var(--color-text-muted)] shrink-0 mt-0.5" />
+          <div>
+            <h2 className="font-semibold text-[var(--color-text-primary)]">
+              {t("privacy.quarantine.title")}
+            </h2>
+            <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+              {t("privacy.quarantine.desktopOnly")}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const quarantined =
+    report?.entries.filter((e) => e.status === "quarantined") ?? [];
+  const other = report?.entries.filter((e) => e.status !== "quarantined") ?? [];
+
+  return (
+    <div className="p-4 sm:p-6 max-w-3xl mx-auto w-full space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="w-6 h-6 text-[var(--color-accent)] shrink-0 mt-1" />
+          <div>
+            <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
+              {t("privacy.quarantine.title")}
+            </h2>
+            <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+              {t("privacy.quarantine.subtitle")}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadReport()}
+          aria-label={t("privacy.quarantine.refresh")}
+          title={t("privacy.quarantine.refresh")}
+          className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="text-sm text-red-400 flex items-center gap-2"
+        >
+          <AlertCircle className="w-4 h-4" /> {error}
+        </div>
+      )}
+
+      {result && (
+        <div
+          role="status"
+          className={`text-sm rounded-lg px-3 py-2 border ${
+            result.ok
+              ? "text-emerald-400 border-emerald-500/30 bg-emerald-500/10"
+              : "text-red-400 border-red-500/30 bg-red-500/10"
+          }`}
+        >
+          {result.ok
+            ? t(
+                result.kind === "migrated"
+                  ? "privacy.quarantine.migrated"
+                  : "privacy.quarantine.eliminated",
+                { key: result.key },
+              )
+            : t(
+                result.kind === "migrated"
+                  ? "privacy.quarantine.migrateFailed"
+                  : "privacy.quarantine.eliminateFailed",
+                { key: result.key },
+              )}
+        </div>
+      )}
+
+      {quarantined.length === 0 ? (
+        <div className="surface rounded-xl p-4">
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            {t("privacy.quarantine.noQuarantined")}
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {quarantined.map((entry) => (
+            <li
+              key={entry.key}
+              className="surface rounded-xl p-3 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold text-[var(--color-text-primary)] flex items-center gap-2">
+                  <Lock className="w-3.5 h-3.5 text-amber-400" />
+                  {entry.key}
+                </p>
+                <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+                  {t("privacy.quarantine.statusQuarantined")}
+                  {entry.recordCount !== undefined &&
+                    ` · ${t("privacy.quarantine.records", {
+                      count: entry.recordCount,
+                    })}`}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  type="button"
+                  onClick={() => void handleMigrate(entry.key)}
+                  disabled={busyKey === entry.key}
+                  className="min-h-[44px] px-3 py-2 rounded-xl text-xs font-semibold bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none disabled:opacity-60"
+                >
+                  {busyKey === entry.key
+                    ? t("privacy.quarantine.working")
+                    : t("privacy.quarantine.migrate")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleEliminate(entry.key)}
+                  disabled={busyKey === entry.key}
+                  aria-label={t("privacy.quarantine.eliminate")}
+                  title={t("privacy.quarantine.eliminate")}
+                  className="min-h-[44px] min-w-[44px] px-3 py-2 rounded-xl text-xs font-semibold bg-[var(--color-bg-elevated)] text-red-400 hover:bg-[var(--color-bg-hover)] border border-red-500/30 transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none disabled:opacity-60"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {other.length > 0 && (
+        <div className="surface rounded-xl p-3">
+          <p className="text-xs text-[var(--color-text-muted)] mb-1">
+            {t("privacy.quarantine.otherData")}
+          </p>
+          <ul className="text-xs text-[var(--color-text-secondary)] space-y-0.5">
+            {other.map((entry) => (
+              <li key={entry.key}>
+                {entry.key} —{" "}
+                {t(
+                  STATUS_LABEL_KEYS[entry.status] ??
+                    "privacy.quarantine.statusUnknown",
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <p className="text-[11px] text-[var(--color-text-muted)]">
+        {t("privacy.quarantine.readNote")}
+      </p>
+    </div>
+  );
+}

--- a/src/shared/components/Privacy/__tests__/PrivacyScreen.test.tsx
+++ b/src/shared/components/Privacy/__tests__/PrivacyScreen.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PrivacyScreen } from "../PrivacyScreen";
+
+// ---------------------------------------------------------------------------
+// D1.1 S4 — privacy screen: presents the quarantine state (metadata only)
+// and the two explicit exits (migrate / eliminate — ADR-002 §2.2.3/§2.2.4).
+// ---------------------------------------------------------------------------
+
+const hoisted = vi.hoisted(() => ({
+  quarantineReport: vi.fn(),
+  migrateKey: vi.fn(),
+  eliminateKey: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => {
+  const t = (key: string, opts?: Record<string, unknown>) => {
+    if (opts && "key" in opts) return `${key}:${String(opts.key)}`;
+    if (opts && "count" in opts) return `${key}:${String(opts.count)}`;
+    return key;
+  };
+  return {
+    useTranslation: () => ({ t }),
+  };
+});
+
+const baseReport = {
+  scannedAt: new Date().toISOString(),
+  entries: [
+    { key: "open3dcalc_quotes_v1", status: "quarantined", recordCount: 3 },
+    { key: "open3dcalc_settings_v2", status: "non_pii" },
+  ],
+  quarantinedKeys: ["open3dcalc_quotes_v1"],
+};
+
+function stubElectronApi(): void {
+  vi.stubGlobal("electronAPI", {
+    privacy: {
+      quarantineReport: hoisted.quarantineReport,
+      migrateKey: hoisted.migrateKey,
+      eliminateKey: hoisted.eliminateKey,
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  hoisted.quarantineReport.mockResolvedValue(baseReport);
+  hoisted.migrateKey.mockResolvedValue({
+    key: "open3dcalc_quotes_v1",
+    migrated: true,
+    verified: true,
+  });
+  hoisted.eliminateKey.mockResolvedValue({
+    key: "open3dcalc_quotes_v1",
+    eliminated: true,
+  });
+});
+
+describe("PrivacyScreen (D1.1 S4)", () => {
+  it("renders quarantined keys with record counts and both exits", async () => {
+    stubElectronApi();
+    render(<PrivacyScreen />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/quarantined|Quarantined/).length).toBeGreaterThan(0),
+    );
+    expect(screen.getByText(/privacy.quarantine.records:3/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "privacy.quarantine.migrate" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "privacy.quarantine.eliminate" }),
+    ).toBeInTheDocument();
+  });
+
+  it("migrate calls the IPC and refreshes the report", async () => {
+    stubElectronApi();
+    const user = userEvent.setup();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<PrivacyScreen />);
+    await waitFor(() =>
+      expect(hoisted.quarantineReport).toHaveBeenCalledTimes(1),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "privacy.quarantine.migrate" }),
+    );
+    await waitFor(() => expect(hoisted.migrateKey).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(hoisted.quarantineReport).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("eliminate calls the IPC with the quarantined key", async () => {
+    stubElectronApi();
+    const user = userEvent.setup();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<PrivacyScreen />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "privacy.quarantine.eliminate" })),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "privacy.quarantine.eliminate" }),
+    );
+    await waitFor(() =>
+      expect(hoisted.eliminateKey).toHaveBeenCalledWith("open3dcalc_quotes_v1"),
+    );
+  });
+
+  it("never renders quarantined values — metadata only", async () => {
+    stubElectronApi();
+    render(<PrivacyScreen />);
+    await waitFor(() => expect(screen.getAllByText(/open3dcalc_quotes_v1/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/Fernanda/)).not.toBeInTheDocument();
+  });
+
+  it("shows the desktop-only notice on web (no electronAPI)", () => {
+    render(<PrivacyScreen />);
+    expect(screen.getByText("privacy.quarantine.desktopOnly")).toBeInTheDocument();
+    expect(hoisted.quarantineReport).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -21,7 +21,8 @@
     "quotes": "Quotes",
     "more": "More",
     "menu": "Menu",
-    "settings": "Settings"
+    "settings": "Settings",
+    "privacy": "Privacy"
   },
   "dashboard": {
     "totalCost": "Total Cost",
@@ -611,6 +612,31 @@
       "section8Item3": "No data is transmitted to any server during export or import",
       "section8Item4": "You can encrypt bundles with your own password",
       "section8Lgpd": "In compliance with LGPD Art. 18 (right to data portability), you can export your data at any time and import it on another device."
+    },
+    "quarantine": {
+      "title": "Legacy data quarantine",
+      "subtitle": "Personal data written in plaintext by older versions is quarantined: readable, but blocked from new writes until you choose to migrate (encrypt) or eliminate it.",
+      "desktopOnly": "Legacy data quarantine is available only in the desktop app, where data is durable in SQLite. On the web, your data stays local to the browser.",
+      "refresh": "Re-scan",
+      "noQuarantined": "No data in quarantine. Everything stored is already encrypted or is not personal data.",
+      "statusQuarantined": "Quarantined (read-only)",
+      "statusEncrypted": "Encrypted at rest",
+      "statusAbsent": "Absent",
+      "statusNonPii": "Not personal data",
+      "statusUnknown": "Unknown key (denied)",
+      "records": "{{count}} record(s)",
+      "migrate": "Migrate",
+      "eliminate": "Eliminate",
+      "working": "Working…",
+      "confirmMigrate": "Migrate \"{{key}}\" to encryption at rest? The plaintext copy is only destroyed after the encrypted copy is verified.",
+      "confirmEliminate": "Permanently eliminate the quarantined data of \"{{key}}\"? This action cannot be undone.",
+      "migrated": "\"{{key}}\" migrated and verified.",
+      "eliminated": "\"{{key}}\" eliminated.",
+      "migrateFailed": "Failed to migrate \"{{key}}\" — nothing was lost; please try again.",
+      "eliminateFailed": "Failed to eliminate \"{{key}}\" — the data stays quarantined.",
+      "otherData": "Other local data",
+      "readNote": "Quarantine never resolves on its own: the only exits are migrate or eliminate, always through your explicit action.",
+      "loadError": "Could not load the quarantine report."
     }
   },
   "tooltip": {

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -21,7 +21,8 @@
     "mainNavigation": "Navegação principal",
     "more": "Mais",
     "menu": "Menu",
-    "settings": "Configurações"
+    "settings": "Configurações",
+    "privacy": "Privacidade"
   },
   "dashboard": {
     "totalCost": "Custo Total",
@@ -611,6 +612,31 @@
       "section8Item3": "Nenhum dado é transmitido a qualquer servidor durante a exportação ou importação",
       "section8Item4": "Você pode criptografar os pacotes com sua própria senha",
       "section8Lgpd": "Em conformidade com o Art. 18 da LGPD (direito à portabilidade dos dados), você pode exportar seus dados a qualquer momento e importá-los em outro dispositivo."
+    },
+    "quarantine": {
+      "title": "Quarentena de dados legados",
+      "subtitle": "Dados pessoais gravados em texto puro por versões antigas ficam em quarentena: legíveis, mas bloqueados para novas gravações até você escolher migrar (criptografar) ou eliminar.",
+      "desktopOnly": "A quarentena de dados legados está disponível apenas no aplicativo desktop, onde os dados são duráveis em SQLite. Na web, seus dados continuam locais no navegador.",
+      "refresh": "Reverificar",
+      "noQuarantined": "Nenhum dado em quarentena. Tudo que está gravado já está criptografado ou não é dado pessoal.",
+      "statusQuarantined": "Em quarentena (somente leitura)",
+      "statusEncrypted": "Criptografado em repouso",
+      "statusAbsent": "Ausente",
+      "statusNonPii": "Não é dado pessoal",
+      "statusUnknown": "Chave desconhecida (negada)",
+      "records": "{{count}} registro(s)",
+      "migrate": "Migrar",
+      "eliminate": "Eliminar",
+      "working": "Processando…",
+      "confirmMigrate": "Migrar \"{{key}}\" para criptografia em repouso? A cópia em texto puro só é destruída depois que a cópia criptografada for verificada.",
+      "confirmEliminate": "Eliminar definitivamente os dados em quarentena de \"{{key}}\"? Essa ação não pode ser desfeita.",
+      "migrated": "\"{{key}}\" migrado e verificado.",
+      "eliminated": "\"{{key}}\" eliminado.",
+      "migrateFailed": "Falha ao migrar \"{{key}}\" — nada foi perdido; tente novamente.",
+      "eliminateFailed": "Falha ao eliminar \"{{key}}\" — os dados permanecem em quarentena.",
+      "otherData": "Outros dados locais",
+      "readNote": "A quarentena nunca se resolve sozinha: as únicas saídas são migrar ou eliminar, sempre por uma ação sua explícita.",
+      "loadError": "Não foi possível carregar o relatório de quarentena."
     }
   },
   "tooltip": {


### PR DESCRIPTION
## D1.1 S4 — Legacy plaintext quarantine + privacy screen + migrate/eliminate (ADR-002)

Implements slice **S4** of the D1 track (OWNERS-RUNBOOK §4): the ADR-002 §2.2
quarantine regime — legacy plaintext PII is detected by the scan, becomes
**read-only**, is surfaced in a **dedicated privacy screen**, and leaves quarantine
only through the two explicit user actions (migrate or eliminate).

### Declared scope (OWNERS-RUNBOOK §6)

- `electron/quarantine.ts` — state machine per ADR-002 §2.3:
  - `legacy_plaintext ⇒ QUARANTINED` (read-only, **never auto-resolves** — §2.2.5);
  - **MIGRATE** (§2.2.3): encrypt through the ADR-001 capability, replace the row,
    verify the encrypted copy reads back identical, `VACUUM` scrubs freed pages —
    the plaintext copy is physically destroyed only after verification; restore-
    on-failure makes data loss impossible; deny-path platforms can only eliminate;
  - **ELIMINATE** (§2.2.3): deletes the quarantined rows and verifies absence
    (the SPEC-02 saga with journal/receipts formalizes the cross-surface flow in S7);
  - state is **derived from the §2.3 scan** — no new storage key, no manifest/policy
    change, survives restarts because the underlying data does.
- `electron/persistGate.ts` — §2.2.1 read-only enforcement: gated writes over a
  quarantined key are refused (`quarantined_read_only`); encrypted and non-PII keys
  unaffected.
- IPC: `privacy:quarantine-report`, `privacy:migrate-key`, `privacy:eliminate-key`
  (+ preload + typed `electron.d.ts`). Metadata-only logging (§3.2).
- **Privacy screen** (`PrivacyScreen.tsx`) — new "Privacy" nav tab (§2.2.4):
  quarantined keys with record counts, migrate/eliminate with confirmations,
  per-action results, quarantined **values are never rendered**; desktop-only
  notice on web; i18n pt-BR + en-US (§9.2). Tablet sidebar tab-count test synced.

### Real-Electron verification (no mocks, real SQLite file)

- Quarantined key detected (with record count) → gated write over it **refused**.
- MIGRATE: row becomes ciphertext, reads back verified → **DB-file byte scan finds
  ZERO occurrences** of the synthetic PII marker afterwards.
- ELIMINATE: second planted legacy key deleted, absence verified, quarantine report
  empty after both explicit exits.

### Verification

- **1,332 tests** across 101 files; typecheck (app + Electron), lint, desktop/web
  builds, pre-push gate — all green.
- Coverage on the S4 contract modules: **87.9% lines / 84.6% branches**.
- No contract documents modified (no policy bump — the state derives from the scan).

### Rollback (OWNERS-RUNBOOK §7)

Revert — the screen disappears and the gate stops refusing quarantined writes. No
migration or elimination happens without explicit user action, so nothing needs
reversing.

⚠️ Themis gate applies before merge (final approval: repo owner).
