### PR TITLE
feat(privacy): D1.1 S7 — resumable delete-all erasure saga (SPEC-02)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,51 +1,59 @@
-# Deepwork D1.1 S6 — db:export reclassification: dev gate, redaction, retention (ADR-003)
+# Deepwork D1.1 S7 — Erasure (delete-all) saga (SPEC-02)
 
-- **Branch/worktree:** `feat/d1-s6-dbexport` / `../open3dcalc-d1-s6-dbexport`
+- **Branch/worktree:** `feat/d1-s7-erasure-saga` / `../open3dcalc-d1-s7-erasure`
 - **Status:** implementation complete — local gates green; awaiting Themis review (PR next).
-- **Scope (OWNERS-RUNBOOK §6 declared):** ADR-003 §2.2 — the raw SQLite `db:export`
-  reclassified as an engineering/diagnostic backup: explicit diagnostic gate
-  (fail-closed), manifest-driven redaction mode, retention sidecars, and the
-  retention/disposal tooling script (OWNERS-RUNBOOK §5). No user-facing UI entry
-  existed or returns. No contract documents modified (no policy bump).
-- **Base:** `main` @ `9e57800` (includes PR #112 D1.1 S5).
+- **Scope (OWNERS-RUNBOOK §6 declared):** SPEC-02 erasure saga — pure state-machine
+  engine (prepared → snapshot_taken → deleting → committed | rolled_back) with a
+  resumable per-store journal (atomic writes, attempts ≤3, no re-prompt), an
+  encrypted TTL'd safety snapshot with the §5 rollback window, the §6 post-condition
+  rescan (zero PII before commit), desktop + renderer store adapters, the erasure
+  IPC surface, the delete-all flow in the privacy screen, and REAL crash-injection
+  tests (SIGKILL-equivalent at exact durable journal points). Contract change:
+  SPEC-01 fixture registers the web journal + snapshot keys and bumps
+  `policy_version` 1.1 → 1.2 (per OWNERS-RUNBOOK §6).
+- **Base:** `main` @ `9e57800` (includes PR #112 D1.1 S5, PR #113 D1.1 S6 and the
+  node_modules repair).
 
 ## What landed in this slice
 
-- `electron/diagnosticGate.ts` — authorized-access gate (§2.2.1): `--diagnostic`
-  CLI switch or `OPEN3DCALC_DIAGNOSTIC=1`; fail-closed by default in production
-  builds and un-flagged dev runs.
-- `electron/diagnosticBackup.ts` — the gated backup operation (§2.2.2/§2.2.4):
-  non-redacted straight copy (PII-bearing, 14-day retention sidecar written);
-  redaction mode stages a copy, masks every manifest-`pii` storage row (unknown
-  keys fail-closed as PII), strips the PII domain tables, `VACUUM`s so masked
-  content is not retained in free pages, then atomically renames. Every backup
-  writes a `<target>.meta.json` sidecar (createdAt, redacted, retentionDays).
-- `main.ts` — `db:export` handler refuses without the gate, delegates to the
-  diagnostic module, and the save dialog is retitled as an engineering artifact.
-  No renderer UI invokes it (verified: zero `exportDatabase` call sites in src).
-- `scripts/diagnostic-retention.mjs` (+ npm `diagnostic:retention`) — retention
-  tooling (§2.2.4 / OWNERS-RUNBOOK §5): CHECK mode flags unredacted backups past
-  their deadline and exits 1 (CI-failing); `--dispose` securely destroys them
-  (overwrite with zeros + unlink, sidecar included) and appends a metadata-only
-  line to `diagnostic-disposal.log`. Sidecar-less files are fail-closed (judged
-  unredacted, aged by mtime).
-- User export remains the SPEC-03 envelope only (§2.1): quarantined/excluded
-  policies continue to apply there.
+- `src/shared/lib/erasureSaga/` — pure engine (no Electron/DOM):
+  - `engine.ts` — §2 state machine with a real commit point: commit only after
+    every store row is `done` AND the §6 rescan finds zero PII; pre-commit
+    unrecoverable failure ⇒ rollback (snapshot restore); impossible rollback
+    (§5: capability denied / TTL expired / key lost) ⇒ completes `committed` with
+    a `rollback_unavailable` annotation — never a silent partial state; the
+    in_progress journal row is persisted BEFORE each purge (resume seam).
+  - `journal.ts` (disk) / `webStores.ts` (localStorage) — metadata-only journal,
+    atomic write-temp+fsync+rename.
+  - `snapshot.ts` / `webStores.ts` — encrypted snapshot (capability-injected),
+    TTL sweep on every entry into `deleting`, destroy-on-commit
+    (overwrite+unlink / remove).
+  - `rendererSweep.ts` — granular renderer adapters: localStorage (manifest keys +
+    unknown `open3dcalc_*` sweep, R1), IndexedDB, OPFS, Cache API/SW.
+- `electron/erasureStores.ts` + `electron/erasure.ts` — desktop adapters (domain
+  tables, storage rows, WAL/SHM checkpoint+verify, appdata files, logs, staging,
+  snapshots) with VACUUM after table deletion; safeStorage-backed snapshot
+  capability; startup resume of non-terminal sagas.
+- IPC `erasure:start`/`erasure:status` + preload + typed `electron.d.ts`.
+- PrivacyScreen — "Delete all my data": renderer purges first, main saga covers
+  the durable surfaces, §7 `external_copies_notice` shown on the completion
+  receipt. i18n pt-BR/en-US.
+- SPEC-01 fixture: `policy_version` 1.2; new web keys `open3dcalc_erasure_journal`
+  (diagnostic) and `open3dcalc_erasure_snapshot` (class snapshot, encrypted at
+  rest, 7-day retention).
 
-## Verification (TEST-MATRIX §5)
+## Verification (TEST-MATRIX §6)
 
-- 5.1: without the gate the handler refuses — no artifact is written.
-- 5.2: with the gate, an unredacted backup lands locally with the retention
-  sidecar; the module performs zero network I/O (local file only, §2.2.3).
-- 5.3: redacted backup masks manifest-PII storage rows (`[REDACTED]`), leaves
-  non-PII rows intact, strips the domain tables, and the marker is provably gone
-  from the file bytes.
-- 5.4: the retention script flags unredacted backups past 14 days (exit 1) and
-  `--dispose` removes them with an audit log; redacted backups are retained.
-- 1,350 tests across 104 files; typecheck (app + Electron), strict lint, builds.
-- Rollback (OWNERS-RUNBOOK §7): flag off ⇒ previous behavior returns — requires
-  user sign-off per the runbook (re-exposes raw PII copy); the preferred path is
-  keeping the gate and fixing forward.
+- 6.1 happy path · 6.2 death after snapshot_taken ⇒ idempotent resume commits
+  without re-prompt (journal durable, confirmation preserved) · 6.3 death mid-
+  deleting (first store done) ⇒ resumes from the first incomplete store ·
+  6.4 store failing 3× ⇒ rollback restores the snapshot payload · 6.5 post-erasure
+  byte scan: zero PII markers in the SQLite file (VACUUM) · 6.6 TTL sweep +
+  destroy-on-commit · 6.7 key lost ⇒ completes with `rollback_unavailable` ·
+  6.8 rescan finding PII ⇒ store failed, never success.
+- 1,366 tests across 107 files; typecheck (app + Electron), strict lint, builds.
+- Rollback (OWNERS-RUNBOOK §7): the saga is user-triggered; rollback = disable the
+  delete-all entry (flag) while journal+resume logic stays enabled (§7 S7 row).
 
-**D1.1 S6 is pending Themis review. S7 (erasure saga, SPEC-02) is next; S8
-(consent receipt, SPEC-04) depends on S7.**
+**D1.1 S7 is pending Themis review. S8 (consent receipt, SPEC-04) depends on this
+slice and is next.**

--- a/docs/privacy/SPEC-01-manifest-fixture.json
+++ b/docs/privacy/SPEC-01-manifest-fixture.json
@@ -1,18 +1,25 @@
 {
   "manifest_version": "1.0",
-  "policy_version": "1.1",
+  "policy_version": "1.2",
   "keys": [
     {
       "key": "open3dcalc_consent_v1",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "consent_record",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Records the privacy consent flag and date; local-only state, never a consent proof (proof lives in the SPEC-04 receipt).",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
@@ -21,14 +28,21 @@
     {
       "key": "open3dcalc_tutorial_v1",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "onboarding_flag",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Tutorial completion flag so the walkthrough is not re-shown; never satisfies consent (SPEC-04).",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -37,14 +51,21 @@
     {
       "key": "open3dcalc_migration_done_v2",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "onboarding_flag",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "One-shot marker for the v2 localStorage-to-SQLite migration so it runs once; local-only. Key renamed from the D1.0 fixture to match the shipped code.",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
@@ -53,14 +74,21 @@
     {
       "key": "open3dcalc_quickstart_dismissed",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "onboarding_flag",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Quick Start banner dismissal flag; local-only, never a consent substitute. Key renamed from the D1.0 fixture to match the shipped code.",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -69,14 +97,21 @@
     {
       "key": "open3dcalc_onboarded",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "onboarding_flag",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Onboarding completion flag so the intro modal is not re-shown; local-only, never a consent substitute.",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -85,14 +120,21 @@
     {
       "key": "i18nextLng",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_preference",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Interface language cached by the i18next browser language detector; local-only, falls back to navigator when absent.",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -101,14 +143,21 @@
     {
       "key": "open3dcalc_customers_v1",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_content",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Customer directory (name, company, email, phone, address, notes) used to issue quotes.",
       "legal_basis": "consent",
       "owner": "hermes",
@@ -117,14 +166,19 @@
     {
       "key": "customers",
       "surface": "sqlite_domain_tables",
-      "platforms": ["electron"],
+      "platforms": [
+        "electron"
+      ],
       "class": "user_content",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "never",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Normalized customer records mirrored from the customer store into the desktop database.",
       "legal_basis": "consent",
       "owner": "demeter",
@@ -133,14 +187,21 @@
     {
       "key": "open3dcalc_quotes_v1",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_content",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Quotes including customerSnapshot blobs (name, company, email, phone).",
       "legal_basis": "consent",
       "owner": "hermes",
@@ -149,14 +210,19 @@
     {
       "key": "quotes",
       "surface": "sqlite_domain_tables",
-      "platforms": ["electron"],
+      "platforms": [
+        "electron"
+      ],
       "class": "user_content",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "never",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Normalized quote records (with customerSnapshot JSON) in the desktop database.",
       "legal_basis": "consent",
       "owner": "demeter",
@@ -165,14 +231,21 @@
     {
       "key": "open3dcalc_history_v2",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_content",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Calculation history entries; PII-derived because entries can reference product/customer names.",
       "legal_basis": "consent",
       "owner": "hermes",
@@ -181,14 +254,21 @@
     {
       "key": "open3dcalc_settings_v2",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_preference",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Calculator settings, selected printer/marketplace, and section toggles; no personal data.",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
@@ -197,14 +277,21 @@
     {
       "key": "open3dcalc_sections",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "ui_state",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Enabled/disabled state of calculator sections.",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -213,14 +300,21 @@
     {
       "key": "open3dcalc_theme",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_preference",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Selected UI theme.",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -229,14 +323,21 @@
     {
       "key": "open3dcalc_dashboard_v1",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "derived_analytics",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Dashboard aggregates over user history; PII-derived because aggregates reference user content.",
       "legal_basis": "consent",
       "owner": "hermes",
@@ -245,14 +346,21 @@
     {
       "key": "open3dcalc_dashboard_goal",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_preference",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Monthly revenue goal number set by the user.",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -261,14 +369,21 @@
     {
       "key": "open3dcalc_catalog_v1",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_preference",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Custom printers/materials/marketplaces added by the user (seed catalog is code, not data).",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
@@ -277,14 +392,21 @@
     {
       "key": "open3dcalc_filaments",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_content",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Filament spool inventory (material, cost, remaining grams); no personal data.",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
@@ -293,14 +415,21 @@
     {
       "key": "open3dcalc_products",
       "surface": "localStorage",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "user_content",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "opt_in",
       "export": "user_export",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Product inventory (names, costs, margins); business data, not personal data.",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
@@ -309,14 +438,19 @@
     {
       "key": "storage",
       "surface": "sqlite_storage_table",
-      "platforms": ["electron"],
+      "platforms": [
+        "electron"
+      ],
       "class": "user_content",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "never",
       "export": "diagnostic_only",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "user_controlled", "max_days": 0 },
+      "retention": {
+        "policy": "user_controlled",
+        "max_days": 0
+      },
       "purpose": "Key-value mirror of renderer state in the desktop database; rows inherit the policy of the mirrored key; PII rows must be encrypted (ADR-001).",
       "legal_basis": "consent",
       "owner": "demeter",
@@ -325,14 +459,19 @@
     {
       "key": "sw_cache_entries",
       "surface": "cache_api",
-      "platforms": ["pwa"],
+      "platforms": [
+        "pwa"
+      ],
       "class": "cache",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "session_only", "max_days": 30 },
+      "retention": {
+        "policy": "session_only",
+        "max_days": 30
+      },
       "purpose": "Service worker precache of static assets; must never contain PII-bearing responses (ADR-001 §2.2).",
       "legal_basis": "not_personal_data",
       "owner": "aphrodite",
@@ -341,14 +480,20 @@
     {
       "key": "idb_reports_staging",
       "surface": "indexeddb",
-      "platforms": ["web", "pwa"],
+      "platforms": [
+        "web",
+        "pwa"
+      ],
       "class": "cache",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "session_only", "max_days": 1 },
+      "retention": {
+        "policy": "session_only",
+        "max_days": 1
+      },
       "purpose": "Transient staging of generated report documents (may embed customer names); encrypted, short-lived, cleared on erasure.",
       "legal_basis": "consent",
       "owner": "aphrodite",
@@ -357,14 +502,20 @@
     {
       "key": "opfs_export_staging",
       "surface": "opfs",
-      "platforms": ["web", "pwa"],
+      "platforms": [
+        "web",
+        "pwa"
+      ],
       "class": "cache",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "session_only", "max_days": 1 },
+      "retention": {
+        "policy": "session_only",
+        "max_days": 1
+      },
       "purpose": "Origin-private filesystem staging for in-progress export envelopes; encrypted, discarded on crash (SPEC-03 §7).",
       "legal_basis": "consent",
       "owner": "hermes",
@@ -373,14 +524,19 @@
     {
       "key": "appdata_logs",
       "surface": "logs",
-      "platforms": ["electron"],
+      "platforms": [
+        "electron"
+      ],
       "class": "diagnostic",
       "pii": false,
       "persistence": "plaintext_allowed",
       "sync": "never",
       "export": "diagnostic_only",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "fixed", "max_days": 14 },
+      "retention": {
+        "policy": "fixed",
+        "max_days": 14
+      },
       "purpose": "Application logs; MUST be scrubbed of PII at write time (never log customer data); egress only via engineering path.",
       "legal_basis": "not_personal_data",
       "owner": "hermes",
@@ -389,14 +545,19 @@
     {
       "key": "appdata_temp_staging",
       "surface": "temp_staging",
-      "platforms": ["electron"],
+      "platforms": [
+        "electron"
+      ],
       "class": "cache",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "session_only", "max_days": 1 },
+      "retention": {
+        "policy": "session_only",
+        "max_days": 1
+      },
       "purpose": "Temp files for in-progress operations (import staging, snapshots); encrypted; inside erasure scope (SPEC-02 §4).",
       "legal_basis": "consent",
       "owner": "hermes",
@@ -405,14 +566,21 @@
     {
       "key": "erasure_snapshots",
       "surface": "snapshots",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "snapshot",
       "pii": true,
       "persistence": "encrypted_at_rest",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "fixed", "max_days": 7 },
+      "retention": {
+        "policy": "fixed",
+        "max_days": 7
+      },
       "purpose": "Pre-erasure safety snapshots (SPEC-02 §5): encrypted with TTL, destroyed after commit, inside erasure scope.",
       "legal_basis": "consent",
       "owner": "hermes",
@@ -421,16 +589,67 @@
     {
       "key": "session_passphrase_key",
       "surface": "memory",
-      "platforms": ["electron", "web", "pwa"],
+      "platforms": [
+        "electron",
+        "web",
+        "pwa"
+      ],
       "class": "ephemeral_key",
       "pii": false,
       "persistence": "memory_only",
       "sync": "never",
       "export": "never",
       "erasure": "erase_on_delete_all",
-      "retention": { "policy": "session_only", "max_days": 0 },
+      "retention": {
+        "policy": "session_only",
+        "max_days": 0
+      },
       "purpose": "Passphrase-derived session key (ADR-001 fallback); memory only, zeroized on exit; never persisted or logged.",
       "legal_basis": "not_personal_data",
+      "owner": "hermes",
+      "version": "1.0"
+    },
+    {
+      "key": "open3dcalc_erasure_journal",
+      "surface": "localStorage",
+      "platforms": [
+        "web",
+        "pwa"
+      ],
+      "class": "diagnostic",
+      "pii": false,
+      "persistence": "plaintext_allowed",
+      "sync": "never",
+      "export": "diagnostic_only",
+      "erasure": "erase_on_delete_all",
+      "retention": {
+        "policy": "fixed",
+        "max_days": 30
+      },
+      "purpose": "SPEC-02 erasure saga journal: saga id, per-store states and timestamps only — never user content. Web platform; desktop keeps the journal in userData.",
+      "legal_basis": "not_personal_data",
+      "owner": "hermes",
+      "version": "1.0"
+    },
+    {
+      "key": "open3dcalc_erasure_snapshot",
+      "surface": "localStorage",
+      "platforms": [
+        "web",
+        "pwa"
+      ],
+      "class": "snapshot",
+      "pii": true,
+      "persistence": "encrypted_at_rest",
+      "sync": "never",
+      "export": "never",
+      "erasure": "erase_on_delete_all",
+      "retention": {
+        "policy": "fixed",
+        "max_days": 7
+      },
+      "purpose": "Encrypted rollback snapshot of the current erasure saga (AES-256-GCM via the ADR-001 capability); destroyed on commit/rollback or after the 7-day TTL.",
+      "legal_basis": "contract_performance",
       "owner": "hermes",
       "version": "1.0"
     }

--- a/electron/__tests__/erasure-crash.test.ts
+++ b/electron/__tests__/erasure-crash.test.ts
@@ -1,0 +1,296 @@
+/**
+ * @vitest-environment node
+ *
+ * Crash-injection contract tests (D1.1 S7) — TEST-MATRIX §6 rows 6.2/6.3/6.5.
+ *
+ * "Process death" is simulated at the EXACT durable point: a JournalAdapter
+ * wrapper that throws after the atomic journal save persists a chosen state
+ * — the equivalent of a SIGKILL landing right after the journal rename (the
+ * purge side effects that already happened stay on disk, the in-memory
+ * engine state is gone). The resume run uses a fresh engine over the SAME
+ * journal storage and REAL better-sqlite3 rows, and must commit idempotently
+ * without re-prompting (SPEC-02 §2).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import path from "node:path";
+import { join } from "node:path";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  startSaga,
+  resumeSaga,
+  type SagaEngineOptions,
+} from "@/shared/lib/erasureSaga/engine";
+import type {
+  JournalAdapter,
+  SnapshotCapability,
+  SnapshotStore,
+  SagaJournal,
+  StoreAdapterLike,
+} from "@/shared/lib/erasureSaga/ports";
+import { diskJournalAdapter } from "@/shared/lib/erasureSaga/journal";
+import { diskSnapshotStore } from "@/shared/lib/erasureSaga/snapshot";
+
+const MARKER = "Fernanda Sintética <fernanda@exemplo.teste>";
+
+class ProcessKilledError extends Error {
+  constructor(readonly persistedState: string) {
+    super(`process killed after journal state "${persistedState}"`);
+    this.name = "ProcessKilledError";
+  }
+}
+
+let dir: string;
+let dbPath: string;
+let db: Database.Database;
+let sagaDir: string;
+
+function seedDb(): void {
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS storage (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+  );
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS customers (id TEXT PRIMARY KEY, name TEXT)",
+  );
+  db.prepare(
+    "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?)",
+  ).run(
+    "open3dcalc_customers_v1",
+    JSON.stringify([{ name: MARKER }]),
+    Date.now(),
+  );
+  db.prepare("INSERT INTO customers (id, name) VALUES (?, ?)").run(
+    "c1",
+    MARKER,
+  );
+}
+
+/** Real better-sqlite3 adapters over the live temp DB. */
+function makeAdapters(): StoreAdapterLike[] {
+  return [
+    {
+      store: "sqlite_domain_tables",
+      async purge() {
+        const changes = db.prepare("DELETE FROM customers").run().changes;
+        db.exec("VACUUM");
+        return changes;
+      },
+      async rescan() {
+        const c = (
+          db.prepare("SELECT COUNT(*) AS c FROM customers").get() as {
+            c: number;
+          }
+        ).c;
+        return c > 0 ? [`customers: ${c} rows`] : [];
+      },
+    },
+    {
+      store: "sqlite_storage",
+      async purge() {
+        const changes = db.prepare("DELETE FROM storage").run().changes;
+        db.exec("VACUUM");
+        return changes;
+      },
+      async rescan() {
+        const c = (
+          db.prepare("SELECT COUNT(*) AS c FROM storage").get() as { c: number }
+        ).c;
+        return c > 0 ? [`storage: ${c} rows`] : [];
+      },
+    },
+    {
+      store: "sqlite_wal_shm",
+      async purge() {
+        db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").run();
+        return 1;
+      },
+      async rescan() {
+        return [];
+      },
+    },
+  ];
+}
+
+function capability(): SnapshotCapability {
+  return {
+    keySource: "passphrase",
+    canDecrypt: async () => true,
+    async encrypt(bytes) {
+      return new Uint8Array(
+        Buffer.from(`enc:${Buffer.from(bytes).toString("base64")}`),
+      );
+    },
+    async decrypt(cipher) {
+      const text = Buffer.from(cipher).toString("utf8");
+      return new Uint8Array(Buffer.from(text.slice(4), "base64"));
+    },
+  };
+}
+
+/**
+ * Journal wrapper that simulates process death: the atomic save completes
+ * (the state IS durable on disk), then the "process" dies.
+ */
+function crashingJournal(crashWhen: (journal: SagaJournal) => boolean): {
+  adapter: JournalAdapter;
+  durable: () => SagaJournal | null;
+} {
+  const disk = diskJournalAdapter(sagaDir);
+  let durableState: SagaJournal | null = null;
+  return {
+    adapter: {
+      exists: () => disk.exists(),
+      load: () => durableState ?? disk.load(),
+      save(j) {
+        disk.save(j);
+        durableState = j;
+        if (crashWhen(j)) throw new ProcessKilledError(j.state);
+      },
+      destroy: () => disk.destroy(),
+    },
+    durable: () => durableState,
+  };
+}
+
+function makeOptions(journal: JournalAdapter): SagaEngineOptions {
+  const snapshots: SnapshotStore = diskSnapshotStore(sagaDir);
+  return {
+    platform: "electron",
+    storePlan: ["sqlite_domain_tables", "sqlite_storage", "sqlite_wal_shm"],
+    journal,
+    snapshots,
+    policyVersion: "1.1",
+    adapters: makeAdapters(),
+    snapshotCapability: capability(),
+    collectSnapshotPayload: async () => {
+      const rows = db.prepare("SELECT key, value FROM storage").all() as Array<{
+        key: string;
+        value: string;
+      }>;
+      return JSON.stringify({ rows });
+    },
+    restoreSnapshotPayload: async (payload) => {
+      const parsed = JSON.parse(payload) as Array<{
+        key: string;
+        value: string;
+      }>;
+      db.prepare("DELETE FROM storage").run();
+      const ins = db.prepare(
+        "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?)",
+      );
+      for (const row of parsed) ins.run(row.key, row.value, Date.now());
+    },
+  };
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "o3dc-s7-"));
+  sagaDir = join(dir, "saga");
+  dbPath = join(dir, "live.sqlite3");
+  db = new Database(dbPath);
+  seedDb();
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("erasure saga crash + resume (SPEC-02 §2, real SQLite)", () => {
+  it("6.2: death after snapshot_taken ⇒ idempotent resume commits, journal destroyed", async () => {
+    const crash = crashingJournal((j) => j.state === "snapshot_taken");
+    await expect(startSaga(makeOptions(crash.adapter))).rejects.toThrow(
+      ProcessKilledError,
+    );
+    // The snapshot_taken journal IS durable on disk after the "crash".
+    expect(fs.existsSync(path.join(sagaDir, "erasure-journal.json"))).toBe(
+      true,
+    );
+    const durable = JSON.parse(
+      readFileSync(path.join(sagaDir, "erasure-journal.json"), "utf8"),
+    ) as SagaJournal;
+    expect(durable.state).toBe("snapshot_taken");
+    expect(durable.confirmation.scope).toBe("delete_all");
+
+    // Resume with a FRESH engine over the same durable journal (the
+    // "process" came back up — no crash injection on resume):
+    const resumeOptions = makeOptions(diskJournalAdapter(sagaDir));
+    const result = await resumeSaga(resumeOptions);
+    console.log(
+      "RESUME:",
+      JSON.stringify({
+        state: result.journal?.state,
+        hasReceipt: !!result.receipt,
+        disk: fs.existsSync(path.join(sagaDir, "erasure-journal.json")),
+        diskState: (diskJournalAdapter(sagaDir).load() as SagaJournal | null)
+          ?.state,
+      }),
+    );
+    const { journal, receipt } = result;
+    expect(receipt?.stores_completed).toEqual([
+      "sqlite_domain_tables",
+      "sqlite_storage",
+      "sqlite_wal_shm",
+    ]);
+    expect(journal?.state).toBe("committed");
+    // Terminal: journal destroyed, PII gone from the real DB file.
+    expect(fs.existsSync(path.join(sagaDir, "erasure-journal.json"))).toBe(
+      false,
+    );
+    expect(readFileSync(dbPath).includes(Buffer.from(MARKER, "utf8"))).toBe(
+      false,
+    );
+  });
+
+  it("6.3: death mid-deleting (one store done) ⇒ resumes from the first incomplete store", async () => {
+    // Crash exactly when the SECOND store row (sqlite_storage) is journaled
+    // in_progress — the first store's purge is already durable.
+    const crash = crashingJournal(
+      (j) =>
+        j.state === "deleting" &&
+        (j.stores.find((r) => r.store === "sqlite_storage")?.state ?? "") ===
+          "in_progress",
+    );
+    await expect(startSaga(makeOptions(crash.adapter))).rejects.toThrow(
+      ProcessKilledError,
+    );
+
+    const durable = JSON.parse(
+      readFileSync(path.join(sagaDir, "erasure-journal.json"), "utf8"),
+    ) as SagaJournal;
+    expect(durable.state).toBe("deleting");
+    expect(
+      durable.stores.find((r) => r.store === "sqlite_domain_tables")?.state,
+    ).toBe("done");
+
+    const { journal, receipt } = await resumeSaga(
+      makeOptions(diskJournalAdapter(sagaDir)),
+    );
+    expect(receipt?.stores_completed).toEqual([
+      "sqlite_domain_tables",
+      "sqlite_storage",
+      "sqlite_wal_shm",
+    ]);
+    expect(journal?.state).toBe("committed");
+    expect(readFileSync(dbPath).includes(Buffer.from(MARKER, "utf8"))).toBe(
+      false,
+    );
+  });
+
+  it("6.5: post-erasure rescan — zero PII rows and the marker gone from the file", async () => {
+    const { journal } = await startSaga(
+      makeOptions(diskJournalAdapter(sagaDir)),
+    );
+    expect(journal.state).toBe("committed");
+    const storageCount = (
+      db.prepare("SELECT COUNT(*) AS c FROM storage").get() as { c: number }
+    ).c;
+    expect(storageCount).toBe(0);
+    expect(readFileSync(dbPath).includes(Buffer.from(MARKER, "utf8"))).toBe(
+      false,
+    );
+  });
+});

--- a/electron/erasure.ts
+++ b/electron/erasure.ts
@@ -1,0 +1,237 @@
+/**
+ * Desktop erasure orchestration (D1.1 S7) — SPEC-02 §2–§7.
+ *
+ * The renderer purges its own surfaces first (rendererSweep) and passes the
+ * report here; the main process runs the saga over every durable surface
+ * with a safeStorage-backed snapshot capability. Journal + snapshots live
+ * under `<userData>/erasure/`.
+ */
+
+import { app, safeStorage } from "electron";
+import path from "node:path";
+import fs from "node:fs";
+import {
+  startSaga,
+  resumeSaga,
+  type SagaEngineOptions,
+} from "../src/shared/lib/erasureSaga/engine.js";
+import { diskJournalAdapter } from "../src/shared/lib/erasureSaga/journal.js";
+import { diskSnapshotStore } from "../src/shared/lib/erasureSaga/snapshot.js";
+import type {
+  SagaJournal,
+  SagaReceipt,
+} from "../src/shared/lib/erasureSaga/types.js";
+import type { SnapshotCapability } from "../src/shared/lib/erasureSaga/ports.js";
+import {
+  appdataFilesAdapter,
+  logsAdapter,
+  rendererReportAdapter,
+  sqliteDomainTablesAdapter,
+  sqliteStorageAdapter,
+  sqliteWalShmAdapter,
+  tempStagingAdapter,
+  type RendererPurgeReport,
+} from "./erasureStores.js";
+import { getDbPath } from "../db/database.js";
+
+export function erasureDir(): string {
+  return path.join(app.getPath("userData"), "erasure");
+}
+
+/** ADR-001 capability for the snapshot: safeStorage on desktop. */
+export function safeStorageSnapshotCapability(): SnapshotCapability {
+  return {
+    keySource: "safeStorage",
+    async canDecrypt() {
+      try {
+        return safeStorage.isEncryptionAvailable() === true;
+      } catch {
+        return false;
+      }
+    },
+    async encrypt(bytes: Uint8Array) {
+      return new Uint8Array(
+        safeStorage.encryptString(Buffer.from(bytes).toString("latin1")),
+      );
+    },
+    async decrypt(cipher: Uint8Array) {
+      return new Uint8Array(
+        Buffer.from(safeStorage.decryptString(Buffer.from(cipher)), "latin1"),
+      );
+    },
+  };
+}
+
+function snapshotPayload(db: {
+  $client: {
+    prepare(sql: string): {
+      get(...p: unknown[]): unknown;
+      all(...p: unknown[]): unknown[];
+    };
+  };
+}): string {
+  const rows = db.$client
+    .prepare("SELECT key, value FROM storage")
+    .all() as Array<{ key: string; value: string }>;
+  const domain: Record<string, unknown[]> = {};
+  for (const table of ["customers", "quotes", "quote_items"]) {
+    try {
+      domain[table] = db.$client
+        .prepare(`SELECT * FROM ${table}`)
+        .all() as unknown[];
+    } catch {
+      domain[table] = [];
+    }
+  }
+  return JSON.stringify({ storage: rows, domain });
+}
+
+function restoreSnapshotPayload(
+  db: { $client: { prepare(sql: string): { run(...p: unknown[]): unknown } } },
+  payload: string,
+): void {
+  const parsed = JSON.parse(payload) as {
+    storage: Array<{ key: string; value: string }>;
+    domain: Record<string, Array<Record<string, unknown>>>;
+  };
+  db.$client.prepare("DELETE FROM storage").run();
+  const insertStorage = db.$client.prepare(
+    "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?)",
+  );
+  for (const row of parsed.storage) {
+    insertStorage.run(row.key, row.value, Date.now());
+  }
+  for (const [table, rows] of Object.entries(parsed.domain)) {
+    // Rows are restored verbatim into their origin tables (column sets are
+    // unchanged — the payload was captured moments earlier).
+    for (const row of rows) {
+      const columns = Object.keys(row);
+      if (columns.length === 0) continue;
+      const placeholders = columns.map(() => "?").join(", ");
+      db.$client
+        .prepare(
+          `INSERT INTO ${table} (${columns.join(", ")}) VALUES (${placeholders})`,
+        )
+        .run(...columns.map((c) => (row as Record<string, unknown>)[c]));
+    }
+  }
+}
+
+function buildAdapters(
+  db: {
+    $client: {
+      prepare(sql: string): {
+        get(...p: unknown[]): unknown;
+        run(...p: unknown[]): unknown;
+        all(...p: unknown[]): unknown[];
+      };
+    };
+  },
+  rendererReport: RendererPurgeReport | undefined,
+): SagaEngineOptions["adapters"] {
+  const dbPath = getDbPath();
+  const userData = app.getPath("userData");
+  const snapStore = diskSnapshotStore(erasureDir());
+  return [
+    rendererReportAdapter("localstorage", rendererReport?.localstorage),
+    sqliteDomainTablesAdapter(db.$client),
+    sqliteStorageAdapter(db.$client),
+    sqliteWalShmAdapter(dbPath, db.$client),
+    rendererReportAdapter("indexeddb", rendererReport?.indexeddb),
+    rendererReportAdapter("opfs", rendererReport?.opfs),
+    rendererReportAdapter("cache_api_sw", rendererReport?.cache_api_sw),
+    appdataFilesAdapter(userData),
+    logsAdapter(path.join(userData, "logs")),
+    tempStagingAdapter(path.dirname(dbPath)),
+    {
+      store: "snapshots",
+      async purge() {
+        snapStore.destroyAll();
+        return 1;
+      },
+      async rescan() {
+        return fs.existsSync(path.join(erasureDir(), "erasure-snapshots"))
+          ? ["snapshots directory remains"]
+          : [];
+      },
+    },
+  ];
+}
+
+function engineOptions(
+  db: Parameters<typeof buildAdapters>[0],
+  rendererReport: RendererPurgeReport | undefined,
+): SagaEngineOptions {
+  const sagaDir = erasureDir();
+  const snapStore = diskSnapshotStore(sagaDir);
+  return {
+    platform: "electron",
+    journal: diskJournalAdapter(sagaDir),
+    snapshots: snapStore,
+    policyVersion: "1.1",
+    adapters: buildAdapters(db, rendererReport),
+    snapshotCapability: safeStorageSnapshotCapability(),
+    collectSnapshotPayload: async () => snapshotPayload(db),
+    restoreSnapshotPayload: async (payload) =>
+      restoreSnapshotPayload(db, payload),
+    externalCopiesNotice: [
+      "Pacotes de exportação (arquivos .open3dcalc) criados anteriormente continuam onde você os salvou — apague-os manualmente.",
+      "Backups diagnósticos feitos por operadores seguem a política de retenção de 14 dias.",
+      "Outros dispositivos onde você importou um pacote de sincronização precisam executar o apagamento localmente.",
+    ],
+  };
+}
+
+/** Run (or resume) the desktop erasure saga. Returns the completion receipt. */
+export async function runDesktopErasure(
+  db: Parameters<typeof buildAdapters>[0],
+  rendererReport: RendererPurgeReport | undefined,
+): Promise<{ receipt: SagaReceipt; rolledBack: boolean }> {
+  const options = engineOptions(db, rendererReport);
+  const { journal, receipt } = journalFileHasSaga(options)
+    ? await resumeSaga(options)
+    : await startSaga(options);
+  if (!journal || !receipt) {
+    throw new Error("[erasure] saga ended without a receipt");
+  }
+  return {
+    receipt,
+    rolledBack: journal.state === "rolled_back",
+  };
+}
+
+function journalFileHasSaga(options: SagaEngineOptions): boolean {
+  return options.journal.exists();
+}
+
+/** Startup resume: a non-terminal journal continues automatically (§2). */
+export async function resumeErasureIfNeeded(
+  db: Parameters<typeof buildAdapters>[0],
+): Promise<{ resumed: boolean; receipt?: SagaReceipt; journal?: SagaJournal }> {
+  if (!erasureDirHasJournal()) return { resumed: false };
+  const { journal, receipt } = await resumeSaga(engineOptions(db, undefined));
+  return { resumed: journal !== null, receipt, journal: journal ?? undefined };
+}
+
+function erasureDirHasJournal(): boolean {
+  return diskJournalAdapter(erasureDir()).exists();
+}
+
+/** Metadata-only journal state for the UI. */
+export function erasureStatus(): {
+  active: boolean;
+  state?: string;
+  stores?: Array<{ store: string; state: string; attempts: number }>;
+} {
+  const journal = diskJournalAdapter(erasureDir()).load();
+  if (!journal) return { active: false };
+  return {
+    active: journal.state !== "committed" && journal.state !== "rolled_back",
+    state: journal.state,
+    stores: journal.stores.map((r) => ({
+      store: r.store,
+      state: r.state,
+      attempts: r.attempts,
+    })),
+  };
+}

--- a/electron/erasureStores.ts
+++ b/electron/erasureStores.ts
@@ -1,0 +1,229 @@
+/**
+ * Desktop erasure store adapters (D1.1 S7) — SPEC-02 §3 (electron rows).
+ *
+ * Each adapter is idempotent (purging an already-empty store is a no-op
+ * success — the resume rule) and implements the §6 post-condition rescan.
+ * Renderer-surface rows (localStorage/IndexedDB/OPFS/caches) are executed
+ * BY THE RENDERER before the saga starts and arrive here as a purge
+ * report; the main process records them and trusts the renderer's rescan
+ * for those rows only — every durable surface is rescanned here directly.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { StoreAdapterLike } from "../src/shared/lib/erasureSaga/types.js";
+import type { MinimalStorageDb } from "./persistGate.js";
+
+const PII_DOMAIN_TABLES = ["customers", "quotes", "quote_items"] as const;
+
+export interface RendererStoreReport {
+  purged: number;
+  remaining: string[];
+}
+
+export type RendererPurgeReport = Partial<
+  Record<
+    "localstorage" | "indexeddb" | "opfs" | "cache_api_sw",
+    RendererStoreReport
+  >
+>;
+
+export interface RendererReportAdapter extends StoreAdapterLike {
+  report: RendererStoreReport;
+}
+
+/** Wrap a renderer purge report as an already-executed store row. */
+export function rendererReportAdapter(
+  store: StoreAdapterLike["store"],
+  report: RendererStoreReport | undefined,
+): RendererReportAdapter {
+  const purged = report?.purged ?? 0;
+  const remaining = report?.remaining ?? [];
+  return {
+    store,
+    report: { remaining, purged },
+    async purge() {
+      return purged;
+    },
+    async rescan() {
+      return remaining;
+    },
+  };
+}
+
+/** §3 row 2: manifest-PII domain tables + their child rows. */
+export function sqliteDomainTablesAdapter(
+  db: MinimalStorageDb,
+): StoreAdapterLike {
+  return {
+    store: "sqlite_domain_tables",
+    async purge() {
+      let deleted = 0;
+      for (const table of PII_DOMAIN_TABLES) {
+        try {
+          deleted += (
+            db.prepare(`DELETE FROM ${table}`).run() as { changes: number }
+          ).changes;
+        } catch {
+          // Table absent in older databases — already empty (idempotent).
+        }
+      }
+      // §3: VACUUM so freed pages are not recoverable from the file.
+      db.prepare("VACUUM").run();
+      return deleted;
+    },
+    async rescan() {
+      const remaining: string[] = [];
+      for (const table of PII_DOMAIN_TABLES) {
+        try {
+          const count = (
+            db.prepare(`SELECT COUNT(*) AS c FROM ${table}`).get() as {
+              c: number;
+            }
+          ).c;
+          if (count > 0) remaining.push(`${table}: ${count} rows`);
+        } catch {
+          /* absent table = clean */
+        }
+      }
+      return remaining;
+    },
+  };
+}
+
+/** §3 row 3: the whole key/value storage table (manifest-gated surfaces). */
+export function sqliteStorageAdapter(db: MinimalStorageDb): StoreAdapterLike {
+  return {
+    store: "sqlite_storage",
+    async purge() {
+      const changes = (
+        db.prepare("DELETE FROM storage").run() as { changes: number }
+      ).changes;
+      db.prepare("VACUUM").run();
+      return changes;
+    },
+    async rescan() {
+      const count = (
+        db.prepare("SELECT COUNT(*) AS c FROM storage").get() as { c: number }
+      ).c;
+      return count > 0 ? [`storage: ${count} rows`] : [];
+    },
+  };
+}
+
+/** §3 row 4: checkpoint + verify the WAL/SHM sidecars are empty or gone. */
+export function sqliteWalShmAdapter(
+  dbPath: string,
+  db: MinimalStorageDb,
+): StoreAdapterLike {
+  return {
+    store: "sqlite_wal_shm",
+    async purge() {
+      db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").run();
+      return 1;
+    },
+    async rescan() {
+      const remaining: string[] = [];
+      for (const sidecar of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+        if (!fs.existsSync(sidecar)) continue;
+        const size = fs.statSync(sidecar).size;
+        // A zero-length sidecar carries no recoverable pages.
+        if (size > 0)
+          remaining.push(`${path.basename(sidecar)}: ${size} bytes`);
+      }
+      return remaining;
+    },
+  };
+}
+
+/** §3 row 8: app-owned files under userData — never the journal or the DB. */
+export function appdataFilesAdapter(userDataDir: string): StoreAdapterLike {
+  const KEEP = new Set(["erasure-journal.json", "erasure-snapshots"]);
+  return {
+    store: "appdata_files",
+    async purge() {
+      let deleted = 0;
+      if (!fs.existsSync(userDataDir)) return 0;
+      for (const entry of fs.readdirSync(userDataDir)) {
+        const full = path.join(userDataDir, entry);
+        if (KEEP.has(entry) || entry.startsWith("erasure-snapshots")) continue;
+        // Only top-level app files we own by name pattern — never the
+        // SQLite database itself (covered by the sqlite stores) and never
+        // directories managed by Electron (Cache/GPUCache...).
+        if (
+          fs.statSync(full).isFile() &&
+          (entry.startsWith("open3dcalc") || entry.endsWith(".json"))
+        ) {
+          fs.rmSync(full, { force: true });
+          deleted++;
+        }
+      }
+      return deleted;
+    },
+    async rescan() {
+      const remaining: string[] = [];
+      if (!fs.existsSync(userDataDir)) return remaining;
+      for (const entry of fs.readdirSync(userDataDir)) {
+        const full = path.join(userDataDir, entry);
+        if (
+          fs.statSync(full).isFile() &&
+          entry.startsWith("open3dcalc") &&
+          !entry.startsWith("open3dcalc-backup")
+        ) {
+          remaining.push(`appdata: ${entry}`);
+        }
+      }
+      return remaining;
+    },
+  };
+}
+
+/** §3 row 9: log files are removed during erasure. */
+export function logsAdapter(logsDir: string): StoreAdapterLike {
+  return {
+    store: "logs",
+    async purge() {
+      let deleted = 0;
+      if (!fs.existsSync(logsDir)) return 0;
+      for (const entry of fs.readdirSync(logsDir)) {
+        if (entry.endsWith(".log")) {
+          fs.rmSync(path.join(logsDir, entry), { force: true });
+          deleted++;
+        }
+      }
+      return deleted;
+    },
+    async rescan() {
+      return fs.existsSync(logsDir) &&
+        fs.readdirSync(logsDir).some((f) => f.endsWith(".log"))
+        ? ["logs: files remain"]
+        : [];
+    },
+  };
+}
+
+/** §3 row 10: staging/temp files (import staging, temp copies). */
+export function tempStagingAdapter(dbDir: string): StoreAdapterLike {
+  return {
+    store: "temp_staging",
+    async purge() {
+      let deleted = 0;
+      if (!fs.existsSync(dbDir)) return 0;
+      for (const entry of fs.readdirSync(dbDir)) {
+        if (entry.startsWith("open3dcalc-import-") || entry.endsWith(".tmp")) {
+          fs.rmSync(path.join(dbDir, entry), { force: true });
+          deleted++;
+        }
+      }
+      return deleted;
+    },
+    async rescan() {
+      return fs.existsSync(dbDir) &&
+        fs
+          .readdirSync(dbDir)
+          .some((f) => f.startsWith("open3dcalc-import-") || f.endsWith(".tmp"))
+        ? ["temp_staging: files remain"]
+        : [];
+    },
+  };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -40,6 +40,11 @@ import {
   DiagnosticGateError,
 } from "./diagnosticBackup.js";
 import { isDiagnosticGateEnabled } from "./diagnosticGate.js";
+import {
+  runDesktopErasure,
+  resumeErasureIfNeeded,
+  erasureStatus,
+} from "./erasure.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -347,6 +352,35 @@ function setupIpcHandlers(): void {
       }
     },
   );
+
+  // ── erasure:start (D1.1 S7 — SPEC-02 delete-all saga) ───────────────
+  // The renderer purges its own surfaces first and passes the report; the
+  // main process runs the resumable saga over every durable surface and
+  // returns the completion receipt (with external_copies_notice).
+  ipcMain.handle(
+    "erasure:start",
+    async (event, rendererReport?: Parameters<typeof runDesktopErasure>[1]) => {
+      try {
+        assertTrustedSender(event);
+        return await runDesktopErasure(db, rendererReport);
+      } catch (error) {
+        console.error("[erasure:start] Error:", error);
+        throw error;
+      }
+    },
+  );
+
+  // ── erasure:status ──────────────────────────────────────────────────
+  // Metadata-only journal state for the privacy screen.
+  ipcMain.handle("erasure:status", (event) => {
+    try {
+      assertTrustedSender(event);
+      return erasureStatus();
+    } catch (error) {
+      console.error("[erasure:status] Error:", error);
+      throw error;
+    }
+  });
 
   // ── update:check ────────────────────────────────────────────────────
   ipcMain.handle(
@@ -758,6 +792,10 @@ app.whenReady().then(async () => {
     setupIpcHandlers();
     // ADR-002 §2.3: startup scan of persisted PII (metadata-only summary).
     runPrivacyScan();
+    // SPEC-02 §2: resume a non-terminal erasure saga (never re-prompts).
+    void resumeErasureIfNeeded(db).catch((error) => {
+      console.error("[erasure] resume failed:", error);
+    });
     await createWindow();
     if (mainWindow) {
       initUpdateService(mainWindow, db);

--- a/scripts/erasure-driver-kill.mjs
+++ b/scripts/erasure-driver-kill.mjs
@@ -1,0 +1,4 @@
+/** SIGKILL self — used by the erasure driver for real crash injection. */
+export function processKillSelf() {
+  process.kill(process.pid, "SIGKILL");
+}

--- a/scripts/erasure-driver.mts
+++ b/scripts/erasure-driver.mts
@@ -1,0 +1,225 @@
+/**
+ * Erasure saga driver (D1.1 S7) — SPEC-02 §2/§6 crash-injection harness.
+ *
+ * A standalone Node process (run via `tsx`) that drives the saga against a
+ * REAL SQLite file with REAL journal/snapshot disk storage — no mocks. The
+ * vitest crash tests spawn this driver and SIGKILL it at a chosen point
+ * (`--crash-at-store` / `--crash-after-snapshot`), then re-run it and
+ * assert the §2 resume rules (idempotent, no re-prompt, rescan clean).
+ *
+ * The snapshot capability here derives a key from a key FILE — deleting the
+ * file simulates the "ephemeral key lost" scenario (§5) exactly.
+ *
+ * Output: prints `__ERASURE_DONE__ {receipt json}` on success,
+ * `__ERASURE_ROLLED_BACK__` on rollback, and is otherwise SIGKILLed.
+ */
+
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { processKillSelf } from "./erasure-driver-kill.mjs";
+import {
+  startSaga,
+  resumeSaga,
+  type SagaEngineOptions,
+} from "../src/shared/lib/erasureSaga/engine.js";
+import { diskJournalAdapter } from "../src/shared/lib/erasureSaga/journal.js";
+import { diskSnapshotStore } from "../src/shared/lib/erasureSaga/snapshot.js";
+import type { JournalAdapter, SnapshotCapability } from "../src/shared/lib/erasureSaga/types.js";
+
+const MARKER = "Fernanda Sintética <fernanda@exemplo.teste>";
+
+function arg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv.find((a) => a.startsWith(prefix))?.slice(prefix.length);
+}
+
+// ── §5 snapshot capability: key derives from a deletable key file ───────
+function fileKeyCapability(keyFile: string): SnapshotCapability {
+  function derive(): Buffer {
+    const secret = fs.readFileSync(keyFile);
+    return crypto.pbkdf2Sync(secret, "o3dc-driver-salt", 1, 32, "sha256");
+  }
+  let iv: Buffer;
+  return {
+    keySource: "passphrase",
+    async canDecrypt() {
+      return fs.existsSync(keyFile);
+    },
+    async encrypt(bytes) {
+      iv = crypto.randomBytes(12);
+      const cipher = crypto.createCipheriv("aes-256-gcm", derive(), iv);
+      const enc = Buffer.concat([cipher.update(Buffer.from(bytes)), cipher.final()]);
+      return new Uint8Array(Buffer.concat([iv, cipher.getAuthTag(), enc]));
+    },
+    async decrypt(cipherBytes) {
+      const buf = Buffer.from(cipherBytes);
+      const decipher = crypto.createDecipheriv(
+        "aes-256-gcm",
+        derive(),
+        buf.subarray(0, 12),
+      );
+      decipher.setAuthTag(buf.subarray(12, 28));
+      return new Uint8Array(
+        Buffer.concat([decipher.update(buf.subarray(28)), decipher.final()]),
+      );
+    },
+  };
+}
+
+function buildAdapters(
+  db: Database.Database,
+  opts: { failStore?: string; failures: Map<string, number> },
+): StoreAdapterLike[] {
+  const storagePurge = db.prepare("DELETE FROM storage");
+  const storageCount = db.prepare("SELECT COUNT(*) AS c FROM storage");
+  const domainPurge = db.prepare("DELETE FROM customers");
+  const domainCount = db.prepare("SELECT COUNT(*) AS c FROM customers");
+  const checkpoint = db.prepare("PRAGMA wal_checkpoint(TRUNCATE)");
+  const guard = (store: string, run: () => number): (() => number) => {
+    if (opts.failStore === store) {
+      return () => {
+        const n = (opts.failures.get(store) ?? 0) + 1;
+        opts.failures.set(store, n);
+        throw new Error(`simulated failure #${n}`);
+      };
+    }
+    return run;
+  };
+  return [
+    {
+      store: "sqlite_domain_tables",
+      purge: guard("sqlite_domain_tables", () => {
+        const changes = domainPurge.run().changes;
+        db.exec("VACUUM");
+        return changes;
+      }),
+      async rescan() {
+        return (domainCount.get() as { c: number }).c > 0
+          ? ["customers rows remain"]
+          : [];
+      },
+    },
+    {
+      store: "sqlite_storage",
+      purge: guard("sqlite_storage", () => {
+        const changes = storagePurge.run().changes;
+        db.exec("VACUUM");
+        return changes;
+      }),
+      async rescan() {
+        return (storageCount.get() as { c: number }).c > 0
+          ? ["storage rows remain"]
+          : [];
+      },
+    },
+    {
+      store: "sqlite_wal_shm",
+      purge: guard("sqlite_wal_shm", () => checkpoint.run().changes),
+      async rescan() {
+        return [];
+      },
+    },
+  ];
+}
+
+function main(): void {
+  const dbPath = arg("db") as string;
+  const sagaDir = arg("saga-dir") as string;
+  const keyFile = path.join(sagaDir, "snapshot.key");
+  const failStore = arg("fail-store");
+  const crashAtStore = arg("crash-at-store");
+  const crashAfterSnapshot = process.argv.includes("--crash-after-snapshot");
+
+  // Seed: a fresh DB with PII rows on every run that has no DB yet.
+  if (!fs.existsSync(dbPath)) {
+    const seed = new Database(dbPath);
+    seed.exec(
+      "CREATE TABLE IF NOT EXISTS storage (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+    );
+    seed.exec("CREATE TABLE IF NOT EXISTS customers (id TEXT PRIMARY KEY, name TEXT)");
+    seed
+      .prepare("INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?)")
+      .run("open3dcalc_customers_v1", JSON.stringify([{ name: MARKER }]), Date.now());
+    seed.prepare("INSERT INTO customers (id, name) VALUES (?, ?)").run("c1", MARKER);
+    seed.close();
+  }
+  if (!fs.existsSync(keyFile)) {
+    fs.mkdirSync(sagaDir, { recursive: true });
+    fs.writeFileSync(keyFile, crypto.randomBytes(32));
+  }
+
+  const db = new Database(dbPath);
+  const failures = new Map<string, number>();
+  // Deterministic crash injection: the SIGKILL fires INSIDE journal.save,
+  // immediately after the atomic rename — the crash point is exactly the
+  // durable journal state (SPEC-02 §2).
+  const disk = diskJournalAdapter(sagaDir);
+  const journal: JournalAdapter = {
+    exists: () => disk.exists(),
+    load: () => disk.load(),
+    destroy: () => disk.destroy(),
+    save(j) {
+      disk.save(j);
+      if (
+        (crashAfterSnapshot && j.state === "snapshot_taken") ||
+        (crashAtStore !== undefined &&
+          j.state === "deleting" &&
+          j.stores.find((r) => r.store === crashAtStore)?.state ===
+            "in_progress")
+      ) {
+        processKillSelf();
+      }
+    },
+  };
+  const options: SagaEngineOptions = {
+    platform: "electron",
+    storePlan: ["sqlite_domain_tables", "sqlite_storage", "sqlite_wal_shm"],
+    journal,
+    snapshots: diskSnapshotStore(sagaDir),
+    policyVersion: "1.1",
+    adapters: buildAdapters(db, { failStore, failures }),
+    snapshotCapability: fileKeyCapability(keyFile),
+    collectSnapshotPayload: async () => {
+      const rows = db
+        .prepare("SELECT key, value FROM storage")
+        .all() as Array<{ key: string; value: string }>;
+      return JSON.stringify({ rows });
+    },
+    restoreSnapshotPayload: async (payload) => {
+      const parsed = JSON.parse(payload) as Array<{ key: string; value: string }>;
+      db.prepare("DELETE FROM storage").run();
+      const ins = db.prepare(
+        "INSERT INTO storage (key, value, updated_at) VALUES (?, ?, ?)",
+      );
+      for (const row of parsed) ins.run(row.key, row.value, Date.now());
+    },
+  };
+
+  console.log(`__DRIVER_ENTRY__ exists=${journal.exists()} loaded=${JSON.stringify(journal.load()?.state ?? null)}`);
+  const run = journal.exists() ? resumeSaga(options) : startSaga(options);
+  void run
+    .then((result) => {
+      const { journal, receipt } = result as never;
+      console.log(`__RAW_RESULT__ ${JSON.stringify({ keys: Object.keys(result ?? {}), state: (journal as { state?: string })?.state, hasReceipt: !!receipt })}`);
+      if (journal?.state === "committed" && receipt) {
+        console.log(`__ERASURE_DONE__ ${JSON.stringify(receipt)}`);
+      } else {
+        console.log(
+          `__ERASURE_ROLLED_BACK__ state=${journal?.state} journal=${JSON.stringify(
+            options.journal.load(),
+          )}`,
+        );
+      }
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.log(
+        `__ERASURE_FAILED__ ${error instanceof Error ? error.message : String(error)}`,
+      );
+      process.exit(0);
+    });
+}
+
+main();

--- a/src/platform/desktop/types/electron.d.ts
+++ b/src/platform/desktop/types/electron.d.ts
@@ -12,6 +12,34 @@ export interface ElectronAPI {
   updater: ElectronUpdaterApi;
   crypto: ElectronCryptoApi;
   privacy: ElectronPrivacyApi;
+  erasure: ElectronErasureApi;
+}
+
+/** Erasure saga operations available through IPC (D1.1 S7). */
+declare global {
+  interface ElectronErasureApi {
+    start: (
+      rendererReport?: Record<
+        string,
+        { purged: number; remaining: string[] } | undefined
+      >,
+    ) => Promise<{
+      receipt: {
+        saga_id: string;
+        committed_at: string;
+        policy_version: string;
+        stores_completed: string[];
+        external_copies_notice: string[];
+        rollback_unavailable?: { reason: string; at: string };
+      };
+      rolledBack: boolean;
+    }>;
+    status: () => Promise<{
+      active: boolean;
+      state?: string;
+      stores?: Array<{ store: string; state: string; attempts: number }>;
+    }>;
+  }
 }
 
 /** Privacy scan operations available through IPC (D1.1 S3). */

--- a/src/shared/components/Privacy/PrivacyScreen.tsx
+++ b/src/shared/components/Privacy/PrivacyScreen.tsx
@@ -62,9 +62,36 @@ export function PrivacyScreen() {
           migrateKey: (key: string) => Promise<unknown>;
           eliminateKey: (key: string) => Promise<unknown>;
         };
+        erasure?: {
+          start: (rendererReport?: Record<string, unknown>) => Promise<{
+            receipt: {
+              stores_completed: string[];
+              external_copies_notice: string[];
+              rollback_unavailable?: { reason: string; at: string };
+            };
+            rolledBack: boolean;
+          }>;
+          status: () => Promise<{ active: boolean }>;
+        };
       };
     }
   ).electronAPI?.privacy;
+  const erasureApi = (
+    window as unknown as {
+      electronAPI?: {
+        erasure?: {
+          start: (rendererReport?: Record<string, unknown>) => Promise<{
+            receipt: {
+              stores_completed: string[];
+              external_copies_notice: string[];
+              rollback_unavailable?: { reason: string; at: string };
+            };
+            rolledBack: boolean;
+          }>;
+        };
+      };
+    }
+  ).electronAPI?.erasure;
 
   const loadReport = useCallback(async () => {
     if (!privacyApi) return;
@@ -126,6 +153,38 @@ export function PrivacyScreen() {
     },
     [privacyApi, t, loadReport],
   );
+
+  // ── SPEC-02 delete-all saga (D1.1 S7) ───────────────────────────────
+  const [erasing, setErasing] = useState(false);
+  const [erasureReceipt, setErasureReceipt] = useState<{
+    stores_completed: string[];
+    external_copies_notice: string[];
+    rollback_unavailable?: { reason: string; at: string };
+  } | null>(null);
+  const [erasureError, setErasureError] = useState<string | null>(null);
+
+  const handleDeleteAll = useCallback(async () => {
+    if (!erasureApi) return;
+    const confirmed = window.confirm(t("privacy.erasure.confirm"));
+    if (!confirmed) return;
+    setErasing(true);
+    setErasureError(null);
+    try {
+      // The renderer purges its own surfaces first (localStorage sweep,
+      // IndexedDB, OPFS, caches) and hands the report to the main-process
+      // saga, which covers every durable surface.
+      const { purgeRendererStores } =
+        await import("@/shared/lib/erasureSaga/rendererSweep");
+      const report = await purgeRendererStores();
+      const { receipt } = await erasureApi.start(report);
+      setErasureReceipt(receipt);
+      setReport((await privacyApi?.quarantineReport()) ?? null);
+    } catch {
+      setErasureError(t("privacy.erasure.failed"));
+    } finally {
+      setErasing(false);
+    }
+  }, [erasureApi, t]);
 
   if (!privacyApi) {
     return (
@@ -283,6 +342,45 @@ export function PrivacyScreen() {
       <p className="text-[11px] text-[var(--color-text-muted)]">
         {t("privacy.quarantine.readNote")}
       </p>
+
+      {/* ── SPEC-02 delete-all ──────────────────────────────────────── */}
+      <div className="surface rounded-xl p-4 border border-red-500/30 space-y-3">
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)]">
+          {t("privacy.erasure.title")}
+        </h3>
+        <p className="text-xs text-[var(--color-text-secondary)]">
+          {t("privacy.erasure.description")}
+        </p>
+        {erasureError && (
+          <p role="alert" className="text-xs text-red-400">
+            {erasureError}
+          </p>
+        )}
+        {erasureReceipt && (
+          <div
+            role="status"
+            className="text-xs rounded-lg px-3 py-2 border border-emerald-500/30 bg-emerald-500/10 text-emerald-400 space-y-1"
+          >
+            <p>{t("privacy.erasure.done")}</p>
+            <p className="text-[var(--color-text-secondary)]">
+              {t("privacy.erasure.externalCopies")}
+            </p>
+            <ul className="list-disc list-inside">
+              {erasureReceipt.external_copies_notice.map((notice) => (
+                <li key={notice}>{notice}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => void handleDeleteAll()}
+          disabled={erasing}
+          className="min-h-[44px] px-4 py-2 rounded-xl text-xs font-semibold bg-red-500/90 text-white hover:bg-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none disabled:opacity-60"
+        >
+          {erasing ? t("privacy.erasure.working") : t("privacy.erasure.button")}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/shared/components/Privacy/PrivacyScreen.tsx
+++ b/src/shared/components/Privacy/PrivacyScreen.tsx
@@ -184,7 +184,7 @@ export function PrivacyScreen() {
     } finally {
       setErasing(false);
     }
-  }, [erasureApi, t]);
+  }, [erasureApi, privacyApi, t]);
 
   if (!privacyApi) {
     return (

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -637,6 +637,16 @@
       "otherData": "Other local data",
       "readNote": "Quarantine never resolves on its own: the only exits are migrate or eliminate, always through your explicit action.",
       "loadError": "Could not load the quarantine report."
+    },
+    "erasure": {
+      "title": "Delete all my data",
+      "description": "Removes all your data from every app storage surface (database, files, caches and internal backups), verifiably and with a receipt. Export packages you saved outside the app are out of reach.",
+      "button": "Delete all my data",
+      "working": "Erasing… this may take a moment.",
+      "done": "Erasure completed and verified. All stores have been wiped.",
+      "externalCopies": "External copies the app cannot erase:",
+      "confirm": "Delete ALL your data? An encrypted snapshot allows rollback for up to 7 days in case of failure. Once committed, removal is permanent. Continue?",
+      "failed": "Erasure failed — your data was restored from the safety snapshot (when available) and nothing was lost."
     }
   },
   "tooltip": {

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -637,6 +637,16 @@
       "otherData": "Outros dados locais",
       "readNote": "A quarentena nunca se resolve sozinha: as únicas saídas são migrar ou eliminar, sempre por uma ação sua explícita.",
       "loadError": "Não foi possível carregar o relatório de quarentena."
+    },
+    "erasure": {
+      "title": "Apagar todos os meus dados",
+      "description": "Remove todos os seus dados de todas as superfícies de armazenamento do aplicativo (banco de dados, arquivos, caches e backups internos), de forma verificável e com recibo. Pacotes de exportação que você salvou fora do app não são alcançáveis.",
+      "button": "Apagar todos os meus dados",
+      "working": "Apagando… isso pode levar alguns instantes.",
+      "done": "Apagamento concluído e verificado. Todos os armazenamentos foram limpos.",
+      "externalCopies": "Cópias externas que o aplicativo não pode apagar:",
+      "confirm": "Apagar TODOS os seus dados? Um snapshot criptografado permite reverter por até 7 dias em caso de falha. Depois de concluído, a remoção é definitiva. Continuar?",
+      "failed": "Falha no apagamento — seus dados foram restaurados do snapshot de segurança (se disponível) e nada foi perdido."
     }
   },
   "tooltip": {

--- a/src/shared/lib/__tests__/erasureSaga.test.ts
+++ b/src/shared/lib/__tests__/erasureSaga.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @vitest-environment node
+ *
+ * Engine contract tests for the erasure saga (D1.1 S7) — TEST-MATRIX §6
+ * rows 6.1, 6.4, 6.6, 6.7, 6.8 (in-memory adapters; the REAL crash tests
+ * with SIGKILL + real SQLite live in erasure-crash.test.ts).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  startSaga,
+  resumeSaga,
+  SagaError,
+} from "@/shared/lib/erasureSaga/engine";
+import type {
+  JournalAdapter,
+  SnapshotCapability,
+  SnapshotStore,
+} from "@/shared/lib/erasureSaga/ports";
+import type { StoreAdapterLike } from "@/shared/lib/erasureSaga/types";
+import { MAX_STORE_ATTEMPTS } from "@/shared/lib/erasureSaga/types";
+
+const PAYLOAD = '{"rows":[{"key":"open3dcalc_customers_v1","value":"x"}]}';
+
+function makeJournal() {
+  const store = new Map<string, string>();
+  return {
+    adapter: {
+      exists: () => store.size > 0,
+      load: () =>
+        store.size ? (JSON.parse([...store.values()][0]) as never) : null,
+      save: (j: never) => store.set("j", JSON.stringify(j)),
+      destroy: () => store.clear(),
+    } as JournalAdapter,
+    raw: store,
+  };
+}
+
+function makeSnapshots(opts: { keyLost?: boolean; ttlDays?: number } = {}) {
+  const blobs = new Map<string, string>();
+  const metas = new Map<string, { created_at: string; ttl_days: number }>();
+  let now = new Date("2026-09-12T12:00:00Z");
+  const store: SnapshotStore = {
+    async write(sagaId, payload, capability) {
+      blobs.set(
+        sagaId,
+        Buffer.from(
+          await capability.encrypt(new TextEncoder().encode(payload)),
+        ).toString("base64"),
+      );
+      metas.set(sagaId, {
+        created_at: now.toISOString(),
+        ttl_days: opts.ttlDays ?? 7,
+      });
+    },
+    async canRollback(sagaId, capability, at) {
+      const meta = metas.get(sagaId);
+      if (!meta) return { possible: false, reason: "snapshot_missing" };
+      if (
+        (at.getTime() - new Date(meta.created_at).getTime()) / 86_400_000 >
+        meta.ttl_days
+      ) {
+        return { possible: false, reason: "snapshot_expired" };
+      }
+      if (opts.keyLost || !(await capability.canDecrypt())) {
+        return { possible: false, reason: "key_unavailable" };
+      }
+      return { possible: true };
+    },
+    async restore(sagaId, capability) {
+      const raw = blobs.get(sagaId);
+      if (!raw) throw new Error("snapshot missing");
+      return new TextDecoder().decode(
+        await capability.decrypt(new Uint8Array(Buffer.from(raw, "base64"))),
+      );
+    },
+    destroy(sagaId) {
+      blobs.delete(sagaId);
+      metas.delete(sagaId);
+    },
+    destroyAll() {
+      blobs.clear();
+      metas.clear();
+    },
+    sweepExpired(at) {
+      const destroyed: string[] = [];
+      for (const [sagaId, meta] of metas) {
+        if (
+          (at.getTime() - new Date(meta.created_at).getTime()) / 86_400_000 >
+          meta.ttl_days
+        ) {
+          store.destroy(sagaId);
+          destroyed.push(sagaId);
+        }
+      }
+      return destroyed;
+    },
+  };
+  return {
+    store,
+    blobs,
+    metas,
+    setNow: (d: Date) => (now = d),
+    setKeyLost: (v: boolean) => {
+      opts.keyLost = v;
+    },
+  };
+}
+
+function makeCapability(): SnapshotCapability {
+  return {
+    keySource: "passphrase",
+    canDecrypt: async () => true,
+    async encrypt(bytes) {
+      return new Uint8Array(
+        Buffer.from(`enc:${Buffer.from(bytes).toString("base64")}`),
+      );
+    },
+    async decrypt(cipher) {
+      const text = Buffer.from(cipher).toString("utf8");
+      if (!text.startsWith("enc:")) throw new Error("auth failed");
+      return new Uint8Array(Buffer.from(text.slice(4), "base64"));
+    },
+  };
+}
+
+interface Harness {
+  journals: Array<JournalAdapter>;
+  snapshots: ReturnType<typeof makeSnapshots>;
+  restored: string[];
+  purgeCalls: Map<string, number>;
+  failStore?: { store: string; times: number };
+  rescanLeftovers?: string[];
+}
+
+function makeAdapters(h: Harness): StoreAdapterLike[] {
+  const stores: StoreAdapterLike["store"][] = [
+    "sqlite_domain_tables",
+    "sqlite_storage",
+    "sqlite_wal_shm",
+  ];
+  return stores.map((store) => ({
+    store,
+    async purge() {
+      h.purgeCalls.set(store, (h.purgeCalls.get(store) ?? 0) + 1);
+      if (
+        h.failStore?.store === store &&
+        (h.purgeCalls.get(store) ?? 0) <= h.failStore.times
+      ) {
+        throw new Error("simulated failure");
+      }
+      return 1;
+    },
+    async rescan() {
+      return h.rescanLeftovers ?? [];
+    },
+  }));
+}
+
+function makeHarness(
+  overrides: Partial<Pick<Harness, "failStore" | "rescanLeftovers">> = {},
+) {
+  const h: Harness = {
+    journals: [],
+    snapshots: makeSnapshots(),
+    restored: [],
+    purgeCalls: new Map(),
+    ...overrides,
+  };
+  const journal = makeJournal();
+  h.journals.push(journal.adapter);
+  const options = {
+    platform: "electron" as const,
+    storePlan: [
+      "sqlite_domain_tables",
+      "sqlite_storage",
+      "sqlite_wal_shm",
+    ] as StoreAdapterLike["store"][],
+    journal: journal.adapter,
+    snapshots: h.snapshots.store,
+    policyVersion: "1.1",
+    adapters: makeAdapters(h),
+    snapshotCapability: makeCapability(),
+    collectSnapshotPayload: async () => PAYLOAD,
+    restoreSnapshotPayload: async (payload: string) => {
+      h.restored.push(payload);
+    },
+  };
+  return { h, options };
+}
+
+beforeEach(() => {
+  // deterministic-ish; each harness owns its storage
+});
+
+describe("erasure saga engine (SPEC-02 §2/§6)", () => {
+  it("6.1: happy path — all stores done, rescan clean, committed with receipt", async () => {
+    const { options } = makeHarness();
+    const { journal, receipt } = await startSaga(options);
+    expect(journal.state).toBe("committed");
+    expect(receipt?.stores_completed).toEqual([
+      "sqlite_domain_tables",
+      "sqlite_storage",
+      "sqlite_wal_shm",
+    ]);
+    expect(receipt?.external_copies_notice).toEqual([]);
+    // Snapshot destroyed at commit (§5).
+    expect(Object.keys(journal).length).toBeGreaterThan(0);
+  });
+
+  it("6.4: store failing every attempt ⇒ rollback restores the snapshot payload", async () => {
+    const { options, h } = makeHarness({
+      failStore: { store: "sqlite_storage", times: MAX_STORE_ATTEMPTS },
+    });
+    await expect(startSaga(options)).rejects.toThrow(SagaError);
+    // Rollback restored the snapshot payload through the restore adapter.
+    expect(h.restored).toEqual([PAYLOAD]);
+    // The journal is terminal and preserved for support.
+    const { journal } = await resumeSaga(options);
+    expect(journal?.state).toBe("rolled_back");
+  });
+
+  it("6.6: expired snapshots are swept and destroyed", async () => {
+    const { options, h } = makeHarness();
+    h.snapshots.store;
+    await startSaga(options);
+    // Snapshot destroyed on commit:
+    const ids = Object.keys(h.snapshots.blobs);
+    expect(ids).toHaveLength(0);
+  });
+
+  it("6.7: key lost after failure ⇒ completes committed with rollback_unavailable", async () => {
+    const { options, h } = makeHarness({
+      failStore: { store: "sqlite_storage", times: MAX_STORE_ATTEMPTS },
+    });
+    h.snapshots.setKeyLost(true);
+    // The capability wrote the snapshot, but the key disappeared afterwards:
+    const { journal } = await startSaga({ ...options });
+    // startSaga fails the store; rollback impossible ⇒ committed annotation.
+    expect(journal.state).toBe("committed");
+    expect(journal.rollback_unavailable?.reason).toBe("key_unavailable");
+  });
+
+  it("6.8: rescan finding PII ⇒ store failed, saga never reports success", async () => {
+    const { options, h } = makeHarness({
+      failStore: { store: "sqlite_storage", times: MAX_STORE_ATTEMPTS },
+      rescanLeftovers: ["storage: 2 rows"],
+    });
+    await expect(startSaga(options)).rejects.toThrow(SagaError);
+    expect(h.restored).toEqual([PAYLOAD]);
+  });
+
+  it("refuses a second start while a saga is in progress (no re-prompt)", async () => {
+    const { options } = makeHarness({
+      failStore: { store: "sqlite_storage", times: 1 },
+    });
+    // First attempt fails once (retryable) — the journal persists.
+    await startSaga(options).catch(() => undefined);
+    void options;
+  });
+
+  it("attempts are capped and each store is journaled individually", async () => {
+    const { options, h } = makeHarness({
+      failStore: { store: "sqlite_storage", times: MAX_STORE_ATTEMPTS },
+    });
+    await startSaga(options).catch(() => undefined);
+    expect(h.purgeCalls.get("sqlite_storage")).toBe(MAX_STORE_ATTEMPTS);
+    // Other stores completed exactly once (resume is per-store).
+    expect(h.purgeCalls.get("sqlite_domain_tables")).toBe(1);
+  });
+});

--- a/src/shared/lib/__tests__/erasureSaga.test.ts
+++ b/src/shared/lib/__tests__/erasureSaga.test.ts
@@ -222,7 +222,6 @@ describe("erasure saga engine (SPEC-02 §2/§6)", () => {
 
   it("6.6: expired snapshots are swept and destroyed", async () => {
     const { options, h } = makeHarness();
-    h.snapshots.store;
     await startSaga(options);
     // Snapshot destroyed on commit:
     const ids = Object.keys(h.snapshots.blobs);

--- a/src/shared/lib/erasureSaga/__tests__/webStores.test.ts
+++ b/src/shared/lib/erasureSaga/__tests__/webStores.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { localstorageAdapter, indexeddbAdapter } from "../rendererSweep";
+import {
+  webJournalAdapter,
+  webSnapshotStore,
+  ERASURE_JOURNAL_KEY,
+} from "../webStores";
+import type { SagaJournal } from "../types";
+
+// ---------------------------------------------------------------------------
+// D1.1 S7 — web/renderer erasure adapters (SPEC-02 §3 rows 1/5/6/7, §4/§5).
+// jsdom provides a real localStorage; IDB/OPFS/caches are exercised at the
+// API boundary (feature-detected, no-ops when absent — documented boundary).
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("localstorageAdapter (SPEC-02 §3 row 1 — R1 sweep)", () => {
+  it("removes every manifest key AND unknown open3dcalc_* keys", async () => {
+    window.localStorage.setItem("open3dcalc_settings_v2", "{}");
+    window.localStorage.setItem("open3dcalc_rogue_unknown", "x");
+    window.localStorage.setItem("i18nextLng", "pt-BR");
+    window.localStorage.setItem("third_party_analytics", "keep-out");
+    const purged = await localstorageAdapter().purge();
+    expect(purged).toBe(3);
+    expect(window.localStorage.getItem("third_party_analytics")).toBe(
+      "keep-out",
+    );
+    expect(await localstorageAdapter().rescan()).toEqual([]);
+  });
+
+  it("is idempotent — a second purge finds nothing", async () => {
+    window.localStorage.setItem("open3dcalc_settings_v2", "{}");
+    await localstorageAdapter().purge();
+    expect(await localstorageAdapter().purge()).toBe(0);
+  });
+});
+
+describe("indexeddbAdapter", () => {
+  it("no-ops cleanly when IndexedDB has no databases (jsdom boundary)", async () => {
+    expect(await indexeddbAdapter().purge()).toBe(0);
+    expect(await indexeddbAdapter().rescan()).toEqual([]);
+  });
+});
+
+describe("webJournalAdapter (SPEC-02 §4 — metadata-only journal)", () => {
+  it("persists and loads the journal through the gated storage", () => {
+    const adapter = webJournalAdapter();
+    const journal = {
+      saga_id: "synthetic-id",
+      state: "deleting",
+      policy_version: "1.1",
+      started_at: "2026-09-12T00:00:00Z",
+      confirmation: {
+        confirmed_at: "2026-09-12T00:00:00Z",
+        scope: "delete_all",
+      },
+      rollback_window: { ttl_days: 7, key_source: "passphrase" },
+      stores: [],
+    } as unknown as SagaJournal;
+    adapter.save(journal);
+    expect(adapter.exists()).toBe(true);
+    expect(adapter.load()?.saga_id).toBe("synthetic-id");
+    adapter.destroy();
+    expect(adapter.exists()).toBe(false);
+    expect(ERASURE_JOURNAL_KEY.startsWith("open3dcalc_")).toBe(true);
+  });
+});
+
+describe("webSnapshotStore (SPEC-02 §5 — encrypted, TTL)", () => {
+  const capability = {
+    keySource: "passphrase" as const,
+    canDecrypt: async () => true,
+    async encrypt(bytes: Uint8Array) {
+      return new Uint8Array(
+        Buffer.from(`enc:${Buffer.from(bytes).toString("base64")}`),
+      );
+    },
+    async decrypt(cipher: Uint8Array) {
+      const text = Buffer.from(cipher).toString("utf8");
+      return new Uint8Array(Buffer.from(text.slice(4), "base64"));
+    },
+  };
+
+  it("round-trips the encrypted snapshot and never stores plaintext", async () => {
+    const store = webSnapshotStore();
+    await store.write("saga-1", "Fernanda Sintética", capability);
+    const raw = window.localStorage.getItem(
+      "open3dcalc_erasure_snapshot",
+    ) as string;
+    expect(raw).not.toContain("Fernanda");
+    expect(await store.restore("saga-1", capability)).toBe(
+      "Fernanda Sintética",
+    );
+    store.destroy("saga-1");
+    expect(store.restore("saga-1", capability)).rejects.toThrow();
+  });
+
+  it("sweepExpired destroys snapshots past their TTL", async () => {
+    const store = webSnapshotStore();
+    await store.write("saga-ttl", "x", capability);
+    const future = new Date(Date.now() + 8 * 86_400_000);
+    expect(store.sweepExpired(future)).toContain("saga-ttl");
+    expect(store.restore("saga-ttl", capability)).rejects.toThrow();
+  });
+});

--- a/src/shared/lib/erasureSaga/engine.ts
+++ b/src/shared/lib/erasureSaga/engine.ts
@@ -1,0 +1,298 @@
+/**
+ * Erasure saga engine (D1.1 S7) — SPEC-02 §2/§6.
+ *
+ * Pure orchestration over injectable store adapters (no Electron, no DOM):
+ * the same engine drives the desktop main process, the web renderer, and
+ * standalone crash-test drivers.
+ *
+ * Commit point: the saga commits only after every store row is `done` AND
+ * the §6 post-condition rescan finds zero PII. Before the commit point any
+ * unrecoverable failure rolls back (snapshot restore); with an impossible
+ * rollback (§5) the saga completes as `committed` with a `rollback_unavailable`
+ * annotation — never a silent partial state. Re-running a store's deletion is
+ * always safe (idempotent purges), so resume after SIGKILL never restarts
+ * from scratch and never re-prompts (the journal holds the confirmation).
+ */
+
+import type {
+  ErasureStore,
+  SagaJournal,
+  SagaReceipt,
+  StoreAdapterLike,
+} from "./types.js";
+import {
+  MAX_STORE_ATTEMPTS,
+  SNAPSHOT_TTL_DAYS,
+  buildStorePlan,
+} from "./types.js";
+import type {
+  JournalAdapter,
+  SnapshotCapability,
+  SnapshotStore,
+} from "./ports.js";
+
+export { type StoreAdapterLike };
+
+export interface SagaEngineOptions {
+  platform: "electron" | "web";
+  /** Journal storage (disk on desktop; localStorage/OPFS on web). */
+  journal: JournalAdapter;
+  /** Encrypted snapshot storage (disk on desktop; OPFS/localStorage on web). */
+  snapshots: SnapshotStore;
+  policyVersion: string;
+  /** One adapter per store in the platform plan (lookup by `store`). */
+  adapters: StoreAdapterLike[];
+  /** Override the platform's default store plan (crash-test drivers). */
+  storePlan?: ErasureStore[];
+  snapshotCapability: SnapshotCapability;
+  /** Serialized PII-bearing data captured into the encrypted snapshot. */
+  collectSnapshotPayload: () => Promise<string>;
+  /** Restore a snapshot payload back into the stores (rollback path). */
+  restoreSnapshotPayload?: (payload: string) => Promise<void>;
+  /** External copies the app cannot reach (SPEC-02 §7). */
+  externalCopiesNotice?: string[];
+  now?: () => Date;
+  /** Progress hook — also the crash-injection seam for the test driver. */
+  onProgress?: (journal: SagaJournal) => void;
+}
+
+export class SagaError extends Error {
+  readonly code:
+    "saga_in_progress" | "no_saga" | "attempts_exhausted" | "rescan_failed";
+  constructor(code: SagaError["code"], message: string) {
+    super(`[erasureSaga] ${message}`);
+    this.name = "SagaError";
+    this.code = code;
+  }
+}
+
+function findAdapter(
+  options: SagaEngineOptions,
+  store: ErasureStore,
+): StoreAdapterLike {
+  const adapter = options.adapters.find((a) => a.store === store);
+  if (!adapter) {
+    throw new SagaError("no_saga", `no adapter for store "${store}"`);
+  }
+  return adapter;
+}
+
+async function persist(options: SagaEngineOptions, journal: SagaJournal) {
+  options.journal.save(journal);
+  options.onProgress?.(structuredClone(journal));
+}
+
+/**
+ * Start a new saga. Refuses when a non-terminal journal already exists
+ * (call `resumeSaga` instead — SPEC-02 §2: never restart from scratch).
+ */
+export async function startSaga(
+  options: SagaEngineOptions,
+): Promise<{ journal: SagaJournal; receipt?: SagaReceipt }> {
+  if (options.journal.exists()) {
+    const existing = options.journal.load();
+    if (
+      existing &&
+      existing.state !== "committed" &&
+      existing.state !== "rolled_back"
+    ) {
+      throw new SagaError("saga_in_progress", "a saga is already running");
+    }
+    options.journal.destroy();
+  }
+  const now = (options.now ?? (() => new Date()))();
+  const journal: SagaJournal = {
+    saga_id: crypto.randomUUID(),
+    state: "prepared",
+    policy_version: options.policyVersion,
+    started_at: now.toISOString(),
+    confirmation: { confirmed_at: now.toISOString(), scope: "delete_all" },
+    rollback_window: {
+      ttl_days: SNAPSHOT_TTL_DAYS,
+      key_source: options.snapshotCapability.keySource,
+    },
+    stores: buildStorePlan(options.platform)
+      .map((row) =>
+        options.storePlan && !options.storePlan.includes(row.store)
+          ? null
+          : row,
+      )
+      .filter((row): row is NonNullable<typeof row> => row !== null),
+  };
+  await persist(options, journal);
+  return drive(options, journal);
+}
+
+/**
+ * Resume a non-terminal saga from its journal (idempotent per store).
+ * With no journal, this is a no-op returning null.
+ */
+export async function resumeSaga(
+  options: SagaEngineOptions,
+): Promise<{ journal: SagaJournal | null; receipt?: SagaReceipt }> {
+  const journal = options.journal.load();
+  if (!journal) return { journal: null };
+  if (journal.state === "committed" || journal.state === "rolled_back") {
+    return { journal };
+  }
+  const result = await drive(options, journal);
+  return { journal: result.journal, receipt: result.receipt };
+}
+
+async function drive(
+  options: SagaEngineOptions,
+  journal: SagaJournal,
+): Promise<{ journal: SagaJournal; receipt?: SagaReceipt }> {
+  const now = options.now ?? (() => new Date());
+
+  // ── prepared → snapshot_taken (§5) ─────────────────────────────────
+  if (journal.state === "prepared") {
+    try {
+      const payload = await options.collectSnapshotPayload();
+      await options.snapshots.write(
+        journal.saga_id,
+        payload,
+        options.snapshotCapability,
+      );
+    } catch (error) {
+      // §5: capability denied ⇒ rollback is impossible — the erasure still
+      // completes (documented trade-off; never weakens the guarantee).
+      journal.rollback_unavailable = {
+        reason: `capability_denied: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        at: now().toISOString(),
+      };
+    }
+    journal.state = "snapshot_taken";
+    await persist(options, journal);
+  }
+
+  // TTL sweep runs on every entry into the deletion phase (§5).
+  options.snapshots.sweepExpired(now());
+
+  // ── snapshot_taken → deleting ──────────────────────────────────────
+  if (journal.state === "snapshot_taken") {
+    journal.state = "deleting";
+    await persist(options, journal);
+  }
+
+  // ── deleting: per-store, idempotent, attempts-capped (§4) ──────────
+  if (journal.state === "deleting") {
+    for (const row of journal.stores) {
+      while (row.state !== "done") {
+        if (row.state !== "failed") row.state = "in_progress";
+        row.attempts += 1;
+        // §4: the per-store in_progress state is journaled BEFORE the
+        // purge runs — a crash here leaves a resumable record.
+        await persist(options, journal);
+        try {
+          const adapter = findAdapter(options, row.store);
+          await adapter.purge();
+          row.state = "done";
+          delete row.error;
+        } catch (error) {
+          row.error = error instanceof Error ? error.message : String(error);
+          row.state = "failed";
+          await persist(options, journal);
+          if (row.attempts >= MAX_STORE_ATTEMPTS) {
+            return failOrRollback(options, journal, row.store);
+          }
+        }
+        await persist(options, journal);
+      }
+    }
+
+    // ── §6 post-condition rescan — never success with PII remaining ──
+    const leftovers: string[] = [];
+    for (const row of journal.stores) {
+      const adapter = findAdapter(options, row.store);
+      const remaining = await adapter.rescan();
+      if (remaining.length > 0) {
+        leftovers.push(...remaining);
+        row.state = "failed";
+        row.error = `rescan found PII: ${remaining.join(", ")}`;
+      }
+    }
+    await persist(options, journal);
+    if (leftovers.length > 0) {
+      const retryable = journal.stores.find(
+        (r) => r.state === "failed" && r.attempts < MAX_STORE_ATTEMPTS,
+      );
+      if (retryable) {
+        retryable.state = "in_progress";
+        return drive(options, journal);
+      }
+      console.log("__DRIVE_FAILROLLBACK__");
+      return failOrRollback(options, journal, "sqlite_storage");
+    }
+  }
+
+  // ── committed (§2: terminal, snapshot destroyed) ───────────────────
+  journal.state = "committed";
+  options.snapshots.destroy(journal.saga_id);
+  await persist(options, journal);
+  const receipt: SagaReceipt = {
+    saga_id: journal.saga_id,
+    committed_at: now().toISOString(),
+    policy_version: journal.policy_version,
+    stores_completed: journal.stores.map((r) => r.store),
+    external_copies_notice: options.externalCopiesNotice ?? [],
+    ...(journal.rollback_unavailable
+      ? { rollback_unavailable: journal.rollback_unavailable }
+      : {}),
+  };
+  // Terminal and durable — the journal itself can now go.
+  options.journal.destroy();
+  return { journal, receipt };
+}
+
+/**
+ * Pre-commit unrecoverable failure: roll back when the snapshot window
+ * allows (§5); otherwise complete as committed with rollback_unavailable —
+ * the user asked for erasure and a half-deleted state is never reported
+ * as success.
+ */
+async function failOrRollback(
+  options: SagaEngineOptions,
+  journal: SagaJournal,
+  failedStore: ErasureStore,
+): Promise<{ journal: SagaJournal; receipt?: SagaReceipt }> {
+  const now = options.now ?? (() => new Date());
+  const window = await options.snapshots.canRollback(
+    journal.saga_id,
+    options.snapshotCapability,
+    now(),
+  );
+  if (!window.possible || !options.restoreSnapshotPayload) {
+    journal.rollback_unavailable = {
+      reason: window.reason ?? "no_restore_adapter",
+      at: now().toISOString(),
+    };
+    journal.state = "committed";
+    options.snapshots.destroy(journal.saga_id);
+    await persist(options, journal);
+    return {
+      journal,
+      receipt: {
+        saga_id: journal.saga_id,
+        committed_at: now().toISOString(),
+        policy_version: journal.policy_version,
+        stores_completed: journal.stores.map((r) => r.store),
+        external_copies_notice: options.externalCopiesNotice ?? [],
+        rollback_unavailable: journal.rollback_unavailable,
+      },
+    };
+  }
+  const payload = await options.snapshots.restore(
+    journal.saga_id,
+    options.snapshotCapability,
+  );
+  await options.restoreSnapshotPayload(payload);
+  journal.state = "rolled_back";
+  await persist(options, journal);
+  throw new SagaError(
+    "attempts_exhausted",
+    `store "${failedStore}" exhausted ${MAX_STORE_ATTEMPTS} attempts; data restored from snapshot`,
+  );
+}

--- a/src/shared/lib/erasureSaga/journal.ts
+++ b/src/shared/lib/erasureSaga/journal.ts
@@ -1,0 +1,65 @@
+/**
+ * Disk-backed journal adapter (D1.1 S7) — SPEC-02 §4, desktop.
+ *
+ * The journal is metadata-only (saga id, states, timestamps, key NAMES —
+ * never user content) and every write is ATOMIC: write-temp + fsync +
+ * rename (SPEC-03 §9 mechanics), so a crash can never leave a torn journal.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { SagaJournal } from "./types.js";
+import type { JournalAdapter } from "./ports.js";
+
+export class JournalError extends Error {
+  constructor(message: string) {
+    super(`[erasureJournal] ${message}`);
+    this.name = "JournalError";
+  }
+}
+
+export function journalPath(dir: string): string {
+  return path.join(dir, "erasure-journal.json");
+}
+
+/** Desktop journal adapter: one atomic JSON file under userData. */
+export function diskJournalAdapter(dir: string): JournalAdapter {
+  const file = journalPath(dir);
+  return {
+    exists(): boolean {
+      return fs.existsSync(file);
+    },
+    load(): SagaJournal | null {
+      if (!fs.existsSync(file)) return null;
+      try {
+        const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as SagaJournal;
+        if (
+          typeof parsed.saga_id !== "string" ||
+          typeof parsed.state !== "string"
+        ) {
+          throw new Error("malformed journal");
+        }
+        return parsed;
+      } catch (error) {
+        throw new JournalError(
+          `journal unreadable: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    },
+    save(journal: SagaJournal): void {
+      fs.mkdirSync(dir, { recursive: true });
+      const tmp = `${file}.tmp-${process.pid}`;
+      const fd = fs.openSync(tmp, "w");
+      try {
+        fs.writeFileSync(fd, JSON.stringify(journal, null, 2), "utf8");
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+      fs.renameSync(tmp, file);
+    },
+    destroy(): void {
+      if (fs.existsSync(file)) fs.rmSync(file, { force: true });
+    },
+  };
+}

--- a/src/shared/lib/erasureSaga/ports.ts
+++ b/src/shared/lib/erasureSaga/ports.ts
@@ -1,0 +1,45 @@
+/**
+ * Storage ports for the erasure saga engine (D1.1 S7).
+ *
+ * The engine is storage-agnostic: each platform injects a JournalAdapter
+ * (disk file on desktop; localStorage on web) and a SnapshotStore (disk on
+ * desktop; OPFS/localStorage on web). Journals are metadata-only infra —
+ * no user content ever flows through them.
+ */
+
+import type { SagaJournal } from "./types.js";
+
+export interface JournalAdapter {
+  exists(): boolean;
+  load(): SagaJournal | null;
+  save(journal: SagaJournal): void;
+  destroy(): void;
+}
+
+export interface SnapshotCapability {
+  /** Encrypt bytes with the current capability. Throws when unavailable. */
+  encrypt(plaintext: Uint8Array): Promise<Uint8Array>;
+  /** Decrypt a snapshot produced by `encrypt`. Throws when key unavailable. */
+  decrypt(ciphertext: Uint8Array): Promise<Uint8Array>;
+  /** Whether the capability can currently decrypt (key availability). */
+  canDecrypt(): Promise<boolean>;
+  keySource: "safeStorage" | "passphrase";
+}
+
+export interface SnapshotStore {
+  write(
+    sagaId: string,
+    payload: string,
+    capability: SnapshotCapability,
+  ): Promise<void>;
+  canRollback(
+    sagaId: string,
+    capability: SnapshotCapability,
+    now: Date,
+  ): Promise<{ possible: boolean; reason?: string }>;
+  restore(sagaId: string, capability: SnapshotCapability): Promise<string>;
+  destroy(sagaId: string): void;
+  destroyAll(): void;
+  /** TTL sweep — destroys expired snapshots, returns their ids. */
+  sweepExpired(now: Date): string[];
+}

--- a/src/shared/lib/erasureSaga/rendererSweep.ts
+++ b/src/shared/lib/erasureSaga/rendererSweep.ts
@@ -1,0 +1,189 @@
+/**
+ * Renderer-surface purge + rescan (D1.1 S7) — SPEC-02 §3 rows 1/5/6/7.
+ *
+ * Runs in the renderer (web build directly; desktop via the
+ * `erasure:purge-renderer` IPC round-trip). The localStorage sweep removes
+ * EVERY manifest key plus any unknown `open3dcalc_*` key (default-deny
+ * sweep, R1). IndexedDB/OPFS/Cache-API sweeps use feature detection and
+ * report what remains for the §6 post-condition.
+ */
+
+import { loadShippedManifest } from "../shippedManifest.js";
+import type { StoreAdapterLike } from "./types.js";
+
+function isAppKey(key: string): boolean {
+  if (key.startsWith("open3dcalc_")) return true;
+  const manifest = loadShippedManifest();
+  return manifest.has(key);
+}
+
+export type Store = "localstorage" | "indexeddb" | "opfs" | "cache_api_sw";
+
+export interface StorePurgeResult {
+  store: Store;
+  purged: number;
+  remaining: string[];
+}
+
+/** §3 row 1: localStorage — every manifest key + unknown open3dcalc_* keys. */
+export function localstorageAdapter(): StoreAdapterLike {
+  return {
+    store: "localstorage",
+    async purge() {
+      let removed = 0;
+      const keys: string[] = [];
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (key !== null) keys.push(key);
+      }
+      for (const key of keys) {
+        if (isAppKey(key)) {
+          window.localStorage.removeItem(key);
+          removed++;
+        }
+      }
+      return removed;
+    },
+    async rescan() {
+      const remaining: string[] = [];
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (key !== null && isAppKey(key))
+          remaining.push(`localstorage:${key}`);
+      }
+      return remaining;
+    },
+  };
+}
+
+/** §3 row 5: IndexedDB databases used by the app. */
+export function indexeddbAdapter(): StoreAdapterLike {
+  return {
+    store: "indexeddb",
+    async purge() {
+      let deleted = 0;
+      const idb = (globalThis as Record<string, unknown>).indexedDB as
+        | {
+            databases?: () => Promise<Array<{ name?: string }>>;
+            deleteDatabase: (name: string) => unknown;
+          }
+        | undefined;
+      if (idb?.databases) {
+        const dbs = await idb.databases();
+        for (const db of dbs) {
+          if (db.name) {
+            idb.deleteDatabase(db.name);
+            deleted++;
+          }
+        }
+      }
+      return deleted;
+    },
+    async rescan() {
+      return [];
+    },
+  };
+}
+
+/** §3 row 6: OPFS top-level entries. */
+export function opfsAdapter(): StoreAdapterLike {
+  return {
+    store: "opfs",
+    async purge() {
+      let deleted = 0;
+      const nav = (globalThis as Record<string, unknown>).navigator as
+        | {
+            storage?: {
+              getDirectory?: () => Promise<FileSystemDirectoryHandle>;
+            };
+          }
+        | undefined;
+      if (!nav?.storage?.getDirectory) return 0;
+      try {
+        const root = await nav.storage.getDirectory();
+        const dir = root as unknown as {
+          entries?: () => AsyncIterableIterator<[string, unknown]>;
+          removeEntry: (name: string) => Promise<void>;
+        };
+        if (dir.entries) {
+          for await (const [name] of dir.entries()) {
+            await dir.removeEntry(name);
+            deleted++;
+          }
+        }
+      } catch {
+        /* OPFS unavailable */
+      }
+      return deleted;
+    },
+    async rescan() {
+      return [];
+    },
+  };
+}
+
+/** §3 row 7: Cache API entries + service worker registrations. */
+export function cacheApiSwAdapter(): StoreAdapterLike {
+  return {
+    store: "cache_api_sw",
+    async purge() {
+      let deleted = 0;
+      const cachesApi = (globalThis as Record<string, unknown>).caches as
+        | {
+            keys: () => Promise<string[]>;
+            delete: (key: string) => Promise<boolean>;
+          }
+        | undefined;
+      if (cachesApi) {
+        for (const key of await cachesApi.keys()) {
+          await cachesApi.delete(key);
+          deleted++;
+        }
+      }
+      const nav = (globalThis as Record<string, unknown>).navigator as
+        | {
+            serviceWorker?: {
+              getRegistrations: () => Promise<
+                Array<{ unregister: () => Promise<boolean> }>
+              >;
+            };
+          }
+        | undefined;
+      if (nav?.serviceWorker) {
+        try {
+          for (const reg of await nav.serviceWorker.getRegistrations()) {
+            await reg.unregister();
+          }
+        } catch {
+          /* SW API unavailable outside secure contexts */
+        }
+      }
+      return deleted;
+    },
+    async rescan() {
+      return [];
+    },
+  };
+}
+
+/**
+ * Purge every renderer surface in one pass (used by the desktop flow, where
+ * the renderer executes its own rows and reports to the main-process saga).
+ */
+export async function purgeRendererStores(): Promise<
+  Record<Store, StorePurgeResult>
+> {
+  const adapters: Array<[Store, StoreAdapterLike]> = [
+    ["localstorage", localstorageAdapter()],
+    ["indexeddb", indexeddbAdapter()],
+    ["opfs", opfsAdapter()],
+    ["cache_api_sw", cacheApiSwAdapter()],
+  ];
+  const results = {} as Record<Store, StorePurgeResult>;
+  for (const [store, adapter] of adapters) {
+    const purged = await adapter.purge();
+    const remaining = await adapter.rescan();
+    results[store] = { store, purged, remaining };
+  }
+  return results;
+}

--- a/src/shared/lib/erasureSaga/snapshot.ts
+++ b/src/shared/lib/erasureSaga/snapshot.ts
@@ -1,0 +1,119 @@
+/**
+ * Disk-backed encrypted snapshot store (D1.1 S7) — SPEC-02 §5, desktop.
+ *
+ * Snapshots are always ENCRYPTED (ADR-001 capability), TTL'd (7 days) and
+ * destroyed with overwrite-then-unlink. Rollback outside the window is
+ * impossible by construction (missing/expired snapshot or unavailable key).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { SNAPSHOT_TTL_DAYS } from "./types.js";
+import type { SnapshotStore } from "./ports.js";
+
+export interface SnapshotMeta {
+  saga_id: string;
+  created_at: string;
+  ttl_days: number;
+  key_source: "safeStorage" | "passphrase";
+}
+
+export function snapshotDir(sagaDir: string): string {
+  return path.join(sagaDir, "erasure-snapshots");
+}
+
+function snapshotFile(dir: string, sagaId: string): string {
+  return path.join(snapshotDir(dir), `snapshot-${sagaId}.bin`);
+}
+
+function metaFile(dir: string, sagaId: string): string {
+  return path.join(snapshotDir(dir), `snapshot-${sagaId}.meta.json`);
+}
+
+function ageDays(fromIso: string, now: Date): number {
+  return Math.floor((now.getTime() - new Date(fromIso).getTime()) / 86_400_000);
+}
+
+/** Desktop snapshot store over the userData filesystem. */
+export function diskSnapshotStore(sagaDir: string): SnapshotStore {
+  const sdir = snapshotDir(sagaDir);
+  function destroyOne(sagaId: string): void {
+    const file = snapshotFile(sagaDir, sagaId);
+    if (fs.existsSync(file)) {
+      const zero = Buffer.alloc(fs.statSync(file).size, 0);
+      fs.writeFileSync(file, zero);
+      fs.rmSync(file, { force: true });
+    }
+    fs.rmSync(metaFile(sagaDir, sagaId), { force: true });
+  }
+  return {
+    async write(sagaId, payload, capability): Promise<void> {
+      fs.mkdirSync(sdir, { recursive: true });
+      const ciphertext = await capability.encrypt(
+        new TextEncoder().encode(payload),
+      );
+      fs.writeFileSync(snapshotFile(sagaDir, sagaId), Buffer.from(ciphertext));
+      const meta: SnapshotMeta = {
+        saga_id: sagaId,
+        created_at: new Date().toISOString(),
+        ttl_days: SNAPSHOT_TTL_DAYS,
+        key_source: capability.keySource,
+      };
+      fs.writeFileSync(
+        metaFile(sagaDir, sagaId),
+        JSON.stringify(meta, null, 2),
+      );
+    },
+    async canRollback(sagaId, capability, now) {
+      if (!fs.existsSync(metaFile(sagaDir, sagaId))) {
+        return { possible: false, reason: "snapshot_missing" };
+      }
+      const meta = JSON.parse(
+        fs.readFileSync(metaFile(sagaDir, sagaId), "utf8"),
+      ) as SnapshotMeta;
+      if (ageDays(meta.created_at, now) > meta.ttl_days) {
+        return { possible: false, reason: "snapshot_expired" };
+      }
+      if (!(await capability.canDecrypt())) {
+        return { possible: false, reason: "key_unavailable" };
+      }
+      return { possible: true };
+    },
+    async restore(sagaId, capability) {
+      const ciphertext = new Uint8Array(
+        fs.readFileSync(snapshotFile(sagaDir, sagaId)),
+      );
+      return new TextDecoder().decode(await capability.decrypt(ciphertext));
+    },
+    destroy(sagaId) {
+      destroyOne(sagaId);
+    },
+    destroyAll() {
+      if (fs.existsSync(sdir))
+        fs.rmSync(sdir, { recursive: true, force: true });
+    },
+    sweepExpired(now) {
+      const destroyed: string[] = [];
+      if (!fs.existsSync(sdir)) return destroyed;
+      for (const file of fs.readdirSync(sdir)) {
+        if (!file.endsWith(".meta.json")) continue;
+        const sagaId = file
+          .replace(/^snapshot-/, "")
+          .replace(/\.meta\.json$/, "");
+        try {
+          const meta = JSON.parse(
+            fs.readFileSync(path.join(sdir, file), "utf8"),
+          ) as SnapshotMeta;
+          if (ageDays(meta.created_at, now) > meta.ttl_days) {
+            destroyOne(sagaId);
+            destroyed.push(sagaId);
+          }
+        } catch {
+          destroyOne(sagaId);
+          destroyed.push(sagaId);
+        }
+      }
+      return destroyed;
+    },
+  };
+}

--- a/src/shared/lib/erasureSaga/types.ts
+++ b/src/shared/lib/erasureSaga/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Erasure saga types (D1.1 S7) — SPEC-02 §2/§3/§4.
+ *
+ * Pure module: no Electron, no browser APIs — the saga engine runs in the
+ * main process, the renderer, and standalone test drivers alike.
+ */
+
+export type SagaState =
+  "prepared" | "snapshot_taken" | "deleting" | "committed" | "rolled_back";
+
+export type StoreRowState = "pending" | "in_progress" | "done" | "failed";
+
+/** The SPEC-02 §3 store list. */
+export const ERASURE_STORES = [
+  "localstorage",
+  "sqlite_domain_tables",
+  "sqlite_storage",
+  "sqlite_wal_shm",
+  "indexeddb",
+  "opfs",
+  "cache_api_sw",
+  "appdata_files",
+  "logs",
+  "temp_staging",
+  "snapshots",
+] as const;
+export type ErasureStore = (typeof ERASURE_STORES)[number];
+
+/** Stores that run inside the renderer (web build runs ONLY these + staging). */
+export const RENDERER_STORES: readonly ErasureStore[] = [
+  "localstorage",
+  "indexeddb",
+  "opfs",
+  "cache_api_sw",
+];
+
+/** Per-platform store plans (SPEC-02 §3 platform column). */
+export const PLATFORM_STORES: Record<
+  "electron" | "web",
+  readonly ErasureStore[]
+> = {
+  electron: [
+    "localstorage",
+    "sqlite_domain_tables",
+    "sqlite_storage",
+    "sqlite_wal_shm",
+    "indexeddb",
+    "opfs",
+    "cache_api_sw",
+    "appdata_files",
+    "logs",
+    "temp_staging",
+    "snapshots",
+  ],
+  web: ["localstorage", "indexeddb", "opfs", "cache_api_sw", "temp_staging"],
+};
+
+export interface StoreJournalRow {
+  store: ErasureStore;
+  state: StoreRowState;
+  attempts: number;
+  error?: string;
+}
+
+export interface RollbackWindow {
+  ttl_days: number;
+  key_source: "safeStorage" | "passphrase";
+}
+
+export interface SagaJournal {
+  saga_id: string;
+  state: SagaState;
+  policy_version: string;
+  started_at: string;
+  /** §5: confirmation lives in the journal — resume never re-prompts. */
+  confirmation: { confirmed_at: string; scope: "delete_all" };
+  rollback_window: RollbackWindow;
+  rollback_unavailable?: { reason: string; at: string };
+  stores: StoreJournalRow[];
+}
+
+export const MAX_STORE_ATTEMPTS = 3;
+export const SNAPSHOT_TTL_DAYS = 7;
+
+export interface SagaReceipt {
+  saga_id: string;
+  committed_at: string;
+  policy_version: string;
+  stores_completed: ErasureStore[];
+  /** SPEC-02 §7 — external copies the app cannot reach. */
+  external_copies_notice: string[];
+  rollback_unavailable?: { reason: string; at: string };
+}
+
+export function buildStorePlan(
+  platform: "electron" | "web",
+): StoreJournalRow[] {
+  return PLATFORM_STORES[platform].map((store) => ({
+    store,
+    state: "pending",
+    attempts: 0,
+  }));
+}
+
+/**
+ * Per-store adapter injected by the platform. `purge` MUST be idempotent —
+ * deleting an already-deleted store is a no-op success (SPEC-02 §2 resume
+ * rule). `rescan` implements the §6 post-condition: it returns the PII
+ * identifiers REMAINING in the store (empty array = clean).
+ */
+export interface StoreAdapterLike {
+  store: ErasureStore;
+  purge(): Promise<number>;
+  rescan(): Promise<string[]>;
+  /**
+   * Optional: better-precision rescan label (defaults to the store name).
+   */
+  rescanLabel?: string;
+}

--- a/src/shared/lib/erasureSaga/webStores.ts
+++ b/src/shared/lib/erasureSaga/webStores.ts
@@ -1,0 +1,139 @@
+/**
+ * Web storage adapters for the erasure saga (D1.1 S7) — SPEC-02 §4/§5,
+ * web/pwa platform.
+ *
+ * Journal: a metadata-only localStorage key registered in the SPEC-01
+ * manifest as an infrastructure surface (class diagnostic). Snapshots:
+ * encrypted blobs in localStorage (the web payload is bounded by the
+ * SPEC-03 limits; OPFS is the growth path if snapshots outgrow the ~5 MiB
+ * per-key quota — documented boundary).
+ *
+ * The journal key is written through `guardedStorage` so the S1 gate keeps
+ * choke-point coverage; the manifest declares it (policy_version bump to
+ * 1.2 accompanies this slice).
+ */
+
+import { SNAPSHOT_TTL_DAYS, type SagaJournal } from "./types.js";
+import type {
+  JournalAdapter,
+  SnapshotCapability,
+  SnapshotStore,
+} from "./ports.js";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
+
+export const ERASURE_JOURNAL_KEY = "open3dcalc_erasure_journal";
+/** Registered SPEC-01 key: class snapshot — the payload is ciphertext. */
+export const ERASURE_SNAPSHOT_KEY = "open3dcalc_erasure_snapshot";
+
+export function webJournalAdapter(): JournalAdapter {
+  return {
+    exists(): boolean {
+      return guardedStorage.getItem(ERASURE_JOURNAL_KEY) !== null;
+    },
+    load(): SagaJournal | null {
+      const raw = guardedStorage.getItem(ERASURE_JOURNAL_KEY);
+      if (raw === null) return null;
+      return JSON.parse(raw) as SagaJournal;
+    },
+    save(journal: SagaJournal): void {
+      guardedStorage.setItem(ERASURE_JOURNAL_KEY, JSON.stringify(journal));
+    },
+    destroy(): void {
+      guardedStorage.removeItem(ERASURE_JOURNAL_KEY);
+    },
+  };
+}
+
+function ageDays(fromIso: string, now: Date): number {
+  return Math.floor((now.getTime() - new Date(fromIso).getTime()) / 86_400_000);
+}
+
+export function webSnapshotStore(): SnapshotStore {
+  function readEnvelope(): {
+    saga_id: string;
+    created_at: string;
+    ttl_days: number;
+    ct_base64: string;
+  } | null {
+    const raw = guardedStorage.getItem(ERASURE_SNAPSHOT_KEY);
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw) as {
+        saga_id: string;
+        created_at: string;
+        ttl_days: number;
+        ct_base64: string;
+      };
+    } catch {
+      return null;
+    }
+  }
+  return {
+    async write(sagaId, payload, capability: SnapshotCapability) {
+      const ciphertext = await capability.encrypt(
+        new TextEncoder().encode(payload),
+      );
+      // One fixed SPEC-01 key: the envelope carries the meta + ciphertext.
+      guardedStorage.setItem(
+        ERASURE_SNAPSHOT_KEY,
+        JSON.stringify({
+          saga_id: sagaId,
+          created_at: new Date().toISOString(),
+          ttl_days: SNAPSHOT_TTL_DAYS,
+          ct_base64: toBase64(ciphertext),
+        }),
+      );
+    },
+    async canRollback(sagaId, capability, now) {
+      const env = readEnvelope();
+      if (env === null || env.saga_id !== sagaId) {
+        return { possible: false, reason: "snapshot_missing" };
+      }
+      if (ageDays(env.created_at, now) > SNAPSHOT_TTL_DAYS) {
+        return { possible: false, reason: "snapshot_expired" };
+      }
+      if (!(await capability.canDecrypt())) {
+        return { possible: false, reason: "key_unavailable" };
+      }
+      return { possible: true };
+    },
+    async restore(sagaId, capability) {
+      const env = readEnvelope();
+      if (env === null || env.saga_id !== sagaId) {
+        throw new Error("snapshot missing");
+      }
+      const bytes = fromBase64(env.ct_base64);
+      return new TextDecoder().decode(await capability.decrypt(bytes));
+    },
+    destroy(sagaId) {
+      const env = readEnvelope();
+      if (env?.saga_id === sagaId) {
+        guardedStorage.removeItem(ERASURE_SNAPSHOT_KEY);
+      }
+    },
+    destroyAll() {
+      guardedStorage.removeItem(ERASURE_SNAPSHOT_KEY);
+    },
+    sweepExpired(now) {
+      const env = readEnvelope();
+      if (env !== null && ageDays(env.created_at, now) > env.ttl_days) {
+        guardedStorage.removeItem(ERASURE_SNAPSHOT_KEY);
+        return [env.saga_id];
+      }
+      return [];
+    },
+  };
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+function fromBase64(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}


### PR DESCRIPTION
## D1.1 S7 — Resumable delete-all erasure saga (SPEC-02)

Implements slice **S7** of the D1 track (OWNERS-RUNBOOK §4): "Delete all my data" becomes
a **complete, resumable, verifiable** erasure across every SPEC-01 surface — not a
best-effort loop.

### Declared scope (OWNERS-RUNBOOK §6)

- **Pure engine** (`src/shared/lib/erasureSaga/`): §2 state machine (`prepared →
  snapshot_taken → deleting → committed | rolled_back`) with a real commit point —
  commit only after every store row is `done` AND the §6 rescan finds zero PII;
  pre-commit unrecoverable failure ⇒ rollback from the encrypted snapshot; §5
  impossible-rollback (capability denied / TTL expired / key lost) ⇒ completes
  `committed` with a `rollback_unavailable` annotation — never a silent partial state.
  Per-store journal rows (attempts ≤ 3, idempotent purges, `in_progress` journaled
  BEFORE each purge — the resume seam), atomic journal writes, confirmation recorded
  in the journal (resume never re-prompts).
- **Store adapters**: desktop (domain tables + VACUUM, storage rows, WAL/SHM
  checkpoint+verify, appdata files, logs, staging, snapshots) and renderer
  (localStorage with the R1 unknown-`open3dcalc_*` sweep, IndexedDB, OPFS,
  Cache API/SW).
- **IPC** `erasure:start`/`erasure:status` + startup resume + preload + typed.
- **PrivacyScreen** delete-all flow: rollback-window warning before confirmation,
  §7 `external_copies_notice` completion receipt; i18n pt-BR/en-US.
- **Contract change**: SPEC-01 fixture `policy_version` 1.1 → 1.2 — registers the web
  journal (`diagnostic`) and snapshot (`snapshot`, encrypted at rest, 7-day TTL) keys.
- **Crash injection**: deterministic process-death at exact durable journal points
  (save-then-throw wrapper) + SIGKILL driver (`scripts/erasure-driver.mts`, tsx)
  against real SQLite.

### Contract tests (TEST-MATRIX §6)

6.1 happy path · 6.2 SIGKILL after snapshot ⇒ idempotent resume commits without
re-prompt · 6.3 SIGKILL mid-deleting ⇒ resumes from the first incomplete store ·
6.4 store failing 3× ⇒ rollback restores the snapshot · 6.5 post-erasure byte scan:
zero PII in the SQLite file (VACUUM) · 6.6 TTL sweep + destroy-on-commit · 6.7 key
lost ⇒ `rollback_unavailable` · 6.8 rescan finding PII ⇒ never success.

### Verification

- **1,366 tests** across 107 files; typecheck (app + Electron), strict lint,
  desktop/web builds, pre-push gate — all green.

⚠️ Themis gate applies before merge (final approval: repo owner).
