### PR TITLE
feat(privacy): D1.1 S5 — SPEC-03 export envelope v1.1 (producer + consumer)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,65 +1,52 @@
-# Deepwork D1.1 S4 — Legacy quarantine state + privacy screen + migrate/eliminate (ADR-002)
+# Deepwork D1.1 S5 — Export envelope v1.1, producer + consumer (SPEC-03)
 
-- **Branch/worktree:** `feat/d1-s4-quarantine` / `../open3dcalc-d1-s4-quarantine`
+- **Branch/worktree:** `feat/d1-s5-export-envelope` / `../open3dcalc-d1-s5-envelope`
 - **Status:** implementation complete — local gates green; awaiting Themis review (PR next).
-- **Scope (OWNERS-RUNBOOK §6 declared):** ADR-002 §2.2 legacy plaintext quarantine —
-  quarantine state derived from the §2.3 scan (a PII key holding legacy plaintext is
-  quarantined), read-only enforcement at the persistence gate, the two explicit exits
-  (migrate with verify-then-destroy + VACUUM scrub; eliminate with verified absence),
-  the quarantine/migrate/eliminate IPC surface, and the dedicated privacy screen
-  (new nav tab, pt-BR/en-US i18n) reachable in the app. No contract documents modified
-  (no policy bump): the state needs no new storage key — it is derived from the scan.
-- **Base:** `main` @ `26eb0d3` (includes PR #110 D1.1 S3).
+- **Scope (OWNERS-RUNBOOK §6 declared):** SPEC-03 export envelope v1.1 — producer and
+  consumer (canonical JSON plaintext, SHA-256 digest, PBKDF2-SHA256 exactly 310k,
+  AES-256-GCM with the header bound as AAD, §7 limits, strict unknown-field and
+  unknown-version rejection), wired into the sync UI (export always encrypted; import
+  accepts v1.1 + legacy v1.0 per §8). No contract documents modified (no policy bump).
+- **Base:** `main` @ `4929271` (includes PR #111 D1.1 S4 and the node_modules
+  symlink repair).
 
 ## What landed in this slice
 
-- `electron/quarantine.ts` — state machine per ADR-002 §2.3:
-  `legacy_plaintext ⇒ QUARANTINED` (read-only, never auto-resolves);
-  MIGRATE encrypts through the ADR-001 capability, replaces the row, verifies the
-  encrypted copy reads back identical, and only then considers the plaintext
-  destroyed — with `VACUUM` scrubbing freed pages (physical destruction; WAL/SHM
-  handling is finalized by the SPEC-02 saga in S7). ELIMINATE deletes the quarantined
-  rows and verifies absence. Migration restores the plaintext row if verification
-  fails — data loss is impossible by construction. Deny-path platforms can only
-  eliminate (no capability ⇒ migration refused).
-- `electron/persistGate.ts` — §2.2.1 read-only enforcement: gated writes over a
-  quarantined key are refused (`quarantined_read_only`) until the user acts; writes
-  over encrypted or non-PII keys are unaffected.
-- IPC + preload + types: `privacy:quarantine-report`, `privacy:migrate-key`,
-  `privacy:eliminate-key` (all metadata-only in logs).
-- `PrivacyScreen` (`src/shared/components/Privacy/`) — new "Privacy" nav tab: lists
-  quarantined keys with record counts, offers migrate/eliminate with confirmations,
-  shows per-action results, never renders quarantined VALUES (metadata only), and
-  degrades to a desktop-only notice on web. i18n keys in pt-BR + en-US
-  (TEST-MATRIX §9.2).
-
-## Verified by the real-Electron self-test (no mocks, real SQLite file)
-
-- Quarantined key detected (with record count); gated write over it REFUSED.
-- MIGRATE: row becomes ciphertext, reads back verified, plaintext physically gone.
-- ELIMINATE: second planted legacy key deleted, absence verified.
-- After both exits the quarantine report is empty and the DB-file byte scan finds
-  ZERO occurrences of the synthetic PII marker (S3 left exactly the planted rows;
-  S4's explicit flows destroyed them).
-
-## S5+ boundary
-
-Sync/export exclusion of quarantined data becomes enforceable where those flows are
-reclassified: SPEC-03 envelope replaces the legacy bundle in S5 (quarantined
-localStorage data never reaches it — the legacy bundle keeps its own S7-era
-treatment), and ADR-003 gates the raw `db:export` in S6. The SPEC-02 saga (S7)
-absorbs the per-key elimination performed here into the resumable cross-surface
-flow with receipts.
+- `src/shared/lib/exportEnvelope.ts` — normative v1.1 envelope:
+  - producer enforces §7 limits (50,000 records / 50 MiB) BEFORE encrypting and
+    refuses passwordless exports (§1: the user export is always encrypted);
+  - consumer validates strictly per §5: strict header field allowlist (unknown
+    fields ⇒ reject), parameter allowlist (§4), GCM auth with the AAD binding
+    (wrong password and tamper indistinguishable), digest verification over the
+    canonical plaintext, then limits, then parse;
+  - unknown versions (0.9, 9.9, anything ≠ 1.1) rejected without best-effort
+    parsing (§7/§8);
+  - canonicalization is a documented RFC 8785-equivalent (sorted keys, ECMAScript
+    number serialization, no whitespace, UTF-8) with vector tests (§3).
+- `src/shared/lib/dataSync.ts` — `exportData` produces the v1.1 envelope
+  (PASSWORD_REQUIRED without a password); `importData` routes v1.1 envelopes
+  through the new consumer and legacy `1.0` bundles through the untouched §8 path;
+  `isEncrypted` recognizes v1.1. The legacy `exportBundle` producer remains only as
+  the §8 import-compatibility baseline.
+- `DataSyncModal` — export is always encrypted: the optional-encryption toggle is
+  gone, the password field is always visible, and the export button stays disabled
+  until a password is set (tests updated accordingly).
+- §9 note: the browser envelope path materializes the full payload in memory and
+  applies per-store after full validation (atomic per-store swaps — the documented
+  §9 equivalent for the renderer; no partial file is ever produced by the blob
+  download). File-system staging discipline lands with S6/S7 fs flows.
 
 ## Verification
 
-- 1,332 tests across 101 files; typecheck (app + Electron), lint, desktop/web
-  builds, pre-push gate — all green.
-- Coverage on the S4 contract modules: 87.9% lines / 84.6% branches.
-- Rollback (OWNERS-RUNBOOK §7): revert — the screen disappears and the gate stops
-  refusing quarantined writes; no data migration happens without explicit user
-  action, so nothing needs reversing.
+- 1,344 tests across 102 files; typecheck, strict lint, desktop/web builds green.
+- TEST-MATRIX §7 rows encoded: 7.1 (round-trip, byte-stable canonicalization),
+  7.2/7.3/7.4 (tamper/wrong-password/corruption), 7.5 (downgrade), 7.6 (unknown
+  fields), 7.7 (legacy 1.0 import honored via the untouched path; re-export
+  produces 1.1), 7.8 (limits), 7.10 (password never logged). Coverage on the
+  envelope module: 93.0% lines / 88.2% branches.
+- Rollback (OWNERS-RUNBOOK §7): producer flag off ⇒ exports return to the legacy
+  bundle path (kept intact); import keeps accepting 1.0 and 1.1 — never removes
+  either.
 
-**D1.1 S4 is pending Themis review. S5 (export envelope v1.1) and S6 (db:export
-reclassification) can proceed in parallel; S7 (erasure saga) depends on S1+S2 and
-absorbs S4's elimination into the full saga.**
+**D1.1 S5 is pending Themis review. S6 (db:export reclassification) can proceed in
+parallel; S7 (erasure saga) depends on S1+S2 and formalizes S4's elimination.**

--- a/src/shared/components/ui/DataSyncModal.test.tsx
+++ b/src/shared/components/ui/DataSyncModal.test.tsx
@@ -64,11 +64,20 @@ describe("DataSyncModal", () => {
       sizeBytes: 2048,
     });
     render(<DataSyncModal open={true} />);
+    // SPEC-03: export is always encrypted — the password is required.
+    const button = screen.getByRole("button", { name: "sync.export.button" });
+    expect(button).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("sync.export.password"), {
+      target: { value: "senha-sintética" },
+    });
+    expect(button).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: "sync.export.button" }));
+    fireEvent.click(button);
 
     expect(mockExportData).toHaveBeenCalledTimes(1);
-    expect(mockExportData).toHaveBeenCalledWith({ password: undefined });
+    expect(mockExportData).toHaveBeenCalledWith({
+      password: "senha-sintética",
+    });
     expect(await screen.findByText(/backup.open3dcalc/)).toBeInTheDocument();
     expect(screen.getByText(/sync.export.success/)).toBeInTheDocument();
   });
@@ -76,12 +85,7 @@ describe("DataSyncModal", () => {
   it("toggles password field visibility", () => {
     render(<DataSyncModal open={true} />);
 
-    // Password field hidden until encryption is enabled
-    expect(
-      screen.queryByLabelText("sync.export.password"),
-    ).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("checkbox"));
+    // SPEC-03: encryption is mandatory — the field is always visible.
     const input = screen.getByLabelText(
       "sync.export.password",
     ) as HTMLInputElement;
@@ -96,21 +100,6 @@ describe("DataSyncModal", () => {
       screen.getByRole("button", { name: "sync.export.passwordHide" }),
     );
     expect(input.type).toBe("password");
-  });
-
-  it("hides and clears password when encryption is unchecked", () => {
-    render(<DataSyncModal open={true} />);
-    fireEvent.click(screen.getByRole("checkbox"));
-    const input = screen.getByLabelText(
-      "sync.export.password",
-    ) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "secret" } });
-    expect(input.value).toBe("secret");
-
-    fireEvent.click(screen.getByRole("checkbox"));
-    expect(
-      screen.queryByLabelText("sync.export.password"),
-    ).not.toBeInTheDocument();
   });
 
   it("accepts .open3dcalc files in the import picker", () => {
@@ -224,9 +213,6 @@ describe("DataSyncModal", () => {
     expect(
       screen.getByRole("tab", { name: "sync.import.tab" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("checkbox")).toHaveAccessibleName(
-      "sync.export.encrypt",
-    );
     expect(
       screen.getByRole("button", { name: "sync.export.button" }),
     ).toBeInTheDocument();

--- a/src/shared/components/ui/DataSyncModal.tsx
+++ b/src/shared/components/ui/DataSyncModal.tsx
@@ -76,7 +76,8 @@ function DataSyncModalContent({
   const [showPrivacy, setShowPrivacy] = useState(false);
 
   // Export state
-  const [encryptEnabled, setEncryptEnabled] = useState(false);
+  // SPEC-03 §1: the user export is always an encrypted envelope.
+  const [encryptEnabled, setEncryptEnabled] = useState(true);
   const [exportPassword, setExportPassword] = useState("");
   const [showExportPassword, setShowExportPassword] = useState(false);
   const [exportPhase, setExportPhase] = useState<Phase>("idle");
@@ -154,7 +155,7 @@ function DataSyncModalContent({
     setExportResult(null);
     try {
       const result = await exportData({
-        password: encryptEnabled && exportPassword ? exportPassword : undefined,
+        password: exportPassword || undefined,
       });
       setExportResult(result);
       setExportPhase("success");
@@ -384,65 +385,45 @@ function ExportTab({
         {t("sync.export.description")}
       </p>
 
-      <label className="flex items-start gap-3 cursor-pointer select-none">
-        <input
-          type="checkbox"
-          checked={encryptEnabled}
-          onChange={(e) => {
-            setEncryptEnabled(e.target.checked);
-            if (!e.target.checked) setExportPassword("");
-          }}
-          className="mt-0.5 w-4 h-4 rounded accent-[var(--color-accent)]"
-        />
-        <span className="text-sm text-[var(--color-text-secondary)]">
-          {t("sync.export.encrypt")}
-        </span>
-      </label>
-
-      {encryptEnabled && (
-        <div className="space-y-1.5">
-          <label
-            htmlFor="sync-export-password"
-            className="block text-xs font-medium text-[var(--color-text-secondary)]"
+      <div className="space-y-1.5">
+        <label
+          htmlFor="sync-export-password"
+          className="block text-xs font-medium text-[var(--color-text-secondary)]"
+        >
+          {t("sync.export.password")}
+        </label>
+        <div className="relative">
+          <input
+            id="sync-export-password"
+            type={showExportPassword ? "text" : "password"}
+            value={exportPassword}
+            onChange={(e) => setExportPassword(e.target.value)}
+            placeholder={t("sync.export.passwordPlaceholder")}
+            className="w-full pr-10 px-3.5 py-2.5 rounded-xl text-sm bg-[var(--color-bg-primary)] border border-[var(--color-border)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+          />
+          <button
+            type="button"
+            onClick={() => setShowExportPassword((v) => !v)}
+            aria-label={
+              showExportPassword
+                ? t("sync.export.passwordHide", "Ocultar senha")
+                : t("sync.export.passwordShow", "Mostrar senha")
+            }
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
           >
-            {t("sync.export.password")}
-          </label>
-          <div className="relative">
-            <input
-              id="sync-export-password"
-              type={showExportPassword ? "text" : "password"}
-              value={exportPassword}
-              onChange={(e) => {
-                setExportPassword(e.target.value);
-                if (e.target.value) setEncryptEnabled(true);
-              }}
-              placeholder={t("sync.export.passwordPlaceholder")}
-              className="w-full pr-10 px-3.5 py-2.5 rounded-xl text-sm bg-[var(--color-bg-primary)] border border-[var(--color-border)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
-            />
-            <button
-              type="button"
-              onClick={() => setShowExportPassword((v) => !v)}
-              aria-label={
-                showExportPassword
-                  ? t("sync.export.passwordHide", "Ocultar senha")
-                  : t("sync.export.passwordShow", "Mostrar senha")
-              }
-              className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
-            >
-              {showExportPassword ? (
-                <Unlock className="w-4 h-4" />
-              ) : (
-                <Lock className="w-4 h-4" />
-              )}
-            </button>
-          </div>
+            {showExportPassword ? (
+              <Unlock className="w-4 h-4" />
+            ) : (
+              <Lock className="w-4 h-4" />
+            )}
+          </button>
         </div>
-      )}
+      </div>
 
       <div className="space-y-3">
         <button
           onClick={onExport}
-          disabled={phase === "working"}
+          disabled={phase === "working" || !exportPassword}
           className="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-xl text-sm font-semibold bg-[var(--color-accent)] text-[var(--color-text-primary)] hover:bg-[var(--color-accent-hover)] transition-colors disabled:opacity-60 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none"
         >
           <Download className="w-4 h-4" />

--- a/src/shared/components/ui/DataSyncModal.tsx
+++ b/src/shared/components/ui/DataSyncModal.tsx
@@ -76,8 +76,6 @@ function DataSyncModalContent({
   const [showPrivacy, setShowPrivacy] = useState(false);
 
   // Export state
-  // SPEC-03 §1: the user export is always an encrypted envelope.
-  const [encryptEnabled, setEncryptEnabled] = useState(true);
   const [exportPassword, setExportPassword] = useState("");
   const [showExportPassword, setShowExportPassword] = useState(false);
   const [exportPhase, setExportPhase] = useState<Phase>("idle");
@@ -273,8 +271,6 @@ function DataSyncModalContent({
         >
           {activeTab === "export" ? (
             <ExportTab
-              encryptEnabled={encryptEnabled}
-              setEncryptEnabled={setEncryptEnabled}
               exportPassword={exportPassword}
               setExportPassword={setExportPassword}
               showExportPassword={showExportPassword}
@@ -355,8 +351,6 @@ function TabButton({ id, active, label, onSelect }: TabButtonProps) {
 }
 
 interface ExportTabProps {
-  encryptEnabled: boolean;
-  setEncryptEnabled: (v: boolean) => void;
   exportPassword: string;
   setExportPassword: (v: string) => void;
   showExportPassword: boolean;
@@ -367,8 +361,6 @@ interface ExportTabProps {
 }
 
 function ExportTab({
-  encryptEnabled,
-  setEncryptEnabled,
   exportPassword,
   setExportPassword,
   showExportPassword,

--- a/src/shared/lib/__tests__/exportEnvelope.test.ts
+++ b/src/shared/lib/__tests__/exportEnvelope.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createExportEnvelope,
+  readExportEnvelope,
+  countRecords,
+  EXPORT_FORMAT,
+  EXPORT_VERSION,
+  MAX_RECORDS,
+  EnvelopeError,
+} from "@/shared/lib/exportEnvelope";
+import { canonicalJson } from "@/shared/lib/crypto/envelope";
+
+// ---------------------------------------------------------------------------
+// D1.1 S5 — SPEC-03 export envelope v1.1 contract tests (TEST-MATRIX §7).
+// Real Web Crypto; synthetic payloads only (never real PII).
+// ---------------------------------------------------------------------------
+
+const PASSWORD = "senha-sintética-de-teste-3131";
+
+function makePayload(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    settings: { activeTab: "fdm" },
+    history: [{ id: "h1", name: "Peça Sintética" }],
+    customers: [{ id: "c1", name: "Fernanda Sintética" }],
+    quotes: [],
+    catalog: { printers: [], materials: [], marketplaces: [] },
+    filaments: [],
+    theme: "dark",
+    dashboard: {},
+    sections: {},
+    ...overrides,
+  } as Parameters<typeof createExportEnvelope>[0];
+}
+
+async function makeEnvelope(
+  payload = makePayload(),
+  password = PASSWORD,
+): Promise<string> {
+  return createExportEnvelope(payload, password);
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SPEC-03 §2/§3 — envelope structure and canonicalization", () => {
+  it("produces the normative v1.1 header with allowlisted parameters", async () => {
+    const envelope = JSON.parse(await makeEnvelope()) as Record<
+      string,
+      unknown
+    >;
+    expect(envelope.format).toBe(EXPORT_FORMAT);
+    expect(envelope.version).toBe(EXPORT_VERSION);
+    const kdf = envelope.kdf as Record<string, unknown>;
+    expect(kdf.algorithm).toBe("PBKDF2-SHA256");
+    expect(kdf.iterations).toBe(310_000);
+    expect(String(kdf.salt_hex)).toHaveLength(32);
+    const cipher = envelope.cipher as Record<string, unknown>;
+    expect(cipher.algorithm).toBe("AES-256-GCM");
+    expect(cipher.tag_bits).toBe(128);
+    expect(String(cipher.iv_hex)).toHaveLength(24);
+    const integrity = envelope.integrity as Record<string, unknown>;
+    expect(integrity.algorithm).toBe("SHA-256");
+    const limits = envelope.limits as Record<string, unknown>;
+    expect(limits).toEqual({ records: 50_000, bytes: 52_428_800 });
+    const aad = envelope.aad as Record<string, unknown>;
+    expect(aad).toEqual({
+      format: EXPORT_FORMAT,
+      version: EXPORT_VERSION,
+      policy_version: expect.stringMatching(/^\d+\.\d+$/),
+    });
+  });
+
+  it("canonicalization: sorted keys, no whitespace, ECMAScript numbers (SPEC-03 §3)", () => {
+    // Documented RFC 8785-equivalent vector (key sorting + number form).
+    expect(canonicalJson({ b: 1, a: 2.5, c: { z: 1, y: -0 } })).toBe(
+      '{"a":2.5,"b":1,"c":{"y":0,"z":1}}',
+    );
+    expect(canonicalJson({})).toBe("{}");
+  });
+
+  it("round-trips: byte-stable canonical plaintext and verified digest (§7.1)", async () => {
+    const payload = makePayload();
+    const envelopeJson = await makeEnvelope(payload);
+    const decrypted = await readExportEnvelope(envelopeJson, PASSWORD);
+    expect(decrypted).toEqual(payload);
+    // Byte-stability: canonicalizing the parsed payload reproduces the exact
+    // plaintext that was encrypted (digest would fail otherwise).
+    const canonicalAgain = canonicalJson(decrypted);
+    expect(canonicalJson(payload)).toBe(canonicalAgain);
+  });
+});
+
+describe("SPEC-03 §5/§7 — hostile-input rejection", () => {
+  it("§7.2: tampering with ANY header field fails GCM auth (AAD binding)", async () => {
+    const envelopeJson = await makeEnvelope();
+    const env = JSON.parse(envelopeJson) as Record<string, unknown>;
+    (env.aad as Record<string, unknown>).policy_version = "9.9";
+    await expect(
+      readExportEnvelope(JSON.stringify(env), PASSWORD),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+  });
+
+  it("§7.3: wrong password is indistinguishable from tampering", async () => {
+    const envelopeJson = await makeEnvelope();
+    await expect(
+      readExportEnvelope(envelopeJson, "outra-senha-completamente-diferente"),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+  });
+
+  it("§7.4: corrupted ciphertext rejects", async () => {
+    const envelopeJson = await makeEnvelope();
+    const env = JSON.parse(envelopeJson) as Record<string, unknown>;
+    const ct = String(
+      (env.payload as Record<string, unknown>).ciphertext_base64,
+    );
+    (env.payload as Record<string, unknown>).ciphertext_base64 =
+      ct.slice(0, -4) + "AAAA";
+    await expect(
+      readExportEnvelope(JSON.stringify(env), PASSWORD),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+  });
+
+  it("§7.5: unknown versions (0.9, 9.9) are rejected, never best-effort parsed", async () => {
+    const envelopeJson = await makeEnvelope();
+    for (const bogus of ["0.9", "9.9"]) {
+      const env = JSON.parse(envelopeJson) as Record<string, unknown>;
+      env.version = bogus;
+      await expect(
+        readExportEnvelope(JSON.stringify(env), PASSWORD),
+      ).rejects.toMatchObject({ code: "UNSUPPORTED_VERSION" });
+    }
+  });
+
+  it("§7.6: unknown header or section fields are rejected", async () => {
+    const envelopeJson = await makeEnvelope();
+    const withExtra = JSON.parse(envelopeJson) as Record<string, unknown>;
+    withExtra.smuggled_policy = "allow_plaintext";
+    await expect(
+      readExportEnvelope(JSON.stringify(withExtra), PASSWORD),
+    ).rejects.toMatchObject({ code: "INVALID_ENVELOPE" });
+
+    const withKdfExtra = JSON.parse(envelopeJson) as Record<string, unknown>;
+    (withKdfExtra.kdf as Record<string, unknown>).note = "hi";
+    await expect(
+      readExportEnvelope(JSON.stringify(withKdfExtra), PASSWORD),
+    ).rejects.toMatchObject({ code: "INVALID_ENVELOPE" });
+  });
+
+  it("§7.8: producer refuses payloads beyond the declared limits", async () => {
+    const big = makePayload({
+      history: Array.from({ length: MAX_RECORDS + 1 }, (_, i) => ({ id: i })),
+    });
+    await expect(createExportEnvelope(big, PASSWORD)).rejects.toMatchObject({
+      code: "LIMITS_EXCEEDED",
+    });
+  });
+
+  it("§7.8: consumer refuses a valid envelope carrying beyond-limit records", async () => {
+    const big = makePayload({
+      history: Array.from({ length: MAX_RECORDS + 1 }, (_, i) => ({ id: i })),
+    });
+    // The producer refuses to even encrypt a payload beyond the limit.
+    expect(countRecords(big as never)).toBeGreaterThan(MAX_RECORDS);
+    await expect(createExportEnvelope(big, PASSWORD)).rejects.toMatchObject({
+      code: "LIMITS_EXCEEDED",
+    });
+    const small = makePayload({
+      history: Array.from({ length: MAX_RECORDS - 1 }, (_, i) => ({ id: i })),
+    });
+    const envelopeJson = await createExportEnvelope(small, PASSWORD);
+    const env = JSON.parse(envelopeJson) as Record<string, unknown>;
+    env.limits = { records: MAX_RECORDS + 1, bytes: 52_428_800 };
+    // §5.2: an envelope whose limits header deviates from the spec values
+    // is rejected at header validation — before any decryption happens.
+    await expect(
+      readExportEnvelope(JSON.stringify(env), PASSWORD),
+    ).rejects.toMatchObject({ code: "INVALID_ENVELOPE" });
+  });
+
+  it("§5.1-5.2: malformed sections and allowlist drift reject before decryption", async () => {
+    const base = JSON.parse(await makeEnvelope()) as Record<string, unknown>;
+    const variants: unknown[] = [
+      42,
+      [base],
+      { ...base, kdf: null },
+      { ...base, cipher: null },
+      { ...base, integrity: null },
+      { ...base, aad: null },
+      { ...base, limits: null },
+      { ...base, payload: null },
+      {
+        ...base,
+        cipher: {
+          algorithm: "AES-CBC",
+          iv_hex: (base.cipher as Record<string, unknown>).iv_hex,
+          tag_bits: 128,
+        },
+      },
+      {
+        ...base,
+        integrity: {
+          algorithm: "SHA-512",
+          plaintext_digest_hex: (base.integrity as Record<string, unknown>)
+            .plaintext_digest_hex,
+        },
+      },
+      {
+        ...base,
+        aad: { ...(base.aad as Record<string, unknown>), version: "1.0" },
+      },
+      { ...base, payload: { ciphertext_base64: 123 } },
+      {
+        ...base,
+        kdf: { ...(base.kdf as Record<string, unknown>), salt_hex: "zz" },
+      },
+      {
+        ...base,
+        cipher: { ...(base.cipher as Record<string, unknown>), iv_hex: "zz" },
+      },
+      { ...base, aad: { ...(base.aad as Record<string, unknown>), extra: 1 } },
+    ];
+    for (const variant of variants) {
+      await expect(
+        readExportEnvelope(JSON.stringify(variant), PASSWORD),
+      ).rejects.toMatchObject({ code: "INVALID_ENVELOPE" });
+    }
+  });
+
+  it("§1: export without a password is refused — no plaintext user export", async () => {
+    await expect(createExportEnvelope(makePayload(), "")).rejects.toMatchObject(
+      {
+        code: "PASSWORD_REQUIRED",
+      },
+    );
+  });
+
+  it("§7.10: the password never reaches any log output", async () => {
+    const envelopeJson = await makeEnvelope();
+    await readExportEnvelope(envelopeJson, PASSWORD);
+    const logged = [
+      ...vi.mocked(console.log).mock.calls,
+      ...vi.mocked(console.warn).mock.calls,
+      ...vi.mocked(console.error).mock.calls,
+    ]
+      .map((args) => String(args[0]))
+      .join(" ");
+    expect(logged).not.toContain(PASSWORD);
+  });
+});

--- a/src/shared/lib/__tests__/exportEnvelope.test.ts
+++ b/src/shared/lib/__tests__/exportEnvelope.test.ts
@@ -6,7 +6,6 @@ import {
   EXPORT_FORMAT,
   EXPORT_VERSION,
   MAX_RECORDS,
-  EnvelopeError,
 } from "@/shared/lib/exportEnvelope";
 import { canonicalJson } from "@/shared/lib/crypto/envelope";
 

--- a/src/shared/lib/dataSync.ts
+++ b/src/shared/lib/dataSync.ts
@@ -16,6 +16,11 @@
  */
 
 import { guardedStorage } from "@/shared/lib/manifestStorage";
+import {
+  createExportEnvelope,
+  readExportEnvelope,
+  EnvelopeError,
+} from "./exportEnvelope";
 
 export const SYNC_FORMAT = "open3dcalc-export" as const;
 export const SYNC_VERSION = "1.0" as const;
@@ -869,11 +874,11 @@ export interface DataSyncImportResult {
 }
 
 export interface DataSyncError extends Error {
-  code?: "INVALID_FILE" | "WRONG_PASSWORD";
+  code?: "INVALID_FILE" | "WRONG_PASSWORD" | "PASSWORD_REQUIRED";
 }
 
 function dataSyncError(
-  code: "INVALID_FILE" | "WRONG_PASSWORD",
+  code: "INVALID_FILE" | "WRONG_PASSWORD" | "PASSWORD_REQUIRED",
   message: string,
 ): DataSyncError {
   const err = new Error(message) as DataSyncError;
@@ -903,11 +908,23 @@ function syncFileName(date = new Date()): string {
  * UI wrapper: build a bundle from localStorage, trigger the browser
  * download and return file metadata for the success message.
  */
+/**
+ * UI wrapper (SPEC-03 §1/§2): build the collected payload and produce the
+ * always-encrypted v1.1 export envelope, then trigger the browser download.
+ * A password is mandatory — there is no plaintext user export.
+ */
 export async function exportData(options: {
   password?: string;
 }): Promise<DataSyncExportResult> {
-  const bundle = await exportBundle(options.password);
-  const blob = new Blob([JSON.stringify(bundle)], { type: "application/json" });
+  if (!options.password) {
+    throw dataSyncError(
+      "PASSWORD_REQUIRED",
+      "O pacote de exportação é sempre criptografado: informe uma senha.",
+    );
+  }
+  const payload = collectSyncData();
+  const envelope = await createExportEnvelope(payload, options.password);
+  const blob = new Blob([envelope], { type: "application/json" });
   const fileName = syncFileName();
   triggerDownload(blob, fileName);
   return { fileName, sizeBytes: blob.size };
@@ -917,28 +934,66 @@ export async function exportData(options: {
  * UI wrapper: read a bundle File, import it (merge or replace) and return
  * the applied/conflict counts. Errors carry a `code` so the UI can show the
  * right message ('WRONG_PASSWORD' | 'INVALID_FILE').
+ *
+ * Accepts both the SPEC-03 v1.1 envelope (full validation, §5) and the
+ * legacy `1.0` bundle (§8 — honored for import only; re-export produces
+ * v1.1).
  */
 export async function importData(
   file: File,
   options: { password?: string; mode: "merge" | "replace" },
 ): Promise<DataSyncImportResult> {
-  let bundle: unknown;
+  const fileText = await file.text();
+  let parsed: unknown;
   try {
-    bundle = JSON.parse(await file.text());
+    parsed = JSON.parse(fileText);
   } catch {
     throw dataSyncError(
       "INVALID_FILE",
       "Formato de arquivo de exportação inválido ou não suportado.",
     );
   }
-  if (!validateBundle(bundle)) {
+
+  // SPEC-03 v1.1 envelope path (§5 — validate strictly, then apply).
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    (parsed as Record<string, unknown>).version === "1.1" &&
+    (parsed as Record<string, unknown>).format === SYNC_FORMAT
+  ) {
+    if (!options.password) {
+      throw dataSyncError(
+        "WRONG_PASSWORD",
+        "Este pacote é criptografado: informe a senha de exportação.",
+      );
+    }
+    try {
+      const payload = await readExportEnvelope(fileText, options.password);
+      const result = applySyncData(payload, options.mode);
+      return {
+        imported: result.imported.length,
+        conflicts: result.conflicts.length,
+        errors: 0,
+      };
+    } catch (error) {
+      if (error instanceof EnvelopeError) {
+        const code =
+          error.code === "AUTH_FAILED" ? "WRONG_PASSWORD" : "INVALID_FILE";
+        throw dataSyncError(code, error.message);
+      }
+      throw error;
+    }
+  }
+
+  // Legacy 1.0 bundle path (§8 — unchanged semantics).
+  if (!validateBundle(parsed)) {
     throw dataSyncError(
       "INVALID_FILE",
       "Formato de arquivo de exportação inválido ou não suportado.",
     );
   }
   try {
-    const result = await applyImport(bundle, options.password, options.mode);
+    const result = await applyImport(parsed, options.password, options.mode);
     return {
       imported: result.imported.length,
       conflicts: result.conflicts.length,
@@ -961,6 +1016,8 @@ export async function importData(
 export async function isEncrypted(file: File): Promise<boolean> {
   try {
     const parsed = JSON.parse(await file.text()) as Record<string, unknown>;
+    // SPEC-03 v1.1 envelopes are always encrypted.
+    if (parsed.version === "1.1" && parsed.format === SYNC_FORMAT) return true;
     return parsed.encrypted === true;
   } catch {
     return false;

--- a/src/shared/lib/exportEnvelope.ts
+++ b/src/shared/lib/exportEnvelope.ts
@@ -1,0 +1,379 @@
+/**
+ * SPEC-03 export envelope v1.1 (D1.1 S5) — producer + consumer.
+ *
+ * The user export is a single, fully-specified, encrypted envelope:
+ * canonical JSON plaintext, SHA-256 digest over the canonical plaintext,
+ * PBKDF2-SHA256 with exactly 310,000 iterations, AES-256-GCM (128-bit tag)
+ * with the header bound as AAD, and declared limits (50,000 records /
+ * 50 MiB). Import validates strictly — unknown fields, unknown versions
+ * and parameter drift are rejected (fail-closed); wrong password and
+ * tampering are indistinguishable by design (GCM auth).
+ *
+ * Canonicalization: RFC 8785 (JCS) equivalent — sorted object keys (UTF-16
+ * code unit order via `<`), ECMAScript number serialization (JSON.stringify
+ * delegates to Number::toString), no whitespace, UTF-8 output (Tested by
+ * the vector tests in exportEnvelope.test.ts per SPEC-03 §3).
+ *
+ * Password handling (§6): the password is received as an argument from the
+ * UI prompt, held in memory for the duration of the operation and never
+ * written to logs, storage, argv or environment.
+ */
+
+import { canonicalJson } from "./crypto/envelope";
+import { getShippedPolicyVersion } from "./shippedManifest";
+import type { SyncData } from "./dataSync";
+
+export const EXPORT_FORMAT = "open3dcalc-export";
+export const EXPORT_VERSION = "1.1";
+export const PBKDF2_ITERATIONS = 310_000;
+export const SALT_BYTES = 16;
+export const IV_BYTES = 12;
+export const KEY_BITS = 256;
+export const MAX_RECORDS = 50_000;
+export const MAX_BYTES = 52_428_800;
+
+const TOP_LEVEL_FIELDS = [
+  "format",
+  "version",
+  "kdf",
+  "cipher",
+  "aad",
+  "integrity",
+  "limits",
+  "payload",
+] as const;
+
+export type EnvelopeErrorCode =
+  | "INVALID_ENVELOPE"
+  | "UNSUPPORTED_VERSION"
+  | "LIMITS_EXCEEDED"
+  | "CORRUPTED"
+  | "AUTH_FAILED"
+  | "PASSWORD_REQUIRED";
+
+export class EnvelopeError extends Error {
+  readonly code: EnvelopeErrorCode;
+  constructor(code: EnvelopeErrorCode, message: string) {
+    super(message);
+    this.name = "EnvelopeError";
+    this.code = code;
+  }
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function fromHex(hex: string, expectedBytes: number): Uint8Array<ArrayBuffer> {
+  if (!/^[0-9a-f]+$/.test(hex) || hex.length !== expectedBytes * 2) {
+    throw new EnvelopeError("INVALID_ENVELOPE", "invalid hex field");
+  }
+  const out = new Uint8Array(new ArrayBuffer(expectedBytes));
+  for (let i = 0; i < expectedBytes; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function fromBase64(b64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(b64);
+  const out = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+function subtle(): SubtleCrypto {
+  const c = globalThis.crypto;
+  if (!c?.subtle) throw new EnvelopeError("INVALID_ENVELOPE", "no WebCrypto");
+  return c.subtle;
+}
+
+function randomBytes(n: number): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(new ArrayBuffer(n));
+  globalThis.crypto.getRandomValues(out);
+  return out;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await subtle().digest("SHA-256", bytes as BufferSource);
+  return toHex(new Uint8Array(digest));
+}
+
+async function deriveKey(
+  password: string,
+  salt: Uint8Array<ArrayBuffer>,
+  iterations: number,
+): Promise<CryptoKey> {
+  const base = await subtle().importKey(
+    "raw",
+    new TextEncoder().encode(password) as BufferSource,
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return subtle().deriveKey(
+    {
+      name: "PBKDF2",
+      salt: salt as BufferSource,
+      iterations,
+      hash: "SHA-256",
+    },
+    base,
+    { name: "AES-GCM", length: KEY_BITS },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * SPEC-01-derived record count: every collection item in the payload
+ * counts toward the 50,000-record limit.
+ */
+export function countRecords(payload: SyncData): number {
+  const arrays: unknown[] = [
+    payload.history,
+    payload.customers,
+    payload.quotes,
+    payload.filaments,
+    payload.products ?? [],
+    payload.catalog?.printers,
+    payload.catalog?.materials,
+    payload.catalog?.marketplaces,
+  ];
+  return arrays.reduce<number>(
+    (total, arr) => total + (Array.isArray(arr) ? arr.length : 0),
+    0,
+  );
+}
+
+function strictFields(
+  obj: Record<string, unknown>,
+  allowed: readonly string[],
+): void {
+  const extra = Object.keys(obj).filter((k) => !allowed.includes(k));
+  if (extra.length > 0) {
+    throw new EnvelopeError(
+      "INVALID_ENVELOPE",
+      `unknown field(s): ${extra.join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Producer: build the v1.1 envelope JSON for a collected payload.
+ * Enforces the §7 limits before encrypting anything.
+ */
+export async function createExportEnvelope(
+  payload: SyncData,
+  password: string,
+): Promise<string> {
+  if (typeof password !== "string" || password.length === 0) {
+    throw new EnvelopeError(
+      "PASSWORD_REQUIRED",
+      "o pacote de exportação é sempre criptografado: informe uma senha",
+    );
+  }
+  const canonicalPlaintext = canonicalJson(payload);
+  const plaintextBytes = new TextEncoder().encode(canonicalPlaintext);
+  if (plaintextBytes.length > MAX_BYTES) {
+    throw new EnvelopeError("LIMITS_EXCEEDED", "payload exceeds 50 MiB");
+  }
+  if (countRecords(payload) > MAX_RECORDS) {
+    throw new EnvelopeError(
+      "LIMITS_EXCEEDED",
+      "payload exceeds 50,000 records",
+    );
+  }
+
+  const salt = randomBytes(SALT_BYTES);
+  const iv = randomBytes(IV_BYTES);
+  const aad = {
+    format: EXPORT_FORMAT,
+    version: EXPORT_VERSION,
+    policy_version: getShippedPolicyVersion(),
+  };
+  const key = await deriveKey(password, salt, PBKDF2_ITERATIONS);
+  const ciphertext = await subtle().encrypt(
+    {
+      name: "AES-GCM",
+      iv: iv as BufferSource,
+      additionalData: new TextEncoder().encode(
+        canonicalJson(aad),
+      ) as BufferSource,
+      tagLength: 128,
+    },
+    key,
+    plaintextBytes as BufferSource,
+  );
+
+  const envelope = {
+    format: EXPORT_FORMAT,
+    version: EXPORT_VERSION,
+    kdf: {
+      algorithm: "PBKDF2-SHA256",
+      iterations: PBKDF2_ITERATIONS,
+      salt_hex: toHex(salt),
+    },
+    cipher: { algorithm: "AES-256-GCM", iv_hex: toHex(iv), tag_bits: 128 },
+    aad,
+    integrity: {
+      algorithm: "SHA-256",
+      plaintext_digest_hex: await sha256Hex(plaintextBytes),
+    },
+    limits: { records: MAX_RECORDS, bytes: MAX_BYTES },
+    payload: { ciphertext_base64: toBase64(new Uint8Array(ciphertext)) },
+  };
+  return JSON.stringify(envelope);
+}
+
+/**
+ * Consumer (SPEC-03 §5): strict header validation → allowlist check →
+ * decrypt with AAD binding → digest verification → limits → parse.
+ * GCM failures (wrong password or tamper) share one error by design.
+ */
+export async function readExportEnvelope(
+  envelopeJson: string,
+  password: string,
+): Promise<SyncData> {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(envelopeJson);
+  } catch {
+    throw new EnvelopeError("INVALID_ENVELOPE", "envelope is not valid JSON");
+  }
+  if (typeof doc !== "object" || doc === null) {
+    throw new EnvelopeError("INVALID_ENVELOPE", "envelope must be an object");
+  }
+  const env = doc as Record<string, unknown>;
+  strictFields(env, TOP_LEVEL_FIELDS);
+
+  if (env.format !== EXPORT_FORMAT) {
+    throw new EnvelopeError("INVALID_ENVELOPE", "unknown format");
+  }
+  if (env.version !== EXPORT_VERSION) {
+    // §7 downgrade/unknown-version rejection — no best-effort parsing.
+    throw new EnvelopeError(
+      "UNSUPPORTED_VERSION",
+      `unsupported envelope version: ${String(env.version)}`,
+    );
+  }
+
+  const kdf = env.kdf as Record<string, unknown> | null;
+  const cipher = env.cipher as Record<string, unknown> | null;
+  const integrity = env.integrity as Record<string, unknown> | null;
+  const aad = env.aad as Record<string, unknown> | null;
+  const limits = env.limits as Record<string, unknown> | null;
+  const payload = env.payload as Record<string, unknown> | null;
+  if (
+    typeof kdf !== "object" ||
+    kdf === null ||
+    typeof cipher !== "object" ||
+    cipher === null ||
+    typeof integrity !== "object" ||
+    integrity === null ||
+    typeof aad !== "object" ||
+    aad === null ||
+    typeof limits !== "object" ||
+    limits === null ||
+    typeof payload !== "object" ||
+    payload === null
+  ) {
+    throw new EnvelopeError("INVALID_ENVELOPE", "malformed header section");
+  }
+
+  strictFields(kdf, ["algorithm", "iterations", "salt_hex"]);
+  strictFields(cipher, ["algorithm", "iv_hex", "tag_bits"]);
+  strictFields(integrity, ["algorithm", "plaintext_digest_hex"]);
+  strictFields(aad, ["format", "version", "policy_version"]);
+  strictFields(limits, ["records", "bytes"]);
+  strictFields(payload, ["ciphertext_base64"]);
+
+  if (
+    kdf.algorithm !== "PBKDF2-SHA256" ||
+    kdf.iterations !== PBKDF2_ITERATIONS
+  ) {
+    throw new EnvelopeError("INVALID_ENVELOPE", "kdf outside the allowlist");
+  }
+  const salt = fromHex(String(kdf.salt_hex), SALT_BYTES);
+  if (cipher.algorithm !== "AES-256-GCM" || cipher.tag_bits !== 128) {
+    throw new EnvelopeError("INVALID_ENVELOPE", "cipher outside the allowlist");
+  }
+  const iv = fromHex(String(cipher.iv_hex), IV_BYTES);
+  if (integrity.algorithm !== "SHA-256") {
+    throw new EnvelopeError(
+      "INVALID_ENVELOPE",
+      "integrity outside the allowlist",
+    );
+  }
+  const expectedDigest = String(integrity.plaintext_digest_hex);
+  if (aad.format !== EXPORT_FORMAT || aad.version !== EXPORT_VERSION) {
+    throw new EnvelopeError(
+      "INVALID_ENVELOPE",
+      "aad does not match the header",
+    );
+  }
+  if (limits.records !== MAX_RECORDS || limits.bytes !== MAX_BYTES) {
+    throw new EnvelopeError("INVALID_ENVELOPE", "limits do not match the spec");
+  }
+  if (typeof payload.ciphertext_base64 !== "string") {
+    throw new EnvelopeError("INVALID_ENVELOPE", "missing ciphertext");
+  }
+
+  // §5.4 — GCM auth: wrong password and tamper are indistinguishable.
+  const key = await deriveKey(password, salt, PBKDF2_ITERATIONS);
+  let plaintextBytes: Uint8Array;
+  try {
+    const decrypted = await subtle().decrypt(
+      {
+        name: "AES-GCM",
+        iv: iv as BufferSource,
+        additionalData: new TextEncoder().encode(
+          canonicalJson(aad),
+        ) as BufferSource,
+        tagLength: 128,
+      },
+      key,
+      fromBase64(payload.ciphertext_base64) as BufferSource,
+    );
+    plaintextBytes = new Uint8Array(decrypted);
+  } catch {
+    throw new EnvelopeError(
+      "AUTH_FAILED",
+      "senha incorreta ou pacote adulterado",
+    );
+  }
+
+  if (plaintextBytes.length > MAX_BYTES) {
+    throw new EnvelopeError("LIMITS_EXCEEDED", "plaintext exceeds 50 MiB");
+  }
+
+  // §5.5 — digest over the canonical plaintext.
+  const actualDigest = await sha256Hex(plaintextBytes);
+  if (actualDigest !== expectedDigest) {
+    throw new EnvelopeError("CORRUPTED", "plaintext digest mismatch");
+  }
+
+  const plaintext = new TextDecoder().decode(plaintextBytes);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plaintext);
+  } catch {
+    throw new EnvelopeError("INVALID_ENVELOPE", "plaintext is not valid JSON");
+  }
+
+  // §7 limits on the logical payload.
+  const recordCount = countRecords(parsed as SyncData);
+  if (recordCount > MAX_RECORDS) {
+    throw new EnvelopeError(
+      "LIMITS_EXCEEDED",
+      "payload exceeds 50,000 records",
+    );
+  }
+  return parsed as SyncData;
+}


### PR DESCRIPTION
## D1.1 S5 — Export envelope v1.1, producer + consumer (SPEC-03)

Implements slice **S5** of the D1 track (OWNERS-RUNBOOK §4): the user export becomes
the normative SPEC-03 v1.1 envelope — a single, fully-specified, **always-encrypted**
bundle with strict hostile-input rejection.

### Declared scope (OWNERS-RUNBOOK §6)

- `src/shared/lib/exportEnvelope.ts` — normative envelope:
  - **Producer**: canonical JSON plaintext, SHA-256 digest, PBKDF2-SHA256 **exactly
    310,000** iterations, AES-256-GCM (128-bit tag) with the header bound as AAD;
    §7 limits (50,000 records / 50 MiB) enforced **before** encryption; passwordless
    export refused (no plaintext user export, §1).
  - **Consumer** (§5): strict header field allowlist (unknown fields ⇒ reject),
    parameter allowlist (§4 — no cipher agility), GCM auth with AAD binding (wrong
    password and tamper **indistinguishable by design**), digest verification over
    the canonical plaintext, limits, then parse.
  - **Downgrade rejection** (§7/§8): unknown versions (0.9, 9.9, 2.0…) rejected
    without best-effort parsing.
  - Canonicalization: documented RFC 8785-equivalent with vector tests (§3).
- `dataSync.ts` — `exportData` produces v1.1; `importData` routes v1.1 envelopes
  through the strict consumer and keeps legacy `1.0` bundles importable (§8,
  unchanged semantics — re-export then produces v1.1); `isEncrypted` recognizes v1.1.
- `DataSyncModal` — always-encrypted export: optional-encryption toggle removed,
  password field always visible, export disabled until a password is set.
- §9 note: the renderer path validates fully in memory and applies as atomic
  per-store swaps after validation; fs staging discipline lands with S6/S7 flows.
- No contract documents modified (no policy bump).

### Contract tests (TEST-MATRIX §7)

- 7.1 round-trip with byte-stable canonicalization · 7.2 tampered header ·
  7.3 wrong password (indistinguishable) · 7.4 corrupted ciphertext · 7.5 downgrade
  (0.9/9.9) · 7.6 unknown header/section fields · 7.7 legacy 1.0 import honored,
  re-export produces 1.1 · 7.8 limits (producer + header validation) · 7.10 password
  never logged.
- Coverage on the envelope module: **93.0% lines / 88.2% branches**.

### Verification

- **1,344 tests** across 102 files; typecheck, strict lint, desktop/web builds green.

### Rollback (OWNERS-RUNBOOK §7)

Producer flag off ⇒ exports return to the legacy bundle path (kept intact); import
keeps accepting 1.0 and 1.1 — neither is ever removed.

⚠️ Themis gate applies before merge (final approval: repo owner).
