### PR TITLE
feat(privacy): D1.1 S6 — db:export reclassified as gated diagnostic backup (ADR-003)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,52 +1,51 @@
-# Deepwork D1.1 S5 — Export envelope v1.1, producer + consumer (SPEC-03)
+# Deepwork D1.1 S6 — db:export reclassification: dev gate, redaction, retention (ADR-003)
 
-- **Branch/worktree:** `feat/d1-s5-export-envelope` / `../open3dcalc-d1-s5-envelope`
+- **Branch/worktree:** `feat/d1-s6-dbexport` / `../open3dcalc-d1-s6-dbexport`
 - **Status:** implementation complete — local gates green; awaiting Themis review (PR next).
-- **Scope (OWNERS-RUNBOOK §6 declared):** SPEC-03 export envelope v1.1 — producer and
-  consumer (canonical JSON plaintext, SHA-256 digest, PBKDF2-SHA256 exactly 310k,
-  AES-256-GCM with the header bound as AAD, §7 limits, strict unknown-field and
-  unknown-version rejection), wired into the sync UI (export always encrypted; import
-  accepts v1.1 + legacy v1.0 per §8). No contract documents modified (no policy bump).
-- **Base:** `main` @ `4929271` (includes PR #111 D1.1 S4 and the node_modules
-  symlink repair).
+- **Scope (OWNERS-RUNBOOK §6 declared):** ADR-003 §2.2 — the raw SQLite `db:export`
+  reclassified as an engineering/diagnostic backup: explicit diagnostic gate
+  (fail-closed), manifest-driven redaction mode, retention sidecars, and the
+  retention/disposal tooling script (OWNERS-RUNBOOK §5). No user-facing UI entry
+  existed or returns. No contract documents modified (no policy bump).
+- **Base:** `main` @ `9e57800` (includes PR #112 D1.1 S5).
 
 ## What landed in this slice
 
-- `src/shared/lib/exportEnvelope.ts` — normative v1.1 envelope:
-  - producer enforces §7 limits (50,000 records / 50 MiB) BEFORE encrypting and
-    refuses passwordless exports (§1: the user export is always encrypted);
-  - consumer validates strictly per §5: strict header field allowlist (unknown
-    fields ⇒ reject), parameter allowlist (§4), GCM auth with the AAD binding
-    (wrong password and tamper indistinguishable), digest verification over the
-    canonical plaintext, then limits, then parse;
-  - unknown versions (0.9, 9.9, anything ≠ 1.1) rejected without best-effort
-    parsing (§7/§8);
-  - canonicalization is a documented RFC 8785-equivalent (sorted keys, ECMAScript
-    number serialization, no whitespace, UTF-8) with vector tests (§3).
-- `src/shared/lib/dataSync.ts` — `exportData` produces the v1.1 envelope
-  (PASSWORD_REQUIRED without a password); `importData` routes v1.1 envelopes
-  through the new consumer and legacy `1.0` bundles through the untouched §8 path;
-  `isEncrypted` recognizes v1.1. The legacy `exportBundle` producer remains only as
-  the §8 import-compatibility baseline.
-- `DataSyncModal` — export is always encrypted: the optional-encryption toggle is
-  gone, the password field is always visible, and the export button stays disabled
-  until a password is set (tests updated accordingly).
-- §9 note: the browser envelope path materializes the full payload in memory and
-  applies per-store after full validation (atomic per-store swaps — the documented
-  §9 equivalent for the renderer; no partial file is ever produced by the blob
-  download). File-system staging discipline lands with S6/S7 fs flows.
+- `electron/diagnosticGate.ts` — authorized-access gate (§2.2.1): `--diagnostic`
+  CLI switch or `OPEN3DCALC_DIAGNOSTIC=1`; fail-closed by default in production
+  builds and un-flagged dev runs.
+- `electron/diagnosticBackup.ts` — the gated backup operation (§2.2.2/§2.2.4):
+  non-redacted straight copy (PII-bearing, 14-day retention sidecar written);
+  redaction mode stages a copy, masks every manifest-`pii` storage row (unknown
+  keys fail-closed as PII), strips the PII domain tables, `VACUUM`s so masked
+  content is not retained in free pages, then atomically renames. Every backup
+  writes a `<target>.meta.json` sidecar (createdAt, redacted, retentionDays).
+- `main.ts` — `db:export` handler refuses without the gate, delegates to the
+  diagnostic module, and the save dialog is retitled as an engineering artifact.
+  No renderer UI invokes it (verified: zero `exportDatabase` call sites in src).
+- `scripts/diagnostic-retention.mjs` (+ npm `diagnostic:retention`) — retention
+  tooling (§2.2.4 / OWNERS-RUNBOOK §5): CHECK mode flags unredacted backups past
+  their deadline and exits 1 (CI-failing); `--dispose` securely destroys them
+  (overwrite with zeros + unlink, sidecar included) and appends a metadata-only
+  line to `diagnostic-disposal.log`. Sidecar-less files are fail-closed (judged
+  unredacted, aged by mtime).
+- User export remains the SPEC-03 envelope only (§2.1): quarantined/excluded
+  policies continue to apply there.
 
-## Verification
+## Verification (TEST-MATRIX §5)
 
-- 1,344 tests across 102 files; typecheck, strict lint, desktop/web builds green.
-- TEST-MATRIX §7 rows encoded: 7.1 (round-trip, byte-stable canonicalization),
-  7.2/7.3/7.4 (tamper/wrong-password/corruption), 7.5 (downgrade), 7.6 (unknown
-  fields), 7.7 (legacy 1.0 import honored via the untouched path; re-export
-  produces 1.1), 7.8 (limits), 7.10 (password never logged). Coverage on the
-  envelope module: 93.0% lines / 88.2% branches.
-- Rollback (OWNERS-RUNBOOK §7): producer flag off ⇒ exports return to the legacy
-  bundle path (kept intact); import keeps accepting 1.0 and 1.1 — never removes
-  either.
+- 5.1: without the gate the handler refuses — no artifact is written.
+- 5.2: with the gate, an unredacted backup lands locally with the retention
+  sidecar; the module performs zero network I/O (local file only, §2.2.3).
+- 5.3: redacted backup masks manifest-PII storage rows (`[REDACTED]`), leaves
+  non-PII rows intact, strips the domain tables, and the marker is provably gone
+  from the file bytes.
+- 5.4: the retention script flags unredacted backups past 14 days (exit 1) and
+  `--dispose` removes them with an audit log; redacted backups are retained.
+- 1,350 tests across 104 files; typecheck (app + Electron), strict lint, builds.
+- Rollback (OWNERS-RUNBOOK §7): flag off ⇒ previous behavior returns — requires
+  user sign-off per the runbook (re-exposes raw PII copy); the preferred path is
+  keeping the gate and fixing forward.
 
-**D1.1 S5 is pending Themis review. S6 (db:export reclassification) can proceed in
-parallel; S7 (erasure saga) depends on S1+S2 and formalizes S4's elimination.**
+**D1.1 S6 is pending Themis review. S7 (erasure saga, SPEC-02) is next; S8
+(consent receipt, SPEC-04) depends on S7.**

--- a/electron/__tests__/diagnosticBackup.test.ts
+++ b/electron/__tests__/diagnosticBackup.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment node
+ *
+ * Contract tests for the diagnostic SQLite backup (D1.1 S6) — TEST-MATRIX
+ * §5 rows 5.1–5.3 (ADR-003 §2.2): dev gate closed by default, backup lands
+ * locally only, redaction masks PII per the SPEC-01 manifest. Real
+ * better-sqlite3, real files — no mocks for storage.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createDiagnosticBackup,
+  DiagnosticGateError,
+  DIAGNOSTIC_RETENTION_DAYS,
+} from "../diagnosticBackup.js";
+import { resetDiagnosticGateForTests } from "../diagnosticGate.js";
+
+const MARKER = "Fernanda Sintética <fernanda@exemplo.teste>";
+
+let dir: string;
+let dbPath: string;
+
+function makeLiveDb(): void {
+  const db = new Database(dbPath);
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS storage (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+  );
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS customers (id TEXT PRIMARY KEY, name TEXT)",
+  );
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS quotes (id TEXT PRIMARY KEY, customer_id TEXT)",
+  );
+  db.exec("CREATE TABLE IF NOT EXISTS quote_items (id TEXT PRIMARY KEY)");
+  db.prepare(
+    "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?)",
+  ).run(
+    "open3dcalc_customers_v1",
+    JSON.stringify([{ name: MARKER }]),
+    Date.now(),
+  );
+  db.prepare(
+    "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?)",
+  ).run("open3dcalc_settings_v2", '{"activeTab":"fdm"}', Date.now());
+  db.prepare("INSERT INTO customers (id, name) VALUES (?, ?)").run(
+    "c1",
+    MARKER,
+  );
+  db.close();
+}
+
+beforeEach(() => {
+  delete process.env.OPEN3DCALC_DIAGNOSTIC;
+  resetDiagnosticGateForTests();
+  dir = mkdtempSync(join(tmpdir(), "o3dc-diag-"));
+  dbPath = join(dir, "live.sqlite3");
+  makeLiveDb();
+});
+
+afterEach(() => {
+  delete process.env.OPEN3DCALC_DIAGNOSTIC;
+  resetDiagnosticGateForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("diagnostic backup (ADR-003 §2.2)", () => {
+  it("§5.1: refuses without the diagnostic gate (production default)", async () => {
+    await expect(
+      createDiagnosticBackup({
+        dbPath,
+        targetPath: join(dir, "out.sqlite3"),
+        redact: false,
+      }),
+    ).rejects.toThrow(DiagnosticGateError);
+    expect(existsSync(join(dir, "out.sqlite3"))).toBe(false);
+  });
+
+  it("§5.2: with the gate, an unredacted backup lands locally with a retention sidecar", async () => {
+    process.env.OPEN3DCALC_DIAGNOSTIC = "1";
+    resetDiagnosticGateForTests();
+    const target = join(dir, "diagnostic-backup-full.sqlite3");
+    const result = await createDiagnosticBackup({
+      dbPath,
+      targetPath: target,
+      redact: false,
+    });
+    expect(existsSync(target)).toBe(true);
+    const bytes = readFileSync(target);
+    expect(bytes.includes(Buffer.from(MARKER, "utf8"))).toBe(true);
+    const meta = JSON.parse(readFileSync(result.metaPath, "utf8"));
+    expect(meta.redacted).toBe(false);
+    expect(meta.retentionDays).toBe(DIAGNOSTIC_RETENTION_DAYS);
+    expect(meta.retentionDays).toBe(14);
+  });
+
+  it("§5.3: redacted backup masks manifest-PII storage rows and strips domain tables", async () => {
+    process.env.OPEN3DCALC_DIAGNOSTIC = "1";
+    resetDiagnosticGateForTests();
+    const target = join(dir, "diagnostic-backup-redacted.sqlite3");
+    const result = await createDiagnosticBackup({
+      dbPath,
+      targetPath: target,
+      redact: true,
+    });
+    expect(result.redacted).toBe(true);
+    expect(result.maskedStorageRows).toBe(1);
+    expect(result.strippedDomainRows).toBe(1);
+
+    const sqlite = new Database(target);
+    const customersRow = sqlite
+      .prepare("SELECT value FROM storage WHERE key = ?")
+      .get("open3dcalc_customers_v1") as { value: string };
+    const settingsRow = sqlite
+      .prepare("SELECT value FROM storage WHERE key = ?")
+      .get("open3dcalc_settings_v2") as { value: string };
+    const customersCount = (
+      sqlite.prepare("SELECT COUNT(*) AS c FROM customers").get() as {
+        c: number;
+      }
+    ).c;
+    sqlite.close();
+
+    expect(customersRow.value).toBe("[REDACTED]");
+    expect(settingsRow.value).toBe('{"activeTab":"fdm"}');
+    expect(customersCount).toBe(0);
+    // Redaction is provable: the marker is gone from the file bytes.
+    expect(readFileSync(target).includes(Buffer.from(MARKER, "utf8"))).toBe(
+      false,
+    );
+    const meta = JSON.parse(readFileSync(result.metaPath, "utf8"));
+    expect(meta.redacted).toBe(true);
+  });
+});

--- a/electron/diagnosticBackup.ts
+++ b/electron/diagnosticBackup.ts
@@ -1,0 +1,178 @@
+/**
+ * Diagnostic SQLite backup (D1.1 S6) — ADR-003 §2.2.
+ *
+ * The raw SQLite copy is an engineering/diagnostic artifact, never a user
+ * feature:
+ *
+ *  1. Gated: refuses to run without the diagnostic gate (§2.2.1).
+ *  2. Redaction: optional redaction mode masks storage rows whose key is
+ *     `pii: true` in the SPEC-01 manifest and strips the PII domain tables
+ *     (customers/quotes/quote_items) before the file lands (§2.2.2).
+ *  3. Local only: the output path is operator-chosen; nothing in this
+ *     module performs any network I/O (§2.2.3).
+ *  4. Retention: every backup writes a `<target>.meta.json` sidecar
+ *     (createdAt, redacted, retentionDays) consumed by the retention
+ *     script — unredacted backups expire after 14 days (§2.2.4).
+ *
+ * Metadata only in logs: file names and row counts, never stored values.
+ */
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { isKnownKey, getEntry } from "../src/shared/lib/dataManifest.js";
+import { loadManifestFromDisk } from "./manifestSource.js";
+import { isDiagnosticGateEnabled } from "./diagnosticGate.js";
+
+export const DIAGNOSTIC_RETENTION_DAYS = 14;
+
+export class DiagnosticGateError extends Error {
+  readonly code = "diagnostic_gate_closed";
+  constructor() {
+    super("[diagnosticBackup] refused: diagnostic gate is closed");
+    this.name = "DiagnosticGateError";
+  }
+}
+
+export interface DiagnosticBackupOptions {
+  dbPath: string;
+  targetPath: string;
+  /** Mask/strip PII rows per the SPEC-01 manifest before writing (§2.2.2). */
+  redact: boolean;
+  /** Checkpoint the live DB's WAL before copying (caller-provided). */
+  checkpoint?: () => void;
+}
+
+export interface DiagnosticBackupResult {
+  targetPath: string;
+  metaPath: string;
+  redacted: boolean;
+  maskedStorageRows: number;
+  strippedDomainRows: number;
+}
+
+const REQUIRE = createRequire(import.meta.url);
+
+/** better-sqlite3 resolved lazily so the module is importable in unit tests. */
+function getSqlite(): typeof import("better-sqlite3") {
+  return REQUIRE("better-sqlite3") as typeof import("better-sqlite3");
+}
+
+const PII_DOMAIN_TABLES = ["customers", "quotes", "quote_items"] as const;
+
+/**
+ * Produce the diagnostic backup. Refuses without the diagnostic gate.
+ * Returns the written paths and (when redacting) how much was masked.
+ */
+export async function createDiagnosticBackup(
+  options: DiagnosticBackupOptions,
+): Promise<DiagnosticBackupResult> {
+  if (!isDiagnosticGateEnabled()) {
+    throw new DiagnosticGateError();
+  }
+
+  const { dbPath, targetPath, redact, checkpoint } = options;
+  if (!redact) {
+    // §2.2.3: straight copy — the artifact is PII-bearing and falls under
+    // the 14-day retention rule enforced by the retention script.
+    checkpoint?.();
+    await fsp.copyFile(dbPath, targetPath);
+    const metaPath = writeMeta(targetPath, { redacted: false });
+    return {
+      targetPath,
+      metaPath,
+      redacted: false,
+      maskedStorageRows: 0,
+      strippedDomainRows: 0,
+    };
+  }
+
+  // §2.2.2 redaction: stage a copy, mask PII per the manifest, then move.
+  const stagingPath = `${targetPath}.staging-${process.pid}`;
+  checkpoint?.();
+  await fsp.copyFile(dbPath, stagingPath);
+
+  const Database = getSqlite();
+  const sqlite = new Database(stagingPath);
+  let maskedStorageRows = 0;
+  let strippedDomainRows = 0;
+  let manifest: ReturnType<typeof loadManifestFromDisk> | undefined;
+  try {
+    try {
+      manifest = loadManifestFromDisk();
+    } catch {
+      // Fail-closed: without the manifest nothing can be proven non-PII —
+      // redact every storage row and strip every domain table.
+      maskedStorageRows = sqlite
+        .prepare("UPDATE storage SET value = '[REDACTED]'")
+        .run().changes;
+      for (const table of PII_DOMAIN_TABLES) {
+        strippedDomainRows += sqlite
+          .prepare(`DELETE FROM ${table}`)
+          .run().changes;
+      }
+    }
+    if (manifest) {
+      const rows = sqlite
+        .prepare("SELECT key, value FROM storage")
+        .all() as Array<{ key: string; value: string }>;
+      const mask = sqlite.prepare(
+        "UPDATE storage SET value = '[REDACTED]' WHERE key = ?",
+      );
+      for (const row of rows) {
+        if (isKnownKey(manifest, row.key)) {
+          const entry = getEntry(manifest, row.key);
+          if (entry?.pii) {
+            mask.run(row.key);
+            maskedStorageRows++;
+          }
+        } else {
+          // Unknown key: default-deny — treat as PII and mask it.
+          mask.run(row.key);
+          maskedStorageRows++;
+        }
+      }
+      for (const table of PII_DOMAIN_TABLES) {
+        strippedDomainRows += sqlite
+          .prepare(`DELETE FROM ${table}`)
+          .run().changes;
+      }
+    }
+    // Compact so masked content is not retained in free pages.
+    sqlite.exec("VACUUM");
+  } finally {
+    sqlite.close();
+  }
+
+  await fsp.rename(stagingPath, targetPath);
+  const metaPath = writeMeta(targetPath, { redacted: true });
+  console.log(
+    `[diagnosticBackup] redacted backup written: ${path.basename(targetPath)} ` +
+      `(maskedStorageRows=${maskedStorageRows}, strippedDomainRows=${strippedDomainRows})`,
+  );
+  return {
+    targetPath,
+    metaPath,
+    redacted: true,
+    maskedStorageRows,
+    strippedDomainRows,
+  };
+}
+
+function writeMeta(targetPath: string, meta: { redacted: boolean }): string {
+  const metaPath = `${targetPath}.meta.json`;
+  fs.writeFileSync(
+    metaPath,
+    JSON.stringify(
+      {
+        createdAt: new Date().toISOString(),
+        redacted: meta.redacted,
+        retentionDays: DIAGNOSTIC_RETENTION_DAYS,
+      },
+      null,
+      2,
+    ),
+  );
+  return metaPath;
+}

--- a/electron/diagnosticGate.ts
+++ b/electron/diagnosticGate.ts
@@ -1,0 +1,28 @@
+/**
+ * Diagnostic gate (D1.1 S6) — ADR-003 §2.2.1.
+ *
+ * The raw SQLite `db:export` is reclassified as an engineering/diagnostic
+ * backup and is NOT a user feature: the handler refuses to run unless an
+ * explicit diagnostic gate is present:
+ *
+ *  - `--diagnostic` CLI switch, or
+ *  - `OPEN3DCALC_DIAGNOSTIC=1` environment variable.
+ *
+ * Fail-closed by default: production builds and un-flagged dev runs refuse.
+ * There is no UI entry point (the renderer never calls this).
+ */
+
+let cached: boolean | null = null;
+
+export function isDiagnosticGateEnabled(): boolean {
+  if (cached !== null) return cached;
+  cached =
+    process.argv.includes("--diagnostic") ||
+    process.env.OPEN3DCALC_DIAGNOSTIC === "1";
+  return cached;
+}
+
+/** Test-only: drop the cached gate decision. */
+export function resetDiagnosticGateForTests(): void {
+  cached = null;
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -35,6 +35,11 @@ import {
   migrateKey,
   eliminateKey,
 } from "./quarantine.js";
+import {
+  createDiagnosticBackup,
+  DiagnosticGateError,
+} from "./diagnosticBackup.js";
+import { isDiagnosticGateEnabled } from "./diagnosticGate.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -282,42 +287,66 @@ function setupIpcHandlers(): void {
     }
   });
 
-  // ── db:export ────────────────────────────────────────────────────
-  ipcMain.handle("db:export", async (event): Promise<string> => {
-    try {
-      assertTrustedSender(event);
-      const dbPath = getDbPath();
+  // ── db:export (D1.1 S6 — ADR-003 §2.2 reclassification) ─────────────
+  // The raw SQLite copy is a DIAGNOSTIC backup, not a user feature: it is
+  // gated behind the diagnostic flag, refuses to run in production without
+  // it, and supports manifest-driven redaction. Users export via the
+  // SPEC-03 envelope instead. No renderer UI invokes this.
+  ipcMain.handle(
+    "db:export",
+    async (event, options?: { redact?: boolean }): Promise<string> => {
+      try {
+        assertTrustedSender(event);
+        const redact = options?.redact === true;
+        const dbPath = getDbPath();
 
-      if (!mainWindow) {
-        throw new Error("No active window");
+        // §2.2.1 authorized access only — fail-closed without the gate.
+        if (!isDiagnosticGateEnabled()) {
+          throw new DiagnosticGateError();
+        }
+
+        if (!mainWindow) {
+          throw new Error("No active window");
+        }
+
+        const suffix = redact ? "redacted" : "full";
+        const result = await dialog.showSaveDialog(mainWindow, {
+          title: "Backup diagnóstico (engenharia) — uso interno",
+          defaultPath: `diagnostic-backup-${suffix}-${new Date()
+            .toISOString()
+            .slice(0, 10)}.sqlite3`,
+          filters: [
+            { name: "SQLite Database", extensions: ["sqlite3", "db"] },
+            { name: "All Files", extensions: ["*"] },
+          ],
+        });
+
+        if (result.canceled || !result.filePath) {
+          throw new Error("Export cancelled");
+        }
+
+        const backup = await createDiagnosticBackup({
+          dbPath,
+          targetPath: result.filePath,
+          redact,
+          checkpoint: () => {
+            // Checkpoint first so the copy includes all WAL data.
+            if (db && db.$client) {
+              db.$client.pragma("wal_checkpoint(TRUNCATE)");
+            }
+          },
+        });
+        console.log(
+          `[db:export] diagnostic backup (${suffix}) written by operator: ` +
+            `${path.basename(backup.targetPath)}`,
+        );
+        return backup.targetPath;
+      } catch (error) {
+        console.error("[db:export] Error:", error);
+        throw error;
       }
-
-      const result = await dialog.showSaveDialog(mainWindow, {
-        title: "Exportar Banco de Dados",
-        defaultPath: `open3dcalc-backup-${new Date().toISOString().slice(0, 10)}.sqlite3`,
-        filters: [
-          { name: "SQLite Database", extensions: ["sqlite3", "db"] },
-          { name: "All Files", extensions: ["*"] },
-        ],
-      });
-
-      if (result.canceled || !result.filePath) {
-        throw new Error("Export cancelled");
-      }
-
-      // Checkpoint first so the exported single file includes all WAL data
-      // (otherwise the copy could silently omit recent writes).
-      if (db && db.$client) {
-        db.$client.pragma("wal_checkpoint(TRUNCATE)");
-      }
-
-      await fs.copyFile(dbPath, result.filePath);
-      return result.filePath;
-    } catch (error) {
-      console.error("[db:export] Error:", error);
-      throw error;
-    }
-  });
+    },
+  );
 
   // ── update:check ────────────────────────────────────────────────────
   ipcMain.handle(

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -29,6 +29,8 @@
     "legacyScan.ts",
     "quarantine.ts",
     "manifestSource.ts",
+    "diagnosticBackup.ts",
+    "diagnosticGate.ts",
     "../src/shared/lib/dataManifest.ts"
   ],
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx db/migrate.ts",
     "postinstall": "node -e \"if (!process.env.CI) require('child_process').execSync('electron-rebuild -f -w better-sqlite3', { stdio: 'inherit' })\"",
-    "prepare": "husky"
+    "prepare": "husky",
+    "diagnostic:retention": "node scripts/diagnostic-retention.mjs"
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.20",

--- a/scripts/__tests__/diagnostic-retention.test.mjs
+++ b/scripts/__tests__/diagnostic-retention.test.mjs
@@ -8,7 +8,6 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
-import path from "node:path";
 import { mkdtempSync, rmSync, writeFileSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/scripts/__tests__/diagnostic-retention.test.mjs
+++ b/scripts/__tests__/diagnostic-retention.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment node
+ *
+ * Contract tests for the diagnostic backup retention script (D1.1 S6) —
+ * TEST-MATRIX §5 row 5.4 (ADR-003 §2.2.4, OWNERS-RUNBOOK §5): unredacted
+ * backups past 14 days are flagged and disposed with an audit log.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanBackups, disposeExpired, DEFAULT_RETENTION_DAYS } from "../diagnostic-retention.mjs";
+
+let dir;
+const NOW = new Date("2026-09-12T12:00:00Z");
+
+function writeBackup(name, { ageDays, redacted, withMeta = true }) {
+  const filePath = join(dir, `${name}.sqlite3`);
+  writeFileSync(filePath, Buffer.alloc(64, 1));
+  const created = new Date(NOW.getTime() - ageDays * 86_400_000);
+  if (withMeta) {
+    writeFileSync(
+      `${filePath}.meta.json`,
+      JSON.stringify({
+        createdAt: created.toISOString(),
+        redacted,
+        retentionDays: DEFAULT_RETENTION_DAYS,
+      }),
+    );
+  } else {
+    // No sidecar: fail-closed uses the file mtime.
+    utimesSync(filePath, created, created);
+  }
+  return filePath;
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "o3dc-retention-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("diagnostic backup retention (ADR-003 §2.2.4)", () => {
+  it("§5.4: flags unredacted backups past the 14-day deadline", () => {
+    writeBackup("diagnostic-backup-full-old", { ageDays: 20, redacted: false });
+    writeBackup("diagnostic-backup-full-fresh", { ageDays: 3, redacted: false });
+    writeBackup("diagnostic-backup-redacted-old", { ageDays: 40, redacted: true });
+    const { backups, violations } = scanBackups(dir, NOW);
+    expect(backups).toHaveLength(3);
+    expect(violations.map((v) => v.file)).toEqual([
+      "diagnostic-backup-full-old.sqlite3",
+    ]);
+  });
+
+  it("fail-closed: a backup without a sidecar is judged by mtime, unredacted", () => {
+    writeBackup("diagnostic-backup-orphan", { ageDays: 30, redacted: false, withMeta: false });
+    const { violations } = scanBackups(dir, NOW);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("--dispose overwrites and unlinks expired unredacted files, logging metadata", () => {
+    const oldPath = writeBackup("diagnostic-backup-full-old", {
+      ageDays: 20,
+      redacted: false,
+    });
+    writeBackup("diagnostic-backup-full-fresh", { ageDays: 3, redacted: false });
+    const disposed = disposeExpired(dir, NOW);
+    expect(disposed).toEqual(["diagnostic-backup-full-old.sqlite3"]);
+    expect(fs.existsSync(oldPath)).toBe(false);
+    expect(fs.existsSync(`${oldPath}.meta.json`)).toBe(false);
+    // Fresh unredacted backup untouched.
+    expect(
+      fs.existsSync(join(dir, "diagnostic-backup-full-fresh.sqlite3")),
+    ).toBe(true);
+    // Disposal log records metadata only (date, file, method).
+    const log = fs.readFileSync(join(dir, "diagnostic-disposal.log"), "utf8");
+    expect(log).toContain("diagnostic-backup-full-old.sqlite3");
+    expect(log).toContain("method=overwrite+unlink");
+  });
+});

--- a/scripts/diagnostic-retention.mjs
+++ b/scripts/diagnostic-retention.mjs
@@ -53,7 +53,7 @@ export function scanBackups(dir, now = new Date()) {
   const backups = files.map((base) => {
     const filePath = path.join(dir, `${base}.sqlite3`);
     const metaPath = `${filePath}.meta.json`;
-    let meta = null;
+    let meta;
     try {
       meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
     } catch {

--- a/scripts/diagnostic-retention.mjs
+++ b/scripts/diagnostic-retention.mjs
@@ -1,0 +1,152 @@
+/**
+ * Diagnostic backup retention check (D1.1 S6) — ADR-003 §2.2.4,
+ * OWNERS-RUNBOOK §5.
+ *
+ * Scans a directory of diagnostic SQLite backups (each with a
+ * `<file>.meta.json` sidecar written by electron/diagnosticBackup.ts) and:
+ *
+ *   - CHECK mode (default): flags unredacted backups past their retention
+ *     deadline (default 14 days). Exits 1 when violations exist — CI fails.
+ *   - --dispose: securely destroys expired unredacted backups (overwrite
+ *     with zeros, then unlink, sidecar included) and appends a metadata-only
+ *     line to `diagnostic-disposal.log` next to the backups.
+ *
+ * Files WITHOUT a sidecar are treated as unredacted with an unknown creation
+ * date — fail-closed: use the file mtime and flag if older than the default
+ * retention. The disposal log records metadata only (date, file, method),
+ * never PII.
+ *
+ * Usage: node scripts/diagnostic-retention.mjs <backups-dir> [--dispose]
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const DEFAULT_RETENTION_DAYS = 14;
+const DISPOSAL_LOG = "diagnostic-disposal.log";
+
+function listBackupFiles(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter(
+      (f) =>
+        f.endsWith(".sqlite3") &&
+        !f.includes(".staging-") &&
+        fs.statSync(path.join(dir, f)).isFile(),
+    )
+    .map((f) => f.replace(/\.sqlite3$/, ""));
+}
+
+function statAgeDays(filePath, now) {
+  const stat = fs.statSync(filePath);
+  return Math.floor((now.getTime() - stat.mtimeMs) / 86_400_000);
+}
+
+/**
+ * Scan `dir` and return every backup with its retention state.
+ * Backups WITHOUT a sidecar are fail-closed: judged unredacted, aged by
+ * file mtime. `now` is injectable for tests. Never reads backup CONTENTS
+ * — metadata only.
+ */
+export function scanBackups(dir, now = new Date()) {
+  const files = listBackupFiles(dir);
+  const backups = files.map((base) => {
+    const filePath = path.join(dir, `${base}.sqlite3`);
+    const metaPath = `${filePath}.meta.json`;
+    let meta = null;
+    try {
+      meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+    } catch {
+      meta = null;
+    }
+    const redacted = meta?.redacted === true;
+    const retentionDays =
+      typeof meta?.retentionDays === "number"
+        ? meta.retentionDays
+        : DEFAULT_RETENTION_DAYS;
+    const createdAt =
+      typeof meta?.createdAt === "string" ? new Date(meta.createdAt) : null;
+    const ageDays =
+      createdAt !== null && !Number.isNaN(createdAt.getTime())
+        ? Math.floor((now.getTime() - createdAt.getTime()) / 86_400_000)
+        : statAgeDays(filePath, now);
+    const expired = !redacted && ageDays > retentionDays;
+    return { file: `${base}.sqlite3`, redacted, ageDays, retentionDays, expired, metaPath };
+  });
+  const violations = backups.filter((b) => b.expired);
+  return { backups, violations };
+}
+
+function secureUnlink(filePath) {
+  // Overwrite with zeros, then unlink — best-effort secure disposal
+  // (srm-class tooling may be substituted by operators per the runbook).
+  const stat = fs.statSync(filePath);
+  const zeroBuf = Buffer.alloc(stat.size, 0);
+  fs.writeFileSync(filePath, zeroBuf);
+  fs.unlinkSync(filePath);
+}
+
+/**
+ * Dispose expired unredacted backups (overwrite + unlink) and log the
+ * disposal — metadata only (date, file, method).
+ * Returns the disposed file list.
+ */
+export function disposeExpired(dir, now = new Date()) {
+  const { violations } = scanBackups(dir, now);
+  const disposed = [];
+  for (const violation of violations) {
+    const filePath = path.join(dir, violation.file);
+    secureUnlink(filePath);
+    try {
+      fs.unlinkSync(violation.metaPath);
+    } catch {
+      /* sidecar already gone */
+    }
+    disposed.push(violation.file);
+    fs.appendFileSync(
+      path.join(dir, DISPOSAL_LOG),
+      `${new Date(now).toISOString()} disposed=${violation.file} method=overwrite+unlink ageDays=${violation.ageDays}\n`,
+    );
+  }
+  return disposed;
+}
+
+function main() {
+  const args = process.argv.slice(2).filter((a) => a !== "--dispose");
+  const dispose = process.argv.includes("--dispose");
+  const dir = args[0] ?? path.join("diagnostic-backups");
+  if (!fs.existsSync(dir)) {
+    console.log(`[retention] no diagnostic backup directory at ${dir} — nothing to check`);
+    process.exit(0);
+  }
+  const { backups, violations } = scanBackups(dir);
+  for (const backup of backups) {
+    const state = backup.expired
+      ? "EXPIRED (unredacted past retention)"
+      : backup.redacted
+        ? "ok (redacted)"
+        : "ok";
+    console.log(`[retention] ${backup.file}: ${state} (ageDays=${backup.ageDays})`);
+  }
+  if (violations.length > 0) {
+    if (dispose) {
+      const disposed = disposeExpired(dir);
+      console.log(
+        `[retention] disposed ${disposed.length} expired unredacted backup(s); logged to ${path.join(dir, DISPOSAL_LOG)}`,
+      );
+      process.exit(0);
+    }
+    console.error(
+      `[retention] ${violations.length} unredacted backup(s) past retention — dispose them (--dispose) or record an extension in the runbook log`,
+    );
+    process.exit(1);
+  }
+  console.log("[retention] no retention violations");
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  main();
+}


### PR DESCRIPTION
## D1.1 S6 — db:export reclassification: dev gate, redaction, retention (ADR-003)

Implements slice **S6** of the D1 track (OWNERS-RUNBOOK §4): the raw SQLite
`db:export` is reclassified as an **engineering/diagnostic backup** — gated, local-
only, redactable, and retention-audited. The user export remains the SPEC-03
envelope only (§2.1).

### Declared scope (OWNERS-RUNBOOK §6)

- `electron/diagnosticGate.ts` — authorized access only (§2.2.1): `--diagnostic`
  CLI switch or `OPEN3DCALC_DIAGNOSTIC=1`; fail-closed by default in production
  builds and un-flagged dev runs.
- `electron/diagnosticBackup.ts` — gated backup (§2.2.2/§2.2.4):
  - non-redacted: straight local copy, PII-bearing, with a retention sidecar
    (`createdAt`/`redacted`/`retentionDays` = 14 days);
  - redacted: masks every manifest-`pii` storage row (unknown keys fail-closed as
    PII), strips the PII domain tables, `VACUUM`s, atomic rename — redaction is
    provable by a byte scan;
  - zero network I/O — local file only (§2.2.3).
- `main.ts` — `db:export` refuses without the gate; dialog retitled as an
  engineering artifact; **no renderer UI invokes it** (zero call sites verified).
- `scripts/diagnostic-retention.mjs` (+ `npm run diagnostic:retention`) — retention
  tooling (OWNERS-RUNBOOK §5): CHECK mode fails (exit 1) when unredacted backups
  pass their 14-day deadline; `--dispose` overwrites+unlinks them and logs
  metadata-only disposal lines. Sidecar-less files are fail-closed (judged
  unredacted, aged by mtime).
- No contract documents modified (no policy bump).

### Contract tests (TEST-MATRIX §5)

- 5.1 gate closed ⇒ handler refuses, no artifact written.
- 5.2 gate open ⇒ backup lands locally with retention sidecar; zero network I/O.
- 5.3 redaction ⇒ manifest-PII storage rows masked, non-PII intact, domain tables
  stripped, marker provably gone from the file bytes.
- 5.4 retention script ⇒ unredacted backups past 14 days flagged (exit 1) and
  disposed with an audit log; redacted backups retained; sidecar-less files
  fail-closed.

### Verification

- **1,350 tests** across 104 files; typecheck (app + Electron), strict lint,
  desktop/web builds green.

### Rollback (OWNERS-RUNBOOK §7)

Flag off ⇒ previous behavior returns — **requires user sign-off** (re-exposes raw
PII copy); the preferred path is keeping the gate and fixing forward.

⚠️ Themis gate applies before merge (final approval: repo owner).
