### PR TITLE
docs: user guide for the privacy tab and encrypted export (D1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Baixe a versão desktop para Windows ou Linux na [página de releases](https://g
 
 ---
 
+## 🔒 Privacidade e seus dados
+
+O Open3DCalc é **local-first**: seus dados vivem no seu dispositivo e nada é enviado a servidores. A partir da v1.12, a política de privacidade (LGPD) é executada pelo próprio aplicativo:
+
+- **Aba 🔒 Privacidade** — um só lugar para ver e agir sobre seus dados:
+  - **Quarentena de dados legados**: dados antigos gravados em texto puro ficam legíveis, porém bloqueados para novas gravações, até você escolher **migrar** (criptografar e verificar) ou **eliminar**;
+  - **Consentimento**: um recibo à prova de adulteração, vinculado à versão exata da política que você aceitou — flags de tutorial/onboarding nunca substituem consentimento, e a retirada apaga os dados coletados sob ela;
+  - **Apagar todos os meus dados**: apagamento completo e verificável em todas as superfícies (banco, arquivos, caches, backups internos), com journal recuperável, snapshot criptografado de reversão (7 dias) e recibo listando as cópias externas que o app não alcança (ex.: exports salvos fora do app).
+- **Exportação sempre criptografada**: o pacote de sincronização/exportação (`.open3dcalc`) sai criptografado com AES-256-GCM a partir de uma senha sua — sem senha, não há export. Pacotes legados antigos continuam importáveis.
+- **Backup bruto deixou de ser recurso de usuário**: a cópia bruta do banco SQLite agora é um artefato de diagnóstico interno, bloqueado por padrão (gate de desenvolvimento), com modo de redação de dados pessoais e retenção máxima de 14 dias. Para levar seus dados a outra máquina, use o pacote de exportação criptografado.
+
+> Detalhes técnicos: `docs/privacy/` (SPEC-01 manifest de dados, ADR-001 capacidade criptográfica, ADR-002 quarentena, ADR-003 export vs backup, SPEC-02 saga de apagamento, SPEC-03 envelope de exportação, SPEC-04 recibo de consentimento).
+
+---
+
 ## 🏗️ Project Structure
 
 ```


### PR DESCRIPTION
User-facing documentation for the D1.1 privacy work: the privacy tab (quarantine, consent receipt, delete-all saga), the always-encrypted export package, and the reclassification of the raw SQLite copy as a diagnostic artifact (ADR-003 §3 requires the replacement to be stated). Docs only.