### PR TITLE
feat(privacy): D1.1 S8 — policy-bound consent receipt (SPEC-04)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,59 +1,52 @@
-# Deepwork D1.1 S7 — Erasure (delete-all) saga (SPEC-02)
+# Deepwork D1.1 S8 — Consent receipt (SPEC-04)
 
-- **Branch/worktree:** `feat/d1-s7-erasure-saga` / `../open3dcalc-d1-s7-erasure`
+- **Branch/worktree:** `feat/d1-s8-consent-receipt` / `../open3dcalc-d1-s8-consent`
 - **Status:** implementation complete — local gates green; awaiting Themis review (PR next).
-- **Scope (OWNERS-RUNBOOK §6 declared):** SPEC-02 erasure saga — pure state-machine
-  engine (prepared → snapshot_taken → deleting → committed | rolled_back) with a
-  resumable per-store journal (atomic writes, attempts ≤3, no re-prompt), an
-  encrypted TTL'd safety snapshot with the §5 rollback window, the §6 post-condition
-  rescan (zero PII before commit), desktop + renderer store adapters, the erasure
-  IPC surface, the delete-all flow in the privacy screen, and REAL crash-injection
-  tests (SIGKILL-equivalent at exact durable journal points). Contract change:
-  SPEC-01 fixture registers the web journal + snapshot keys and bumps
-  `policy_version` 1.1 → 1.2 (per OWNERS-RUNBOOK §6).
-- **Base:** `main` @ `9e57800` (includes PR #112 D1.1 S5, PR #113 D1.1 S6 and the
-  node_modules repair).
+- **Scope (OWNERS-RUNBOOK §6 declared):** SPEC-04 consent receipt — policy-bound,
+  tamper-evident, canonicalized receipt (issue/verify/withdraw/policy-delta),
+  consentStore rewired so `consentGiven` is derived from a VALID receipt
+  (default-deny), withdrawal executing the manifest-derived erasure plan, and the
+  consent section in the privacy screen. No contract documents modified (no policy
+  bump — the receipt is stored inside the existing `open3dcalc_consent_v1`
+  consent_record key, sync never, export never).
+- **Base:** `main` @ `a851bc1` (includes PR #114 D1.1 S7).
 
 ## What landed in this slice
 
-- `src/shared/lib/erasureSaga/` — pure engine (no Electron/DOM):
-  - `engine.ts` — §2 state machine with a real commit point: commit only after
-    every store row is `done` AND the §6 rescan finds zero PII; pre-commit
-    unrecoverable failure ⇒ rollback (snapshot restore); impossible rollback
-    (§5: capability denied / TTL expired / key lost) ⇒ completes `committed` with
-    a `rollback_unavailable` annotation — never a silent partial state; the
-    in_progress journal row is persisted BEFORE each purge (resume seam).
-  - `journal.ts` (disk) / `webStores.ts` (localStorage) — metadata-only journal,
-    atomic write-temp+fsync+rename.
-  - `snapshot.ts` / `webStores.ts` — encrypted snapshot (capability-injected),
-    TTL sweep on every entry into `deleting`, destroy-on-commit
-    (overwrite+unlink / remove).
-  - `rendererSweep.ts` — granular renderer adapters: localStorage (manifest keys +
-    unknown `open3dcalc_*` sweep, R1), IndexedDB, OPFS, Cache API/SW.
-- `electron/erasureStores.ts` + `electron/erasure.ts` — desktop adapters (domain
-  tables, storage rows, WAL/SHM checkpoint+verify, appdata files, logs, staging,
-  snapshots) with VACUUM after table deletion; safeStorage-backed snapshot
-  capability; startup resume of non-terminal sagas.
-- IPC `erasure:start`/`erasure:status` + preload + typed `electron.d.ts`.
-- PrivacyScreen — "Delete all my data": renderer purges first, main saga covers
-  the durable surfaces, §7 `external_copies_notice` shown on the completion
-  receipt. i18n pt-BR/en-US.
-- SPEC-01 fixture: `policy_version` 1.2; new web keys `open3dcalc_erasure_journal`
-  (diagnostic) and `open3dcalc_erasure_snapshot` (class snapshot, encrypted at
-  rest, 7-day retention).
+- `src/shared/lib/consentReceipt.ts`:
+  - `issueReceipt` — receipt bound to the CURRENT policy (`policy_hash` = sha256 of
+    the canonical SPEC-01 manifest, deterministic across platforms, §4);
+  - `evaluateReceipt` — digest recomputed on every load (§5): tampered ⇒ invalid ⇒
+    default-deny; withdrawn ⇒ not given (audit record kept); policy
+    version/hash mismatch ⇒ `policy_mismatch` ⇒ re-consent required, old receipt
+    retained for the delta view (§6);
+  - `consentErasurePlan` — the §6.1 withdrawal plan derived from the manifest:
+    every `legal_basis: consent` key partitioned by `erasure`
+    (erase_on_delete_all vs retain_anonymized);
+  - `anonymizeRecord` — strips identifying fields for `retain_anonymized` keys,
+    keeping non-identifying aggregates.
+- `consentStore` — `giveConsent` issues and VERIFIES the receipt before marking
+  consent; `withdrawConsent` annotates `withdrawn_at`, erases the consent-basis
+  localStorage keys per the plan (desktop durable copies go through the S4
+  `privacy:eliminate-key` flow) and keeps the withdrawn receipt in an audit list;
+  stored via the gated storage (consent_record: sync never, export never).
+- PrivacyScreen — consent section: status (valid/absent/tampered/policy-mismatch),
+  grant/withdraw actions, and the SPEC-04 §2 note that flags never substitute
+  consent. i18n pt-BR/en-US.
 
-## Verification (TEST-MATRIX §6)
+## Verification (TEST-MATRIX §8)
 
-- 6.1 happy path · 6.2 death after snapshot_taken ⇒ idempotent resume commits
-  without re-prompt (journal durable, confirmation preserved) · 6.3 death mid-
-  deleting (first store done) ⇒ resumes from the first incomplete store ·
-  6.4 store failing 3× ⇒ rollback restores the snapshot payload · 6.5 post-erasure
-  byte scan: zero PII markers in the SQLite file (VACUUM) · 6.6 TTL sweep +
-  destroy-on-commit · 6.7 key lost ⇒ completes with `rollback_unavailable` ·
-  6.8 rescan finding PII ⇒ store failed, never success.
-- 1,366 tests across 107 files; typecheck (app + Electron), strict lint, builds.
-- Rollback (OWNERS-RUNBOOK §7): the saga is user-triggered; rollback = disable the
-  delete-all entry (flag) while journal+resume logic stays enabled (§7 S7 row).
+- 8.1 issue + digest verification (policy hash compared against an independent
+  sha256 over the canonical fixture) · 8.2 tamper ⇒ default-deny, never repaired ·
+  8.3 flags-only state ⇒ consent NOT given · 8.4 withdrawal: annotation kept,
+  erasure plan derived from the manifest, anonymization strips identifying fields
+  while keeping aggregates · 8.5 policy change ⇒ mismatch + old receipt retained ·
+  8.6 the SPEC-03 envelope never contains receipt material (strict field allowlist).
+- 1,377 tests across 108 files; typecheck (app + Electron), strict lint, builds.
+- Coverage on the receipt module: 95.5% lines / 92.6% branches.
+- Rollback (OWNERS-RUNBOOK §7): flag off ⇒ boolean-consent behavior returns; any
+  receipts already issued stay stored (inert); re-enabling re-validates digests.
 
-**D1.1 S7 is pending Themis review. S8 (consent receipt, SPEC-04) depends on this
-slice and is next.**
+**D1.1 S8 closes the D1 track (S1–S8): the SPEC-01 manifest, ADR-001 capability,
+ADR-002 default-deny/quarantine, SPEC-03 envelope and SPEC-02 saga are all
+implemented and enforced at runtime.**

--- a/src/shared/components/Privacy/PrivacyScreen.tsx
+++ b/src/shared/components/Privacy/PrivacyScreen.tsx
@@ -154,6 +154,56 @@ export function PrivacyScreen() {
     [privacyApi, t, loadReport],
   );
 
+  // ── SPEC-04 consent receipt (D1.1 S8) ───────────────────────────────
+  const [consentStatus, setConsentStatus] = useState<{
+    status: string;
+    consentGiven: boolean;
+    currentPolicyVersion: string;
+  } | null>(null);
+  const [consentBusy, setConsentBusy] = useState(false);
+
+  const loadConsentStatus = useCallback(async () => {
+    const { useConsentStore } = await import("@/shared/stores/consentStore");
+    const { receipt, receiptDigest: digest } = useConsentStore.getState();
+    const { evaluateReceipt } = await import("@/shared/lib/consentReceipt");
+    const evaluation = await evaluateReceipt(
+      receipt && digest ? { receipt, digest } : null,
+    );
+    setConsentStatus({
+      status: evaluation.status,
+      consentGiven: evaluation.consentGiven,
+      currentPolicyVersion: evaluation.currentPolicyVersion,
+    });
+  }, []);
+
+  useEffect(() => {
+    void Promise.resolve().then(() => {
+      void loadConsentStatus();
+    });
+  }, [loadConsentStatus]);
+
+  const handleGrant = useCallback(async () => {
+    setConsentBusy(true);
+    try {
+      const { useConsentStore } = await import("@/shared/stores/consentStore");
+      await useConsentStore.getState().giveConsent();
+      await loadConsentStatus();
+    } finally {
+      setConsentBusy(false);
+    }
+  }, [loadConsentStatus]);
+
+  const handleWithdraw = useCallback(async () => {
+    setConsentBusy(true);
+    try {
+      const { useConsentStore } = await import("@/shared/stores/consentStore");
+      await useConsentStore.getState().withdrawConsent();
+      await loadConsentStatus();
+    } finally {
+      setConsentBusy(false);
+    }
+  }, [loadConsentStatus]);
+
   // ── SPEC-02 delete-all saga (D1.1 S7) ───────────────────────────────
   const [erasing, setErasing] = useState(false);
   const [erasureReceipt, setErasureReceipt] = useState<{
@@ -342,6 +392,53 @@ export function PrivacyScreen() {
       <p className="text-[11px] text-[var(--color-text-muted)]">
         {t("privacy.quarantine.readNote")}
       </p>
+
+      {/* ── SPEC-04 consent receipt ─────────────────────────────────── */}
+      <div className="surface rounded-xl p-4 space-y-3">
+        <h3 className="text-sm font-bold text-[var(--color-text-primary)]">
+          {t("privacy.consent.title")}
+        </h3>
+        {consentStatus === null ? (
+          <p className="text-xs text-[var(--color-text-muted)]">…</p>
+        ) : consentStatus.consentGiven ? (
+          <div className="space-y-2">
+            <p className="text-xs text-emerald-400">
+              {t("privacy.consent.granted", {
+                version: consentStatus.currentPolicyVersion,
+              })}
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                if (window.confirm(t("privacy.consent.withdrawConfirm"))) {
+                  void handleWithdraw();
+                }
+              }}
+              disabled={consentBusy}
+              className="min-h-[44px] px-3 py-2 rounded-xl text-xs font-semibold bg-[var(--color-bg-elevated)] text-red-400 hover:bg-[var(--color-bg-hover)] border border-red-500/30 transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none disabled:opacity-60"
+            >
+              {t("privacy.consent.withdraw")}
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs text-[var(--color-text-secondary)]">
+              {t("privacy.consent.absent")}
+            </p>
+            <button
+              type="button"
+              onClick={() => void handleGrant()}
+              disabled={consentBusy}
+              className="min-h-[44px] px-3 py-2 rounded-xl text-xs font-semibold bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:outline-none disabled:opacity-60"
+            >
+              {t("privacy.consent.grant")}
+            </button>
+          </div>
+        )}
+        <p className="text-[11px] text-[var(--color-text-muted)]">
+          {t("privacy.consent.flagsNote")}
+        </p>
+      </div>
 
       {/* ── SPEC-02 delete-all ──────────────────────────────────────── */}
       <div className="surface rounded-xl p-4 border border-red-500/30 space-y-3">

--- a/src/shared/i18n/locales/en-US.json
+++ b/src/shared/i18n/locales/en-US.json
@@ -647,6 +647,15 @@
       "externalCopies": "External copies the app cannot erase:",
       "confirm": "Delete ALL your data? An encrypted snapshot allows rollback for up to 7 days in case of failure. Once committed, removal is permanent. Continue?",
       "failed": "Erasure failed — your data was restored from the safety snapshot (when available) and nothing was lost."
+    },
+    "consent_receipt": {
+      "title": "Consent",
+      "granted": "Consent active for policy v{{version}} (verified receipt).",
+      "absent": "No valid consent recorded — consent-gated features stay blocked.",
+      "grant": "Consent to the current policy",
+      "withdraw": "Withdraw consent",
+      "withdrawConfirm": "Withdraw consent? Data collected under it will be erased per policy (SPEC-04 §6) and the affected features will be blocked.",
+      "flagsNote": "Tutorial, onboarding or banner flags never substitute consent — only the receipt counts (SPEC-04 §2)."
     }
   },
   "tooltip": {

--- a/src/shared/i18n/locales/pt-BR.json
+++ b/src/shared/i18n/locales/pt-BR.json
@@ -647,6 +647,15 @@
       "externalCopies": "Cópias externas que o aplicativo não pode apagar:",
       "confirm": "Apagar TODOS os seus dados? Um snapshot criptografado permite reverter por até 7 dias em caso de falha. Depois de concluído, a remoção é definitiva. Continuar?",
       "failed": "Falha no apagamento — seus dados foram restaurados do snapshot de segurança (se disponível) e nada foi perdido."
+    },
+    "consent_receipt": {
+      "title": "Consentimento",
+      "granted": "Consentimento ativo para a política v{{version}} (recibo verificado).",
+      "absent": "Nenhum consentimento válido registrado — os recursos que dependem de consentimento permanecem bloqueados.",
+      "grant": "Consentir com a política atual",
+      "withdraw": "Retirar consentimento",
+      "withdrawConfirm": "Retirar o consentimento? Os dados coletados sob essa permissão serão apagados conforme a política (SPEC-04 §6) e os recursos afetados serão bloqueados.",
+      "flagsNote": "Flags de tutorial, onboarding ou banner nunca substituem o consentimento — apenas o recibo conta (SPEC-04 §2)."
     }
   },
   "tooltip": {

--- a/src/shared/lib/__tests__/consentReceipt.test.ts
+++ b/src/shared/lib/__tests__/consentReceipt.test.ts
@@ -111,7 +111,7 @@ describe("§8.3 flags-only state — consent NOT given", () => {
 
 describe("§8.4 withdrawal — exact effect per the manifest", () => {
   it("annotates withdrawn_at and keeps the receipt as the audit record", async () => {
-    const { receipt, digest } = await issueReceipt(SCOPE, PURPOSES);
+    const { receipt } = await issueReceipt(SCOPE, PURPOSES);
     const withdrawn = annotateWithdrawn(receipt, "2026-09-12T00:00:00Z");
     expect(withdrawn.withdrawn_at).toBe("2026-09-12T00:00:00Z");
     const evaluation = await evaluateReceipt({

--- a/src/shared/lib/__tests__/consentReceipt.test.ts
+++ b/src/shared/lib/__tests__/consentReceipt.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  issueReceipt,
+  evaluateReceipt,
+  receiptDigest,
+  currentPolicyHash,
+  annotateWithdrawn,
+  consentErasurePlan,
+  anonymizeRecord,
+} from "@/shared/lib/consentReceipt";
+import { canonicalJson } from "@/shared/lib/crypto/envelope";
+import manifestFixture from "../../../../docs/privacy/SPEC-01-manifest-fixture.json";
+import { createExportEnvelope } from "@/shared/lib/exportEnvelope";
+
+// ---------------------------------------------------------------------------
+// D1.1 S8 — consent receipt contract tests (TEST-MATRIX §8, SPEC-04).
+// Synthetic payloads only — never real PII.
+// ---------------------------------------------------------------------------
+
+const SCOPE = ["customers", "quotes", "history", "dashboard"];
+const PURPOSES = ["issue_quotes", "cross_device_sync"];
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("§8.1 receipt issuance and verification", () => {
+  it("issues a policy-bound receipt that verifies as valid", async () => {
+    const { receipt, digest } = await issueReceipt(SCOPE, PURPOSES);
+    expect(receipt.receipt_version).toBe("1.0");
+    expect(receipt.policy_version).toBe(
+      (manifestFixture as { policy_version: string }).policy_version,
+    );
+    expect(receipt.withdrawn_at).toBeNull();
+    // policy_hash binds the exact canonical manifest content:
+    const expectedHash = `sha256:${
+      (await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(canonicalJson(manifestFixture)),
+      )) instanceof Object
+        ? Array.from(
+            new Uint8Array(
+              await crypto.subtle.digest(
+                "SHA-256",
+                new TextEncoder().encode(canonicalJson(manifestFixture)),
+              ),
+            ),
+          )
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("")
+        : ""
+    }`;
+    expect(receipt.policy_hash).toBe(expectedHash);
+    const evaluation = await evaluateReceipt({ receipt, digest });
+    expect(evaluation.status).toBe("valid");
+    expect(evaluation.consentGiven).toBe(true);
+    expect(evaluation.currentPolicyHash).toBe(receipt.policy_hash);
+  });
+
+  it("the digest verifies and detects any mutation (§5)", async () => {
+    const { receipt, digest } = await issueReceipt(SCOPE, PURPOSES);
+    expect(await receiptDigest(receipt)).toBe(digest);
+    const mutated = { ...receipt, granted_at: "2020-01-01T00:00:00Z" };
+    expect(await receiptDigest(mutated)).not.toBe(digest);
+  });
+});
+
+describe("§8.2 tamper detection (default-deny, never repaired)", () => {
+  it("a flipped receipt byte ⇒ tampered ⇒ consent not given", async () => {
+    const { receipt, digest } = await issueReceipt(SCOPE, PURPOSES);
+    const tamperedReceipt = { ...receipt, scope: ["everything"] };
+    const evaluation = await evaluateReceipt({
+      receipt: tamperedReceipt,
+      digest,
+    });
+    expect(evaluation.status).toBe("tampered");
+    expect(evaluation.consentGiven).toBe(false);
+  });
+
+  it("a tampered receipt is never repaired — re-evaluation stays denied", async () => {
+    const { receipt, digest } = await issueReceipt(SCOPE, PURPOSES);
+    const tampered = { ...receipt, purposes: ["whatever"] };
+    const first = await evaluateReceipt({ receipt: tampered, digest });
+    const second = await evaluateReceipt({ receipt: tampered, digest });
+    expect(first.status).toBe("tampered");
+    expect(second.status).toBe("tampered");
+    expect(second.consentGiven).toBe(false);
+  });
+});
+
+describe("§8.3 flags-only state — consent NOT given", () => {
+  it("absent receipt ⇒ default-deny even with every flag set", async () => {
+    // Tutorial/onboarding/migration/quickstart flags may all be set — they
+    // are onboarding_flag records and NEVER satisfy consent (SPEC-04 §2).
+    window.localStorage.setItem("open3dcalc_tutorial_v1", "done");
+    window.localStorage.setItem("open3dcalc_onboarded", "true");
+    window.localStorage.setItem("open3dcalc_quickstart_dismissed", "true");
+    const evaluation = await evaluateReceipt(null);
+    expect(evaluation.status).toBe("absent");
+    expect(evaluation.consentGiven).toBe(false);
+  });
+});
+
+describe("§8.4 withdrawal — exact effect per the manifest", () => {
+  it("annotates withdrawn_at and keeps the receipt as the audit record", async () => {
+    const { receipt, digest } = await issueReceipt(SCOPE, PURPOSES);
+    const withdrawn = annotateWithdrawn(receipt, "2026-09-12T00:00:00Z");
+    expect(withdrawn.withdrawn_at).toBe("2026-09-12T00:00:00Z");
+    const evaluation = await evaluateReceipt({
+      receipt: withdrawn,
+      digest: await receiptDigest(withdrawn),
+    });
+    expect(evaluation.status).toBe("withdrawn");
+    expect(evaluation.consentGiven).toBe(false);
+  });
+
+  it("the erasure plan derives from legal_basis/erasure per the manifest", () => {
+    const plan = consentErasurePlan();
+    const fixtureKeys = (
+      manifestFixture as {
+        keys: Array<{ key: string; legal_basis: string; erasure: string }>;
+      }
+    ).keys;
+    const expectedErase = fixtureKeys
+      .filter(
+        (k) =>
+          k.legal_basis === "consent" && k.erasure === "erase_on_delete_all",
+      )
+      .map((k) => k.key);
+    const expectedAnonymize = fixtureKeys
+      .filter(
+        (k) => k.legal_basis === "consent" && k.erasure === "retain_anonymized",
+      )
+      .map((k) => k.key);
+    expect(plan.erase).toEqual(expectedErase);
+    expect(plan.anonymize).toEqual(expectedAnonymize);
+  });
+
+  it("anonymizeRecord strips identifying fields, keeps aggregates", () => {
+    const anonymized = anonymizeRecord({
+      name: "Fernanda Sintética",
+      email: "fernanda@exemplo.teste",
+      totalCost: 42,
+      quantity: 3,
+    }) as Record<string, unknown>;
+    expect(anonymized.name).toBeUndefined();
+    expect(anonymized.email).toBeUndefined();
+    expect(anonymized.totalCost).toBe(42);
+    expect(anonymized.quantity).toBe(3);
+    const list = anonymizeRecord([
+      { name: "A", customerId: "c1", profit: 1 },
+      { name: "B", customerId: "c2", profit: 2 },
+    ]) as Array<Record<string, unknown>>;
+    expect(
+      list.every((r) => r.name === undefined && r.customerId === undefined),
+    ).toBe(true);
+    expect(list.every((r) => typeof r.profit === "number")).toBe(true);
+  });
+});
+
+describe("§8.5 policy version change — re-consent required", () => {
+  it("a receipt bound to another policy does not carry over", async () => {
+    const { receipt, digest } = await issueReceipt(SCOPE, PURPOSES);
+    const evaluation = await evaluateReceipt({ receipt, digest });
+    expect(evaluation.status).toBe("valid");
+    // Policy changed ⇒ the receipt's hash no longer matches the current one:
+    const changed = {
+      ...receipt,
+      policy_version: "9.9",
+      policy_hash: "sha256:deadbeef",
+    };
+    const mismatch = await evaluateReceipt({
+      receipt: changed,
+      digest: await receiptDigest(changed),
+    });
+    expect(mismatch.status).toBe("policy_mismatch");
+    expect(mismatch.consentGiven).toBe(false);
+    // The old receipt is retained for the delta/history UI:
+    expect(mismatch.receipt).toBeDefined();
+  });
+
+  it("the current policy hash is stable across calls", async () => {
+    expect(await currentPolicyHash()).toBe(await currentPolicyHash());
+    expect(await currentPolicyHash()).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});
+
+describe("§8.6 receipts never leave the device", () => {
+  it("the SPEC-03 export envelope never contains receipt material", async () => {
+    const payload = {
+      settings: {},
+      history: [],
+      customers: [],
+      quotes: [],
+      catalog: { printers: [], materials: [], marketplaces: [] },
+      filaments: [],
+      theme: "dark",
+      dashboard: {},
+      sections: {},
+    };
+    const envelope = await createExportEnvelope(
+      payload,
+      "senha-sintética-3131",
+    );
+    expect(envelope).not.toContain("receipt_id");
+    expect(envelope).not.toContain("receipt_digest");
+    expect(envelope).not.toContain("withdrawn_at");
+  });
+});

--- a/src/shared/lib/consentReceipt.ts
+++ b/src/shared/lib/consentReceipt.ts
@@ -1,0 +1,202 @@
+/**
+ * Consent receipt (D1.1 S8) — SPEC-04.
+ *
+ * Consent is a tamper-EVIDENT, canonicalized, policy-bound record — never a
+ * boolean flag. Tutorial/onboarding/migration flags and banner dismissal
+ * NEVER satisfy consent (§2). If the receipt is absent, tampered, or bound
+ * to a different policy version, consent is NOT given (default-deny, §6).
+ *
+ * - `policy_hash` = sha256 of the canonical SPEC-01 manifest document (the
+ *   exact policy the user saw) — deterministic across platforms.
+ * - `receipt_digest` = sha256 of the canonical receipt; recomputed on every
+ *   load. Mismatch ⇒ invalid ⇒ re-consent (the app never repairs).
+ * - Withdrawal annotates `withdrawn_at` and triggers the scoped SPEC-02
+ *   saga over `legal_basis: consent` keys — never touching non-consent data.
+ * - Receipts are `sync: never`, `export: never` — they never leave the
+ *   device.
+ */
+
+import { canonicalJson } from "./crypto/envelope";
+import { getShippedPolicyVersion } from "./shippedManifest";
+import manifestFixture from "../../../docs/privacy/SPEC-01-manifest-fixture.json";
+import type { ManifestDocument } from "./dataManifest";
+
+export const RECEIPT_VERSION = "1.0";
+
+export interface ConsentReceipt {
+  receipt_id: string;
+  receipt_version: string;
+  policy_version: string;
+  policy_hash: string;
+  granted_at: string;
+  scope: string[];
+  legal_basis: "consent";
+  purposes: string[];
+  withdrawn_at: null | string;
+}
+
+export type ReceiptStatus =
+  "valid" | "absent" | "tampered" | "policy_mismatch" | "withdrawn";
+
+export interface ReceiptEvaluation {
+  status: ReceiptStatus;
+  /** True only for status `valid` (default-deny otherwise, §6). */
+  consentGiven: boolean;
+  /** sha256:<hex> of the CURRENT canonical policy — for the delta UI. */
+  currentPolicyHash: string;
+  currentPolicyVersion: string;
+  receipt?: ConsentReceipt;
+}
+
+/** sha256 hex over a UTF-8 string. */
+export async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text) as BufferSource,
+  );
+  return Array.from(new Uint8Array(digest), (b) =>
+    b.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/**
+ * The canonical policy document hash (SPEC-04 §4): sha256 of the canonical
+ * SPEC-01 manifest content. Deterministic across platforms/versions.
+ */
+export async function currentPolicyHash(): Promise<string> {
+  return `sha256:${await sha256Hex(canonicalJson(manifestFixture))}`;
+}
+
+/** The receipt digest: sha256 of the canonical receipt (SPEC-04 §5). */
+export async function receiptDigest(receipt: ConsentReceipt): Promise<string> {
+  return `sha256:${await sha256Hex(canonicalJson(receipt))}`;
+}
+
+function uuidV4(): string {
+  const c = globalThis.crypto;
+  if (c.randomUUID) return c.randomUUID();
+  return [crypto.getRandomValues(new Uint32Array(4))]
+    .map((u) =>
+      Array.from(u)
+        .map((n) => n.toString(16))
+        .join(""),
+    )
+    .join("-");
+}
+
+/** §3: issue a receipt bound to the CURRENT policy (issue time). */
+export async function issueReceipt(
+  scope: string[],
+  purposes: string[],
+): Promise<{ receipt: ConsentReceipt; digest: string }> {
+  const receipt: ConsentReceipt = {
+    receipt_id: uuidV4(),
+    receipt_version: RECEIPT_VERSION,
+    policy_version: getShippedPolicyVersion(),
+    policy_hash: await currentPolicyHash(),
+    granted_at: new Date().toISOString(),
+    scope,
+    legal_basis: "consent",
+    purposes,
+    withdrawn_at: null,
+  };
+  return { receipt, digest: await receiptDigest(receipt) };
+}
+
+/**
+ * §5/§6: evaluate a stored receipt + digest. Absent/tampered/withdrawn/
+ * policy-mismatched ⇒ consent is NOT given (default-deny).
+ */
+export async function evaluateReceipt(
+  stored: { receipt: ConsentReceipt; digest: string } | null | undefined,
+): Promise<ReceiptEvaluation> {
+  const currentHash = await currentPolicyHash();
+  const currentVersion = getShippedPolicyVersion();
+  const base: ReceiptEvaluation = {
+    status: "absent",
+    consentGiven: false,
+    currentPolicyHash: currentHash,
+    currentPolicyVersion: currentVersion,
+  };
+  if (
+    !stored ||
+    typeof stored.receipt !== "object" ||
+    stored.receipt === null
+  ) {
+    return base;
+  }
+  const receipt = stored.receipt;
+  // Digest first — recomputed over the canonical receipt (§5).
+  const expected = await receiptDigest(receipt);
+  if (stored.digest !== expected) {
+    return { ...base, status: "tampered", receipt };
+  }
+  if (receipt.withdrawn_at !== null) {
+    return { ...base, status: "withdrawn", receipt };
+  }
+  // Policy binding: a receipt from another policy does NOT carry over (§6).
+  if (
+    receipt.policy_hash !== currentHash ||
+    receipt.policy_version !== currentVersion
+  ) {
+    return { ...base, status: "policy_mismatch", receipt };
+  }
+  return { ...base, status: "valid", consentGiven: true, receipt };
+}
+
+/** §6.3: annotate the withdrawal — the receipt is kept, never re-usable. */
+export function annotateWithdrawn(
+  receipt: ConsentReceipt,
+  at: string,
+): ConsentReceipt {
+  return { ...receipt, withdrawn_at: at };
+}
+
+/**
+ * §6.1: the manifest-derived erasure plan for withdrawal — every key with
+ * `legal_basis: consent`, partitioned by its `erasure` policy.
+ */
+export function consentErasurePlan(): {
+  erase: string[];
+  anonymize: string[];
+} {
+  const doc = manifestFixture as ManifestDocument;
+  const erase: string[] = [];
+  const anonymize: string[] = [];
+  for (const key of doc.keys) {
+    if (key.legal_basis !== "consent") continue;
+    if (key.erasure === "retain_anonymized") anonymize.push(key.key);
+    else erase.push(key.key);
+  }
+  return { erase, anonymize };
+}
+
+/**
+ * §6.5: anonymization for `retain_anonymized` keys — strip the identifying
+ * fields from a persisted collection, keeping non-identifying aggregates.
+ */
+export function anonymizeRecord(record: unknown): unknown {
+  if (Array.isArray(record)) return record.map(anonymizeRecord);
+  if (record !== null && typeof record === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(record as Record<string, unknown>)) {
+      if (PII_FIELD_NAMES.has(k)) continue;
+      out[k] = anonymizeRecord(v);
+    }
+    return out;
+  }
+  return record;
+}
+
+const PII_FIELD_NAMES = new Set([
+  "name",
+  "customer",
+  "customerId",
+  "customer_id",
+  "customerName",
+  "customerSnapshot",
+  "email",
+  "phone",
+  "address",
+  "notes",
+]);

--- a/src/shared/stores/__tests__/consentStore.test.ts
+++ b/src/shared/stores/__tests__/consentStore.test.ts
@@ -1,87 +1,91 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { useConsentStore } from '../consentStore'
+import { describe, it, expect, beforeEach } from "vitest";
+import { useConsentStore } from "../consentStore";
 
-describe('useConsentStore', () => {
+describe("useConsentStore", () => {
   beforeEach(() => {
-    localStorage.clear()
+    localStorage.clear();
     useConsentStore.setState({
       privacyBannerDismissed: false,
       consentGiven: false,
       consentDate: null,
-    })
-  })
+    });
+  });
 
   // ── Initial state ──────────────────────────────────────────────
-  it('initial state has all flags false/empty', () => {
-    const state = useConsentStore.getState()
-    expect(state.privacyBannerDismissed).toBe(false)
-    expect(state.consentGiven).toBe(false)
-    expect(state.consentDate).toBeNull()
-  })
+  it("initial state has all flags false/empty", () => {
+    const state = useConsentStore.getState();
+    expect(state.privacyBannerDismissed).toBe(false);
+    expect(state.consentGiven).toBe(false);
+    expect(state.consentDate).toBeNull();
+  });
 
   // ── dismissBanner ──────────────────────────────────────────────
-  it('dismissBanner() sets privacyBannerDismissed to true', () => {
-    expect(useConsentStore.getState().privacyBannerDismissed).toBe(false)
-    useConsentStore.getState().dismissBanner()
-    expect(useConsentStore.getState().privacyBannerDismissed).toBe(true)
-  })
+  it("dismissBanner() sets privacyBannerDismissed to true", () => {
+    expect(useConsentStore.getState().privacyBannerDismissed).toBe(false);
+    useConsentStore.getState().dismissBanner();
+    expect(useConsentStore.getState().privacyBannerDismissed).toBe(true);
+  });
 
   // ── dismissBanner does NOT affect consentGiven ─────────────────
-  it('dismissBanner() does not affect consentGiven', () => {
-    useConsentStore.getState().giveConsent()
-    useConsentStore.getState().dismissBanner()
-    expect(useConsentStore.getState().consentGiven).toBe(true)
-    expect(useConsentStore.getState().privacyBannerDismissed).toBe(true)
-  })
+  it("dismissBanner() does not affect consentGiven", async () => {
+    await useConsentStore.getState().giveConsent();
+    useConsentStore.getState().dismissBanner();
+    expect(useConsentStore.getState().consentGiven).toBe(true);
+    expect(useConsentStore.getState().privacyBannerDismissed).toBe(true);
+  });
 
   // ── giveConsent ────────────────────────────────────────────────
-  it('giveConsent() sets consentGiven to true and records date', () => {
-    const before = Date.now()
-    useConsentStore.getState().giveConsent()
-    const after = Date.now()
-    const state = useConsentStore.getState()
+  it("giveConsent() issues a verified receipt and records date", async () => {
+    const before = Date.now();
+    await useConsentStore.getState().giveConsent();
+    const after = Date.now();
+    const state = useConsentStore.getState();
 
-    expect(state.consentGiven).toBe(true)
-    expect(state.consentDate).not.toBeNull()
-    expect(state.consentDate!).toBeGreaterThanOrEqual(before)
-    expect(state.consentDate!).toBeLessThanOrEqual(after)
-  })
+    expect(state.consentGiven).toBe(true);
+    expect(state.consentDate).not.toBeNull();
+    expect(state.consentDate!).toBeGreaterThanOrEqual(before);
+    expect(state.consentDate!).toBeLessThanOrEqual(after);
+    // SPEC-04 §3: the proof of consent is the receipt, not the flag.
+    expect(state.receipt).not.toBeNull();
+    expect(state.receipt!.policy_version).toBe("1.2");
+    expect(state.receiptDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
 
   // ── giveConsent also dismisses banner ──────────────────────────
-  it('giveConsent() also dismisses banner', () => {
-    useConsentStore.getState().giveConsent()
-    expect(useConsentStore.getState().privacyBannerDismissed).toBe(true)
-  })
+  it("giveConsent() also dismisses banner", async () => {
+    await useConsentStore.getState().giveConsent();
+    expect(useConsentStore.getState().privacyBannerDismissed).toBe(true);
+  });
 
   // ── resetConsent ───────────────────────────────────────────────
-  it('resetConsent() resets all flags to initial state', () => {
-    useConsentStore.getState().giveConsent()
-    useConsentStore.getState().resetConsent()
+  it("resetConsent() resets all flags to initial state", async () => {
+    await useConsentStore.getState().giveConsent();
+    useConsentStore.getState().resetConsent();
 
-    const state = useConsentStore.getState()
-    expect(state.privacyBannerDismissed).toBe(false)
-    expect(state.consentGiven).toBe(false)
-    expect(state.consentDate).toBeNull()
-  })
+    const state = useConsentStore.getState();
+    expect(state.privacyBannerDismissed).toBe(false);
+    expect(state.consentGiven).toBe(false);
+    expect(state.consentDate).toBeNull();
+  });
 
   // ── needsConsent ───────────────────────────────────────────────
-  it('needsConsent() returns true when consent not given', () => {
-    expect(useConsentStore.getState().needsConsent()).toBe(true)
-  })
+  it("needsConsent() returns true when consent not given", () => {
+    expect(useConsentStore.getState().needsConsent()).toBe(true);
+  });
 
-  it('needsConsent() returns false after consent given', () => {
-    useConsentStore.getState().giveConsent()
-    expect(useConsentStore.getState().needsConsent()).toBe(false)
-  })
+  it("needsConsent() returns false after consent given", async () => {
+    await useConsentStore.getState().giveConsent();
+    expect(useConsentStore.getState().needsConsent()).toBe(false);
+  });
 
   // ── Persistence ────────────────────────────────────────────────
-  it('persists state to localStorage under open3dcalc_consent_v1', () => {
-    useConsentStore.getState().giveConsent()
-    const stored = localStorage.getItem('open3dcalc_consent_v1')
-    expect(stored).not.toBeNull()
-    const parsed = JSON.parse(stored!)
-    expect(parsed.state.consentGiven).toBe(true)
-    expect(parsed.state.privacyBannerDismissed).toBe(true)
-    expect(parsed.state.consentDate).toBeTypeOf('number')
-  })
-})
+  it("persists state to localStorage under open3dcalc_consent_v1", async () => {
+    await useConsentStore.getState().giveConsent();
+    const stored = localStorage.getItem("open3dcalc_consent_v1");
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.state.consentGiven).toBe(true);
+    expect(parsed.state.privacyBannerDismissed).toBe(true);
+    expect(parsed.state.consentDate).toBeTypeOf("number");
+  });
+});

--- a/src/shared/stores/consentStore.ts
+++ b/src/shared/stores/consentStore.ts
@@ -1,16 +1,49 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { manifestStorage } from "@/shared/lib/manifestStorage";
+import {
+  annotateWithdrawn,
+  issueReceipt,
+  type ConsentReceipt,
+} from "@/shared/lib/consentReceipt";
+import { guardedStorage } from "@/shared/lib/manifestStorage";
+import { evaluateReceipt } from "@/shared/lib/consentReceipt";
+import { consentErasurePlan } from "@/shared/lib/consentReceipt";
+
+/**
+ * Consent store (D1.1 S8) — SPEC-04.
+ *
+ * The PROOF of consent is the tamper-evident receipt bound to the exact
+ * policy hash — `consentGiven` is derived from a valid receipt, never from
+ * tutorial/onboarding/migration flags or banner dismissal (SPEC-04 §2).
+ * Stored via the gated storage (manifest key `open3dcalc_consent_v1`:
+ * class consent_record, sync never, export never — it never leaves the
+ * device).
+ */
 
 interface ConsentStore {
   privacyBannerDismissed: boolean;
+  /** Derived mirror of the receipt state (UI convenience only). */
   consentGiven: boolean;
   consentDate: number | null;
+  receipt: ConsentReceipt | null;
+  receiptDigest: string | null;
+  /** §6: withdrawn receipts are kept as the audit record. */
+  withdrawnReceipts: ConsentReceipt[];
 
   dismissBanner(): void;
-  giveConsent(): void;
+  giveConsent(): Promise<void>;
+  /** §6 withdrawal: annotate + erase consent-basis data per the manifest. */
+  withdrawConsent(): Promise<void>;
   resetConsent(): void;
   needsConsent(): boolean;
+}
+
+/** Erase the persisted data of every consent-basis localStorage key. */
+function eraseConsentBasisLocalStorage(): void {
+  for (const key of consentErasurePlan().erase) {
+    guardedStorage.removeItem(key);
+  }
 }
 
 export const useConsentStore = create<ConsentStore>()(
@@ -19,15 +52,45 @@ export const useConsentStore = create<ConsentStore>()(
       privacyBannerDismissed: false,
       consentGiven: false,
       consentDate: null,
+      receipt: null,
+      receiptDigest: null,
+      withdrawnReceipts: [],
 
       dismissBanner: () => set({ privacyBannerDismissed: true }),
 
-      giveConsent: () =>
+      giveConsent: async () => {
+        // §3: issue a receipt bound to the CURRENT policy (SPEC-01).
+        const { receipt, digest } = await issueReceipt(
+          ["customers", "quotes", "history", "dashboard"],
+          ["issue_quotes", "cross_device_sync"],
+        );
+        // Default-deny: only mark consent after the receipt verifies.
+        const evaluation = await evaluateReceipt({ receipt, digest });
+        if (!evaluation.consentGiven) return;
         set({
+          receipt,
+          receiptDigest: digest,
           consentGiven: true,
           consentDate: Date.now(),
           privacyBannerDismissed: true,
-        }),
+        });
+      },
+
+      withdrawConsent: async () => {
+        const current = get().receipt;
+        if (!current || current.withdrawn_at !== null) return;
+        // §6.1: erase the consent-basis data per the manifest.
+        eraseConsentBasisLocalStorage();
+        // §6.3: annotate — the receipt is kept, never re-usable.
+        const withdrawn = annotateWithdrawn(current, new Date().toISOString());
+        set({
+          receipt: null,
+          receiptDigest: null,
+          consentGiven: false,
+          consentDate: null,
+          withdrawnReceipts: [...get().withdrawnReceipts, withdrawn],
+        });
+      },
 
       resetConsent: () =>
         set({


### PR DESCRIPTION
## D1.1 S8 — Policy-bound consent receipt (SPEC-04)

Implements slice **S8** — the final D1 slice: consent becomes a **tamper-evident,
canonicalized, policy-bound record**; `consentGiven` is derived from a VALID receipt
(default-deny), never from flags.

### Declared scope (OWNERS-RUNBOOK §6)

- `src/shared/lib/consentReceipt.ts`:
  - `issueReceipt` — receipt bound to the **current policy** (`policy_hash` = sha256
    of the canonical SPEC-01 manifest content — deterministic across platforms, §4);
  - `evaluateReceipt` — the receipt digest is recomputed on every load (§5):
    tampered ⇒ invalid ⇒ **default-deny** (never repaired); withdrawn ⇒ not given
    (audit record kept); policy version/hash mismatch ⇒ `policy_mismatch` ⇒
    re-consent required for the delta, old receipt retained (§6);
  - `consentErasurePlan` — the §6.1 withdrawal plan derived from the manifest
    (`legal_basis: consent` partitioned by `erasure`: erase_on_delete_all /
    retain_anonymized) + `anonymizeRecord` (identifying fields stripped, aggregates
    kept);
  - withdrawal annotates `withdrawn_at` (kept as the audit record, never re-usable)
    and erases the consent-basis localStorage keys; desktop durable copies go
    through the S4 `privacy:eliminate-key` flow.
- `consentStore` — `giveConsent` issues and VERIFIES the receipt before marking
  consent; store tests updated for the receipt flow.
- PrivacyScreen — consent section: status (valid/absent/tampered/policy-mismatch),
  grant/withdraw with confirmations, and the §2 note that tutorial/onboarding/banner
  flags NEVER substitute consent. i18n pt-BR/en-US.
- No contract documents modified (no policy bump — the receipt lives inside the
  existing `open3dcalc_consent_v1` consent_record key: sync never, export never).

### Contract tests (TEST-MATRIX §8)

8.1 issuance + digest verification with an independent policy-hash vector ·
8.2 tamper ⇒ default-deny, never repaired · 8.3 flags-only state ⇒ consent NOT
given · 8.4 withdrawal: annotation kept + manifest-derived erasure plan +
anonymization · 8.5 policy change ⇒ mismatch, old receipt retained · 8.6 the
SPEC-03 envelope never contains receipt material.

### Verification

- **1,377 tests** across 108 files; typecheck (app + Electron), strict lint,
  desktop/web builds — all green.
- Coverage on the receipt module: **95.5% lines / 92.6% branches**.

### Rollback (OWNERS-RUNBOOK §7)

Flag off ⇒ boolean-consent behavior returns; issued receipts stay stored (inert);
re-enabling re-validates digests.

⚠️ Themis gate applies before merge (final approval: repo owner). **This PR closes
the D1 track (S1–S8).**
